### PR TITLE
Adding License Headers

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,3 @@
+Money Distributed Tracing Library
+Copyright 2012-2015 Comcast Cable Communications Management, LLC
+This product includes software developed at Comcast (http://www.comcast.com/).

--- a/money-aspectj/src/main/scala/com/comcast/money/aspectj/TraceAspect.scala
+++ b/money-aspectj/src/main/scala/com/comcast/money/aspectj/TraceAspect.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.aspectj
 
 import com.comcast.money.annotations.{Timed, Traced}

--- a/money-aspectj/src/test/resources/application.conf
+++ b/money-aspectj/src/test/resources/application.conf
@@ -1,3 +1,17 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 money {
   akka {
     loglevel = INFO

--- a/money-aspectj/src/test/scala/com/comcast/money/aspectj/TraceAspectSpec.scala
+++ b/money-aspectj/src/test/scala/com/comcast/money/aspectj/TraceAspectSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.aspectj
 
 import akka.actor.ActorSystem

--- a/money-core/src/it/resources/application.conf
+++ b/money-core/src/it/resources/application.conf
@@ -1,3 +1,17 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 money {
   enabled = false
   akka {

--- a/money-core/src/it/resources/application.test.conf
+++ b/money-core/src/it/resources/application.test.conf
@@ -1,3 +1,17 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 money {
   enabled = true
 }

--- a/money-core/src/it/scala/com/comcast/money/features/TracerIntegrationSpec.scala
+++ b/money-core/src/it/scala/com/comcast/money/features/TracerIntegrationSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.features
 
 import java.lang.{Class => JavaClass}

--- a/money-core/src/it/scala/com/comcast/money/graphite/TestGraphiteServer.scala
+++ b/money-core/src/it/scala/com/comcast/money/graphite/TestGraphiteServer.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.graphite
 
 import java.net.InetSocketAddress

--- a/money-core/src/main/java/com/comcast/money/annotations/Timed.java
+++ b/money-core/src/main/java/com/comcast/money/annotations/Timed.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.annotations;
 
 import java.lang.annotation.ElementType;

--- a/money-core/src/main/java/com/comcast/money/annotations/Traced.java
+++ b/money-core/src/main/java/com/comcast/money/annotations/Traced.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.annotations;
 
 import java.lang.annotation.Documented;

--- a/money-core/src/main/java/com/comcast/money/annotations/TracedData.java
+++ b/money-core/src/main/java/com/comcast/money/annotations/TracedData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.annotations;
 
 import java.lang.annotation.ElementType;
@@ -58,4 +74,3 @@ public @interface TracedData {
      */
     boolean propagate() default false;
 }
-

--- a/money-core/src/main/java/com/comcast/money/japi/JMoney.java
+++ b/money-core/src/main/java/com/comcast/money/japi/JMoney.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.japi;
 
 import akka.actor.ActorSystem;

--- a/money-core/src/main/java/com/comcast/money/japi/TraceFriendlyExecutors.java
+++ b/money-core/src/main/java/com/comcast/money/japi/TraceFriendlyExecutors.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.japi;
 
 import java.util.concurrent.ExecutorService;

--- a/money-core/src/main/resources/reference.conf
+++ b/money-core/src/main/resources/reference.conf
@@ -1,3 +1,17 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 money {
 
   application-name = "unknown"

--- a/money-core/src/main/scala/com/comcast/money/akka/ActorMaker.scala
+++ b/money-core/src/main/scala/com/comcast/money/akka/ActorMaker.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.akka
 
 import akka.actor.{ActorRef, ActorRefFactory, Props}

--- a/money-core/src/main/scala/com/comcast/money/akka/BinaryExponentialBackOff.scala
+++ b/money-core/src/main/scala/com/comcast/money/akka/BinaryExponentialBackOff.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.akka
 
 import scala.concurrent.duration.{Duration, FiniteDuration}

--- a/money-core/src/main/scala/com/comcast/money/concurrent/Futures.scala
+++ b/money-core/src/main/scala/com/comcast/money/concurrent/Futures.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.concurrent
 
 import akka.actor.ActorRef
@@ -283,4 +299,3 @@ class TracedFuture[T](spanId: SpanId, wrapped: Future[T], executor: ExecutionCon
     new TracedFuture[S](spanId, wrapped.mapTo(tag), executor)
   }
 }
-

--- a/money-core/src/main/scala/com/comcast/money/concurrent/TraceFriendlyExecutionContextExecutor.scala
+++ b/money-core/src/main/scala/com/comcast/money/concurrent/TraceFriendlyExecutionContextExecutor.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.concurrent
 
 import com.comcast.money.internal.{MDCSupport, SpanLocal}

--- a/money-core/src/main/scala/com/comcast/money/concurrent/TraceFriendlyThreadPoolExecutor.scala
+++ b/money-core/src/main/scala/com/comcast/money/concurrent/TraceFriendlyThreadPoolExecutor.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.concurrent
 
 import java.util.concurrent._

--- a/money-core/src/main/scala/com/comcast/money/core/Metrics.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Metrics.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core
 
 import _root_.akka.actor.ActorRef

--- a/money-core/src/main/scala/com/comcast/money/core/Money.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Money.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core
 
 import java.net.InetAddress

--- a/money-core/src/main/scala/com/comcast/money/core/Note.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Note.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core
 
 import com.comcast.money.util.DateTimeUtil

--- a/money-core/src/main/scala/com/comcast/money/core/Span.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Span.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core
 
 import scala.collection.Map

--- a/money-core/src/main/scala/com/comcast/money/core/Tracer.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Tracer.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core
 
 import java.io.Closeable
@@ -375,5 +391,3 @@ trait Tracer extends Closeable {
     SpanLocal.current.map(func)
   }
 }
-
-

--- a/money-core/src/main/scala/com/comcast/money/core/Tracers.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Tracers.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core
 
 import com.comcast.money.logging.TraceLogging

--- a/money-core/src/main/scala/com/comcast/money/emitters/Configurable.scala
+++ b/money-core/src/main/scala/com/comcast/money/emitters/Configurable.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.emitters
 
 import com.typesafe.config.Config

--- a/money-core/src/main/scala/com/comcast/money/emitters/GraphiteEmitter.scala
+++ b/money-core/src/main/scala/com/comcast/money/emitters/GraphiteEmitter.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.emitters
 
 import akka.actor._

--- a/money-core/src/main/scala/com/comcast/money/emitters/GraphiteMetricEmitter.scala
+++ b/money-core/src/main/scala/com/comcast/money/emitters/GraphiteMetricEmitter.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.emitters
 
 import java.net._

--- a/money-core/src/main/scala/com/comcast/money/emitters/LogEmitter.scala
+++ b/money-core/src/main/scala/com/comcast/money/emitters/LogEmitter.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.emitters
 
 import akka.actor.{Actor, ActorLogging, Props}

--- a/money-core/src/main/scala/com/comcast/money/emitters/LogRecorder.scala
+++ b/money-core/src/main/scala/com/comcast/money/emitters/LogRecorder.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.emitters
 
 import com.typesafe.config.Config

--- a/money-core/src/main/scala/com/comcast/money/internal/Emitter.scala
+++ b/money-core/src/main/scala/com/comcast/money/internal/Emitter.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.internal
 
 import akka.actor.{Actor, ActorLogging, Props}
@@ -67,4 +83,3 @@ class Emitter(emitterBus: EmitterBus) extends Actor with ActorMaker with ActorLo
       emitterBus.publish(EmitterEvent(Metric, metricLong))
   }
 }
-

--- a/money-core/src/main/scala/com/comcast/money/internal/EmitterBus.scala
+++ b/money-core/src/main/scala/com/comcast/money/internal/EmitterBus.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.internal
 
 import akka.actor.ActorRef
@@ -34,6 +50,3 @@ class EmitterBus extends EventBus with LookupClassification {
 
   override protected def mapSize(): Int = 3
 }
-
-
-

--- a/money-core/src/main/scala/com/comcast/money/internal/MDCSupport.scala
+++ b/money-core/src/main/scala/com/comcast/money/internal/MDCSupport.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.internal
 
 import com.comcast.money.core.{SpanId, Money}

--- a/money-core/src/main/scala/com/comcast/money/internal/SpanFSM.scala
+++ b/money-core/src/main/scala/com/comcast/money/internal/SpanFSM.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.internal
 
 import java.util.concurrent.TimeUnit
@@ -240,4 +256,3 @@ class SpanFSM(val emitterSupervisor: ActorRef, val openSpanTimeout: FiniteDurati
       spanData.duration, spanData.notes.map(x => x._1 -> x._2.note).toMap)
   }
 }
-

--- a/money-core/src/main/scala/com/comcast/money/internal/SpanLocal.scala
+++ b/money-core/src/main/scala/com/comcast/money/internal/SpanLocal.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.internal
 
 import com.comcast.money.core.SpanId

--- a/money-core/src/main/scala/com/comcast/money/internal/SpanSupervisor.scala
+++ b/money-core/src/main/scala/com/comcast/money/internal/SpanSupervisor.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.internal
 
 import akka.actor._

--- a/money-core/src/main/scala/com/comcast/money/logging/TraceLogging.scala
+++ b/money-core/src/main/scala/com/comcast/money/logging/TraceLogging.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.logging
 
 import com.comcast.money.core.Money

--- a/money-core/src/main/scala/com/comcast/money/metrics/MoneyMetrics.scala
+++ b/money-core/src/main/scala/com/comcast/money/metrics/MoneyMetrics.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.metrics
 
 import java.util.concurrent.TimeUnit

--- a/money-core/src/main/scala/com/comcast/money/metrics/SpanMetrics.scala
+++ b/money-core/src/main/scala/com/comcast/money/metrics/SpanMetrics.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.metrics
 
 import akka.actor.{Actor, ActorLogging, Props}
@@ -46,4 +62,3 @@ class SpanMetricsCollector(conf: Config) extends Actor with ActorMaker with Acto
       }
   }
 }
-

--- a/money-core/src/main/scala/com/comcast/money/reflect/Reflections.scala
+++ b/money-core/src/main/scala/com/comcast/money/reflect/Reflections.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.reflect
 
 import java.lang.annotation.Annotation

--- a/money-core/src/main/scala/com/comcast/money/util/DateTimeUtil.scala
+++ b/money-core/src/main/scala/com/comcast/money/util/DateTimeUtil.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.util
 
 /**

--- a/money-core/src/test/resources/application.conf
+++ b/money-core/src/test/resources/application.conf
@@ -1,3 +1,17 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 money {
   akka {
     loglevel = INFO

--- a/money-core/src/test/resources/application.found_it.conf
+++ b/money-core/src/test/resources/application.found_it.conf
@@ -1,3 +1,17 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 money{
   enabled = false
   bizzare-setting = "bozo"

--- a/money-core/src/test/resources/application.host_specific.conf
+++ b/money-core/src/test/resources/application.host_specific.conf
@@ -1,3 +1,17 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 money{
   enabled = false
   bizzare-setting = "host_bozo"

--- a/money-core/src/test/scala/com/comcast/money/akka/BinaryExponentialBackOffSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/akka/BinaryExponentialBackOffSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.akka
 
 import org.scalatest.WordSpec
@@ -97,4 +113,3 @@ class BinaryExponentialBackOffSpec extends WordSpec {
     }
   }
 }
-

--- a/money-core/src/test/scala/com/comcast/money/concurrent/ConcurrentSupport.scala
+++ b/money-core/src/test/scala/com/comcast/money/concurrent/ConcurrentSupport.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.concurrent
 
 import java.util.concurrent.Callable

--- a/money-core/src/test/scala/com/comcast/money/concurrent/FuturesSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/concurrent/FuturesSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.concurrent
 
 import com.comcast.money.core.Money.tracer

--- a/money-core/src/test/scala/com/comcast/money/concurrent/TraceFriendlyExecutionContextExecutorSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/concurrent/TraceFriendlyExecutionContextExecutorSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.concurrent
 
 import com.comcast.money.core.SpanId

--- a/money-core/src/test/scala/com/comcast/money/concurrent/TraceFriendlyThreadPoolExecutorSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/concurrent/TraceFriendlyThreadPoolExecutorSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.concurrent
 
 import java.util.concurrent.{Callable, ExecutorService}

--- a/money-core/src/test/scala/com/comcast/money/core/MoneySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/MoneySpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core
 
 import java.lang.{Class => JavaClass}

--- a/money-core/src/test/scala/com/comcast/money/core/SpanIdSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/SpanIdSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core
 
 import org.scalatest.{Matchers, WordSpecLike}

--- a/money-core/src/test/scala/com/comcast/money/core/TracerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/TracerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core
 
 import akka.testkit.TestProbe
@@ -188,4 +204,3 @@ class TracerSpec
     }
   }
 }
-

--- a/money-core/src/test/scala/com/comcast/money/core/TracersSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/TracersSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core
 
 import com.comcast.money.core.Tracers._

--- a/money-core/src/test/scala/com/comcast/money/emitters/GraphiteEmitterSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/emitters/GraphiteEmitterSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.emitters
 
 import akka.testkit.{TestActorRef, TestKit}

--- a/money-core/src/test/scala/com/comcast/money/emitters/GraphiteMetricEmitterSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/emitters/GraphiteMetricEmitterSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.emitters
 
 import java.net.DatagramPacket

--- a/money-core/src/test/scala/com/comcast/money/emitters/LogEmitterSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/emitters/LogEmitterSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.emitters
 
 import com.comcast.money.core.{Note, Span, SpanId, StringNote}

--- a/money-core/src/test/scala/com/comcast/money/emitters/LogRecordSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/emitters/LogRecordSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.emitters
 
 import org.scalatest.{BeforeAndAfter, Matchers, OneInstancePerTest, WordSpec}

--- a/money-core/src/test/scala/com/comcast/money/internal/EmitterBusSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/internal/EmitterBusSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.internal
 
 import akka.testkit.TestProbe

--- a/money-core/src/test/scala/com/comcast/money/internal/EmitterSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/internal/EmitterSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.internal
 
 import akka.testkit.TestActorRef

--- a/money-core/src/test/scala/com/comcast/money/internal/MDCSupportSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/internal/MDCSupportSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.internal
 
 import com.comcast.money.core.SpanId

--- a/money-core/src/test/scala/com/comcast/money/internal/SpanFSMSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/internal/SpanFSMSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.internal
 
 import akka.actor.Props

--- a/money-core/src/test/scala/com/comcast/money/internal/SpanLocalSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/internal/SpanLocalSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.internal
 
 import com.comcast.money.core.SpanId

--- a/money-core/src/test/scala/com/comcast/money/internal/SpanSupervisorSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/internal/SpanSupervisorSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.internal
 
 import akka.actor._

--- a/money-core/src/test/scala/com/comcast/money/japi/JMoneySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/japi/JMoneySpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.japi
 
 import com.comcast.money.japi.JMoney.TraceSpan

--- a/money-core/src/test/scala/com/comcast/money/logging/TraceLoggingSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/logging/TraceLoggingSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.logging
 
 import org.mockito.Mockito._

--- a/money-core/src/test/scala/com/comcast/money/metrics/MoneyMetricsSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/metrics/MoneyMetricsSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.metrics
 
 import java.util.concurrent.TimeUnit
@@ -44,4 +60,3 @@ class MoneyMetricsSpec extends WordSpec with Matchers with MockitoSugar with One
     }
   }
 }
-

--- a/money-core/src/test/scala/com/comcast/money/metrics/SpanMetricsSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/metrics/SpanMetricsSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.metrics
 
 import akka.testkit.TestActorRef

--- a/money-core/src/test/scala/com/comcast/money/reflect/ReflectionsSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/reflect/ReflectionsSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.reflect
 
 import com.comcast.money.annotations.TracedData

--- a/money-core/src/test/scala/com/comcast/money/test/AkkaTestJawn.scala
+++ b/money-core/src/test/scala/com/comcast/money/test/AkkaTestJawn.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.test
 
 import akka.actor._

--- a/money-http-client/src/main/resources/reference.conf
+++ b/money-http-client/src/main/resources/reference.conf
@@ -1,3 +1,17 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 money {
   http-client {
     metric-names {

--- a/money-http-client/src/main/scala/com/comcast/money/http/client/HttpTraceAspect.scala
+++ b/money-http-client/src/main/scala/com/comcast/money/http/client/HttpTraceAspect.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.http.client
 
 import com.comcast.money.annotations.Traced

--- a/money-http-client/src/main/scala/com/comcast/money/http/client/HttpTraceConfig.scala
+++ b/money-http-client/src/main/scala/com/comcast/money/http/client/HttpTraceConfig.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.http.client
 
 import com.comcast.money.core.Money

--- a/money-http-client/src/main/scala/com/comcast/money/http/client/TraceFriendlyHttpClient.scala
+++ b/money-http-client/src/main/scala/com/comcast/money/http/client/TraceFriendlyHttpClient.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.http.client
 
 import java.io.Closeable
@@ -128,5 +144,3 @@ class TraceFriendlyResponseHandler[T](wrapee: ResponseHandler[_ <: T], tracer: T
     wrapee.handleResponse(response)
   }
 }
-
-

--- a/money-http-client/src/test/resources/application.conf
+++ b/money-http-client/src/test/resources/application.conf
@@ -1,3 +1,17 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 money {
   akka {
     loglevel = DEBUG

--- a/money-http-client/src/test/scala/com/comcast/money/http/client/HttpTraceAspectSpec.scala
+++ b/money-http-client/src/test/scala/com/comcast/money/http/client/HttpTraceAspectSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.http.client
 
 import java.io.{ByteArrayInputStream, InputStream}

--- a/money-http-client/src/test/scala/com/comcast/money/http/client/TraceFriendlyHttpClientSpec.scala
+++ b/money-http-client/src/test/scala/com/comcast/money/http/client/TraceFriendlyHttpClientSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.http.client
 
 import java.io.Closeable

--- a/money-java-servlet/src/main/scala/com/comcast/money/java/servlet/TraceFilter.scala
+++ b/money-java-servlet/src/main/scala/com/comcast/money/java/servlet/TraceFilter.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.java.servlet
 
 import javax.servlet._

--- a/money-java-servlet/src/test/scala/com/comcast/money/java/servlet/TraceFilterSpec.scala
+++ b/money-java-servlet/src/test/scala/com/comcast/money/java/servlet/TraceFilterSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.java.servlet
 
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}

--- a/money-kafka/src/it/resources/application.conf
+++ b/money-kafka/src/it/resources/application.conf
@@ -1,3 +1,17 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 money {
   akka {
     log-config-on-start = off

--- a/money-kafka/src/it/scala/com/comcast/money/kafka/KafkaConsumerApp.scala
+++ b/money-kafka/src/it/scala/com/comcast/money/kafka/KafkaConsumerApp.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.kafka
 
 import java.util.Properties

--- a/money-kafka/src/it/scala/com/comcast/money/kafka/KafkaEmbedded.scala
+++ b/money-kafka/src/it/scala/com/comcast/money/kafka/KafkaEmbedded.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.kafka
 
 import java.io.File

--- a/money-kafka/src/it/scala/com/comcast/money/kafka/KafkaProducerApp.scala
+++ b/money-kafka/src/it/scala/com/comcast/money/kafka/KafkaProducerApp.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.kafka
 
 import java.util.Properties

--- a/money-kafka/src/it/scala/com/comcast/money/kafka/KafkaSpec.scala
+++ b/money-kafka/src/it/scala/com/comcast/money/kafka/KafkaSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.kafka
 
 import java.util.Properties

--- a/money-kafka/src/it/scala/com/comcast/money/kafka/ZooKeeperEmbedded.scala
+++ b/money-kafka/src/it/scala/com/comcast/money/kafka/ZooKeeperEmbedded.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.kafka
 
 import kafka.utils.Logging

--- a/money-kafka/src/main/resources/reference.conf
+++ b/money-kafka/src/main/resources/reference.conf
@@ -1,3 +1,17 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 money {
   emitter {
     emitters = [

--- a/money-kafka/src/main/scala/com/comcast/money/kafka/KafkaEmitter.scala
+++ b/money-kafka/src/main/scala/com/comcast/money/kafka/KafkaEmitter.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.kafka
 
 import java.util.Properties

--- a/money-kafka/src/test/resources/application.conf
+++ b/money-kafka/src/test/resources/application.conf
@@ -1,3 +1,17 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 money {
   akka {
     log-config-on-start = off

--- a/money-kafka/src/test/scala/com/comcast/money/kafka/KafkaEmitterSpec.scala
+++ b/money-kafka/src/test/scala/com/comcast/money/kafka/KafkaEmitterSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.kafka
 
 import akka.actor.{ActorSystem, Props}

--- a/money-spring/src/main/scala/com/comcast/money/spring/aspectj/ThreadPoolTaskExecutorAspect.scala
+++ b/money-spring/src/main/scala/com/comcast/money/spring/aspectj/ThreadPoolTaskExecutorAspect.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.aspectj
 
 import java.lang.reflect.Field

--- a/money-spring/src/test/resources/application.conf
+++ b/money-spring/src/test/resources/application.conf
@@ -1,3 +1,17 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 money {
   akka {
     loglevel = INFO

--- a/money-spring/src/test/scala/com/comcast/money/spring/aspectj/ThreadPoolTaskExecutorAspectSpec.scala
+++ b/money-spring/src/test/scala/com/comcast/money/spring/aspectj/ThreadPoolTaskExecutorAspectSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.spring.aspectj
 
 import java.util.concurrent.SynchronousQueue

--- a/money-spring3/src/main/scala/com/comcast/money/spring3/SpringTracer.scala
+++ b/money-spring3/src/main/scala/com/comcast/money/spring3/SpringTracer.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.spring3
 
 import akka.actor.ActorRef

--- a/money-spring3/src/main/scala/com/comcast/money/spring3/TracedMethodInterceptor.scala
+++ b/money-spring3/src/main/scala/com/comcast/money/spring3/TracedMethodInterceptor.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.spring3
 
 import java.lang.reflect.Method

--- a/money-spring3/src/test/java/com/comcast/money/spring3/SampleTraceBean.java
+++ b/money-spring3/src/test/java/com/comcast/money/spring3/SampleTraceBean.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.spring3;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/money-spring3/src/test/java/com/comcast/money/spring3/SpringTracerSpec.java
+++ b/money-spring3/src/test/java/com/comcast/money/spring3/SpringTracerSpec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.spring3;
 
 import org.junit.Before;

--- a/money-spring3/src/test/java/com/comcast/money/spring3/TracedMethodInterceptorSpec.java
+++ b/money-spring3/src/test/java/com/comcast/money/spring3/TracedMethodInterceptorSpec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.spring3;
 
 import org.junit.After;

--- a/money-spring3/src/test/resources/application.conf
+++ b/money-spring3/src/test/resources/application.conf
@@ -1,3 +1,17 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 money {
   enabled = true
   tracer {

--- a/money-spring3/src/test/scala/com/comcast/money/spring3/TracedMethodAdvisorSpec.scala
+++ b/money-spring3/src/test/scala/com/comcast/money/spring3/TracedMethodAdvisorSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.spring3
 
 import org.scalatest.mock.MockitoSugar

--- a/money-spring3/src/test/scala/com/comcast/money/spring3/TracedMethodInterceptorScalaSpec.scala
+++ b/money-spring3/src/test/scala/com/comcast/money/spring3/TracedMethodInterceptorScalaSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.spring3
 
 import com.comcast.money.annotations.{Traced, TracedData}

--- a/money-wire/src/main/scala/com/comcast/money/wire/SpanConverters.scala
+++ b/money-wire/src/main/scala/com/comcast/money/wire/SpanConverters.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.wire
 
 import java.io.ByteArrayOutputStream

--- a/money-wire/src/test/scala/com/comcast/money/wire/AvroConversionSpec.scala
+++ b/money-wire/src/test/scala/com/comcast/money/wire/AvroConversionSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.wire
 
 import com.comcast.money.core.{LongNote, Note, Span, SpanId}

--- a/money-wire/src/test/scala/com/comcast/money/wire/JsonConversionSpec.scala
+++ b/money-wire/src/test/scala/com/comcast/money/wire/JsonConversionSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.wire
 
 import com.comcast.money.core.{LongNote, Note, SpanId, Span}

--- a/project/MoneyBuild.scala
+++ b/project/MoneyBuild.scala
@@ -1,10 +1,13 @@
 import com.typesafe.sbt.SbtAspectj.AspectjKeys._
 import com.typesafe.sbt.SbtAspectj._
-import com.typesafe.sbt.SbtSite._
 import sbt.Keys._
 import sbt._
 import sbtavro.SbtAvro._
 import scoverage.ScoverageSbtPlugin._
+import de.heikoseeberger.sbtheader.HeaderPlugin
+import de.heikoseeberger.sbtheader.AutomateHeaderPlugin
+import de.heikoseeberger.sbtheader.HeaderKey._
+import de.heikoseeberger.sbtheader.license.Apache2_0
 
 import scala.sys.SystemProperties
 
@@ -248,8 +251,13 @@ object MoneyBuild extends Build {
       val x = links.collect { case Some(d) => d }.toMap
       println("links: " + x)
       x
-    }
-  )
+    },
+    headers := Map(
+      "scala" -> Apache2_0("2012-2015", "Comcast Cable Communications Management, LLC"),
+      "java" -> Apache2_0("2012-2015", "Comcast Cable Communications Management, LLC"),
+      "conf" -> Apache2_0("2012-2015", "Comcast Cable Communications Management, LLC", "#")
+    )
+  ) ++ HeaderPlugin.settingsFor(IntegrationTest) ++ AutomateHeaderPlugin.automateFor(Compile, Test, IntegrationTest)
 
   object Dependencies {
     val akkaVersion = "2.2.3"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,3 +14,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
 
 addSbtPlugin("com.cavorite" % "sbt-avro" % "0.3.2")
 
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.5.0")
+


### PR DESCRIPTION
Added sbt-header plugin that generates headers for all scala, java, and
conf files on build.

Added NOTICE file.

Updated to sbt 13.8
