### PR TITLE
Prototype Java Api

### DIFF
--- a/money-api/src/main/java/com/comcast/money/api/Note.java
+++ b/money-api/src/main/java/com/comcast/money/api/Note.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.api;
+
+/**
+ * A note that has been recorded on a {@link Span}
+ *
+ * @param <T> The type of Note.  This is currently limited to Long, String, Boolean and Double
+ */
+public class Note<T> {
+
+    private final String name;
+    private final T value;
+    private final long timestamp;
+    private final boolean sticky; // indicates that this note should be sent to child spans if so requested by user
+
+    private Note(String name, T value) {
+        this(name, value, System.currentTimeMillis(), false);
+    }
+
+    private Note(String name, T value, boolean sticky) {
+        this(name, value, System.currentTimeMillis(), sticky);
+    }
+
+    private Note(String name, T value, Long timestamp, boolean sticky) {
+        this.name = name;
+        this.value = value;
+        this.timestamp = timestamp;
+        this.sticky = sticky;
+    }
+
+    /**
+     * @return The name of the note
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * @return The value for the note
+     */
+    public T value() {
+        return value;
+    }
+
+    /**
+     * @return The timestamp in milliseconds when the note was created
+     */
+    public long timestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Stickiness indicates that this note should be passed down to child spans.  It becomes useful
+     * in certain logging situations where a consistent piece of state is maintained throughout the duration
+     * of a trace.
+     *
+     * @return an indicator of whether or not this note is "sticky".
+     */
+    public boolean isSticky() {
+        return sticky;
+    }
+
+    /**
+     * Creates a new note that contains a string
+     * @param name The name of the note
+     * @param value The value for the note
+     * @return A new {@link Note} that contains a String value
+     */
+    public static Note<String> of(String name, String value) {
+        return new Note<String>(name, value);
+    }
+
+    /**
+     * Creates a new note that contains a long
+     * @param name The name of the note
+     * @param value The value for the note
+     * @return A new {@link Note} that contains a long value
+     */
+    public static Note<Long> of(String name, long value) {
+        return new Note<Long>(name, value);
+    }
+
+    /**
+     * Creates a new note that contains a boolean
+     * @param name The name of the note
+     * @param value The value for the note
+     * @return A new {@link Note} that contains a boolean value
+     */
+    public static Note<Boolean> of(String name, boolean value) {
+        return new Note<Boolean>(name, value);
+    }
+
+    /**
+     * Creates a new note that contains a double
+     * @param name The name of the note
+     * @param value The value for the note
+     * @return A new {@link Note} that contains a double value
+     */
+    public static Note<Double> of(String name, double value) {
+        return new Note<Double>(name, value);
+    }
+
+    /**
+     * Creates a new note that contains a string
+     * @param name The name of the note
+     * @param value The value for the note
+     * @param sticky Indicates whether this Note should be sticky
+     * @return A new {@link Note} that contains a String value
+     */
+    public static Note<String> of(String name, String value, boolean sticky) {
+        return new Note<String>(name, value, sticky);
+    }
+
+    /**
+     * Creates a new note that contains a long
+     * @param name The name of the note
+     * @param value The value for the note
+     * @param sticky Indicates whether this Note should be sticky
+     * @return A new {@link Note} that contains a long value
+     */
+    public static Note<Long> of(String name, long value, boolean sticky) {
+        return new Note<Long>(name, value, sticky);
+    }
+
+    /**
+     * Creates a new note that contains a boolean
+     * @param name The name of the note
+     * @param value The value for the note
+     * @param sticky Indicates whether this Note should be sticky
+     * @return A new {@link Note} that contains a boolean value
+     */
+    public static Note<Boolean> of(String name, boolean value, boolean sticky) {
+        return new Note<Boolean>(name, value, sticky);
+    }
+
+    /**
+     * Creates a new note that contains a double
+     * @param name The name of the note
+     * @param value The value for the note
+     * @param sticky Indicates whether this Note should be sticky
+     * @return A new {@link Note} that contains a double value
+     */
+    public static Note<Double> of(String name, double value, boolean sticky) {
+        return new Note<Double>(name, value, sticky);
+    }
+}

--- a/money-api/src/main/java/com/comcast/money/api/Span.java
+++ b/money-api/src/main/java/com/comcast/money/api/Span.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.api;
+
+import java.util.Map;
+
+/**
+ * A Span is a container that represents a unit of work.  It could be a long running operation or sequence of
+ * statements in process, or a remote system call.
+ *
+ * A Span is immutable, all changes to the span result in a new Span being created.
+ */
+public interface Span {
+
+    /**
+     * Signals the span that it has started
+     */
+    void start();
+
+    /**
+     * Stops the span asserts a successful result
+     */
+    void stop();
+
+    /**
+     * Ends a span, moving it to a Stopped state
+     * @param result The result of the span (success or failure)
+     */
+    void stop(boolean result);
+
+    /**
+     * Records a given note onto the span.  If the note was already present, it will be overwritten
+     * @param note
+     */
+    void record(Note<?> note);
+
+    /**
+     * Starts a new timer on the span
+     * @param timerKey The name of the timer to start
+     * @return a new Span with the timer started
+     */
+    void startTimer(String timerKey);
+
+    /**
+     * Stops an existing timer on the span
+     * @param timerKey The name of the timer
+     * @return a new Span with the timer stopped
+     */
+    void stopTimer(String timerKey);
+
+    /**
+      * @return a map of all of the notes that were recorded on the span.  Implementers should enforce
+     * that the map returned is a copy of the notes
+     */
+    Map<String, Note<?>> notes();
+
+    /**
+     * @return the time in milliseconds when this span was started
+     */
+    Long startTime();
+
+    /**
+     * @return the time in microseconds when this span was started
+     */
+    Long startInstant();
+
+    /**
+     * @return the time in milliseconds when this span was ended.  Will return
+     * null if the span is still open
+     */
+    Long endTime();
+
+    /**
+     * @return the time in microseconds when this span was stopped.
+     */
+    Long endInstant();
+
+    /**
+     * @return the result of the span.  Will return null if the span was never stopped.
+     */
+    Boolean success();
+
+    /**
+     * @return the SpanId of the span.
+     */
+    SpanId id();
+
+    /**
+     * @return the name of the span
+     */
+    String name();
+
+    /**
+     * @return how long since the span was started.  Once it is stopped, the duration should reperesent
+     * how long the span was open for.
+     */
+    Long duration();
+
+    /**
+     * Creates a new child from this span
+     *
+     * @param childName The name of the child to create
+     * @param sticky True if the sticky notes from this span should be passed to the child
+     * @return A new Span that is a child of this span
+     */
+    Span childSpan(String childName, boolean sticky);
+
+    /**
+     * Creates a new child from this span
+     *
+     * @param childName The name of the child to create
+     * @return A new Span that is a child of this span
+     */
+    Span childSpan(String childName);
+}

--- a/money-api/src/main/java/com/comcast/money/api/SpanFactory.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.api;
+
+public interface SpanFactory {
+
+    Span newSpan(String spanName);
+
+    Span newSpan(String spanName, boolean sticky);
+}

--- a/money-api/src/main/java/com/comcast/money/api/SpanHandler.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.api;
+
+/**
+ * A handler that does some processing on a Span.
+ * <p>
+ *     When a {@link Span} is stopped, the resulting span is passed to the SpanHandler for processing.  Useful
+ *     processing includes things like logging the span, or sending the span to Graphite.
+ * </p>
+ */
+public interface SpanHandler {
+
+    /**
+     * Handles a span that has been stopped.
+     *
+     * @param span {@link Span} that has been stopped and is ready for processing
+     */
+    void handle(Span span);
+}

--- a/money-api/src/main/java/com/comcast/money/api/SpanId.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanId.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.api;
+
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * A unique identifier for a Span.
+ */
+public class SpanId {
+
+    private static final Random rand = new Random();
+    private static final String STRING_FORMAT = "SpanId~%s~%s~%s";
+
+    private final String traceId;
+    private final long parentId;
+    private final long selfId;
+
+    public SpanId() {
+        this(UUID.randomUUID().toString());
+    }
+
+    public SpanId(String traceId) {
+        this(traceId, rand.nextLong());
+    }
+
+    public SpanId(String traceId, long parentId) {
+        this(traceId, parentId, rand.nextLong());
+    }
+
+    public SpanId(String traceId, long parentId, long selfId) {
+
+        if (traceId == null) {
+            this.traceId = UUID.randomUUID().toString();
+        } else {
+            this.traceId = traceId;
+        }
+        this.parentId = parentId;
+        this.selfId = selfId;
+    }
+
+    public String traceId() {
+        return traceId;
+    }
+
+    public long parentId() {
+        return parentId;
+    }
+
+    public long selfId() {
+        return selfId;
+    }
+
+    public SpanId newChild() {
+        return new SpanId(traceId, selfId);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(STRING_FORMAT, traceId, parentId, selfId);
+    }
+
+    public static SpanId fromString(String spanIdString) {
+
+        String[] parts = spanIdString.split("~");
+        if (parts.length < 4) {
+            return null;
+        }
+
+        String traceId = parts[1].trim();
+        long parentId = Long.parseLong(parts[2].trim());
+        long selfId = Long.parseLong(parts[3].trim());
+        return new SpanId(traceId, parentId, selfId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SpanId spanId = (SpanId) o;
+
+        if (parentId != spanId.parentId) return false;
+        if (selfId != spanId.selfId) return false;
+        return traceId.equals(spanId.traceId);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = traceId.hashCode();
+        result = 31 * result + (int) (parentId ^ (parentId >>> 32));
+        result = 31 * result + (int) (selfId ^ (selfId >>> 32));
+        return result;
+    }
+}

--- a/money-api/src/test/scala/com/comcast/money/api/NoteSpec.scala
+++ b/money-api/src/test/scala/com/comcast/money/api/NoteSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.api
+
+import org.scalatest.{ Matchers, WordSpec }
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+class NoteSpec extends WordSpec with Matchers {
+
+  "A Note" should {
+    "create String notes" in {
+      val note = Note.of("foo", "bar")
+
+      note.isSticky shouldBe false
+      note.name shouldBe "foo"
+      note.value shouldBe "bar"
+      note.timestamp should not be 0
+    }
+
+    "create Long notes" in {
+      val note = Note.of("foo", 1L)
+
+      note.isSticky shouldBe false
+      note.name shouldBe "foo"
+      note.value shouldBe 1L
+      note.timestamp should not be 0
+    }
+
+    "create Double notes" in {
+      val note = Note.of("foo", 2.2)
+
+      note.isSticky shouldBe false
+      note.name shouldBe "foo"
+      note.value shouldBe 2.2
+      note.timestamp should not be 0
+    }
+
+    "create Boolean notes" in {
+      val note = Note.of("foo", true)
+
+      note.isSticky shouldBe false
+      note.name shouldBe "foo"
+      note.value shouldBe true
+      note.timestamp should not be 0
+    }
+
+    "create String notes with propagated" in {
+      val note = Note.of("foo", "bar", true)
+
+      note.isSticky shouldBe true
+      note.name shouldBe "foo"
+      note.value shouldBe "bar"
+      note.timestamp should not be 0
+    }
+
+    "create Long notes with propagated" in {
+      val note = Note.of("foo", 1L, true)
+
+      note.isSticky shouldBe true
+      note.name shouldBe "foo"
+      note.value shouldBe 1L
+      note.timestamp should not be 0
+    }
+
+    "create Double notes with propagated" in {
+      val note = Note.of("foo", 2.2, true)
+
+      note.isSticky shouldBe true
+      note.name shouldBe "foo"
+      note.value shouldBe 2.2
+      note.timestamp should not be 0
+    }
+
+    "create Boolean notes with propagated" in {
+      val note = Note.of("foo", true, true)
+
+      note.isSticky shouldBe true
+      note.name shouldBe "foo"
+      note.value shouldBe true
+      note.timestamp should not be 0
+    }
+  }
+}

--- a/money-api/src/test/scala/com/comcast/money/api/SpanIdSpec.scala
+++ b/money-api/src/test/scala/com/comcast/money/api/SpanIdSpec.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.api
+
+import org.scalatest.{ Matchers, WordSpec }
+
+class SpanIdSpec extends WordSpec with Matchers {
+
+  "SpanId" should {
+    "take 3 constructor arguments" in {
+      val spanId = new SpanId("foo", 1L, 2L)
+
+      spanId.traceId shouldBe "foo"
+      spanId.parentId shouldBe 1L
+      spanId.selfId shouldBe 2L
+    }
+
+    "set self id to a random long if not specified in the constructor" in {
+      val spanId = new SpanId("foo", 1L)
+
+      spanId.traceId shouldBe "foo"
+      spanId.parentId shouldBe 1L
+      Long.box(spanId.selfId) should not be null
+    }
+
+    "set the self and parent id to a random long if not specified" in {
+      val spanId = new SpanId("foo")
+
+      spanId.traceId shouldBe "foo"
+      Long.box(spanId.parentId) should not be null
+      Long.box(spanId.selfId) should not be null
+    }
+
+    "generate a string matching SpanId~%s~%s~%s" in {
+      val format = "SpanId~%s~%s~%s"
+      val expected = format.format("foo", 1L, 2L)
+
+      val spanId = new SpanId("foo", 1L, 2L)
+      val result = spanId.toString
+
+      result shouldEqual expected
+    }
+
+    "parse a string into a span id" in {
+      val spanId = new SpanId("foo", 1L, 2L)
+      val str = spanId.toString
+
+      val parsed = SpanId.fromString(str)
+      parsed.traceId shouldBe spanId.traceId
+      parsed.parentId shouldBe spanId.parentId
+      parsed.selfId shouldBe spanId.selfId
+    }
+
+    "default traceId to UUID if set to null" in {
+      val spanId = new SpanId(null, 1L)
+
+      spanId.traceId should not be null
+    }
+  }
+}

--- a/project/MoneyBuild.scala
+++ b/project/MoneyBuild.scala
@@ -25,7 +25,20 @@ object MoneyBuild extends Build {
     publishLocal := {},
     publish := {}
   )
-  .aggregate(moneyCore, moneyAspectj, moneyHttpClient, moneyJavaServlet, moneyKafka, moneySpring, moneySpring3, moneyWire)
+  .aggregate(moneyApi, moneyCore, moneyAspectj, moneyHttpClient, moneyJavaServlet, moneyKafka, moneySpring, moneySpring3, moneyWire)
+
+  lazy val moneyApi =
+    Project("money-api", file("./money-api"))
+      .configs( IntegrationTest )
+      .settings(projectSettings: _*)
+      .settings(
+        libraryDependencies ++= {
+        Seq(
+          scalaTest,
+          mockito
+        )
+      }
+      )
 
   lazy val moneyCore =
     Project("money-core", file("./money-core"))


### PR DESCRIPTION
This is the second revision of the Java / "new" Money API.  The goals are:

- Create a JAVA api so we can support alternative implementations without _requiring_ Scala
- Have an API that does not _assume_ using ThreadLocal for the implementation.  i.e., users can mange their own spans if they like to.