### PR TITLE
Prepping for Sonatype Publish

### DIFF
--- a/project/MoneyBuild.scala
+++ b/project/MoneyBuild.scala
@@ -231,7 +231,43 @@ object MoneyBuild extends Build {
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF", "-u", "target/scalatest-reports"),
     fork := true,
     publishMavenStyle := true,
-    publishTo := Some(Resolver.mavenLocal),
+    publishTo := {
+      val nexus = "https://oss.sonatype.org/"
+      if (isSnapshot.value)
+        Some("snapshots" at nexus + "content/repositories/snapshots")
+      else
+        Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+    },
+    pomIncludeRepository := { _ => false },
+    pomExtra := (
+      <name>com.comcast:money</name>
+      <description>A distributed tracing framework</description>
+      <url>https://github.com/Comcast/money</url>
+        <licenses>
+          <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+          </license>
+        </licenses>
+        <scm>
+          <url>git@github.com:Comcast/money.git</url>
+          <connection>scm:git:git@github.com:Comcast/money.git</connection>
+        </scm>
+        <developers>
+          <developer>
+            <id>paulcleary</id>
+            <name>Paul Clery</name>
+            <url>https://github.com/paulcleary</url>
+          </developer>
+          <developer>
+            <id>kristomasette</id>
+            <name>Kristofer Tomasette</name>
+            <url>https://github.com/kristomasette</url>
+          </developer>
+        </developers>),
+    publishArtifact in Test := false,
     autoAPIMappings := true,
     apiMappings ++= {
       def findManagedDependency(organization: String, name: String): Option[File] = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,3 +18,5 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.5.0")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.5.1")
 
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+

--- a/samples/samples-springmvc/pom.xml
+++ b/samples/samples-springmvc/pom.xml
@@ -16,6 +16,35 @@
         <money.version>0.8.11-SNAPSHOT</money.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>sonatype-snapshots</id>
+            <name>Sonatype snapshot repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>sonatype-releases</id>
+            <name>Sonatype release repository</name>
+            <url>https://oss.sonatype.org/content/repositories/releases</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- Money -->
         <dependency>

--- a/samples/samples-springmvc/src/main/java/com/comcast/money/samples/springmvc/config/AppConfig.java
+++ b/samples/samples-springmvc/src/main/java/com/comcast/money/samples/springmvc/config/AppConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
-import scala.beans.BeanDescription;
 
 import com.comcast.money.japi.TraceFriendlyExecutors;
 import com.comcast.money.spring3.TracedMethodInterceptor;


### PR DESCRIPTION
Updated build to publish to sonatype.

Added sbt-pbp plugin to allow us to publish signed.

Tested this using 0.8.11-SNAPSHOT to publish a snapshot version.

Note: Signed everything using my own pgp key.