### PR TITLE
Add MetricRegistry factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## Development Status
 We are actively working on version 0.9 that will offer several improvements over both the API and module 
 implementations.  0.8.x is being used in several projects currently, and we will continue to enhance
-0.8.x for the forseeable future while 0.9 work takes place.
+0.8.x for the foreseeable future while 0.9 work takes place.
 
 If you want to work on 0.9, feel free to reach out!
 
 ### Availability
-We have requests in to deploy to a public repo, that should be avaiable shortly
+We have requests in to deploy to a public repo, that should be available shortly
 
 ## Distributed Tracing Reads
 [Distributed Trace For Video Systems](http://www.nctatechnicalpapers.com/Paper/2015/2015-distributed-trace-for-video-systems/download)
@@ -114,7 +114,7 @@ key insight into traces and performance using standard open source tools; here a
 - Splunk / LogStash - we use log aggregators to perform metrics across systems at rest.  The nice thing about log 
 aggregators is that you can not only see your metrics, but you can also look at all of the log entries that happend 
 for a single Span
-- Graphite / Prometheus - we use common analytic systems for monitoring and alterting on Money data
+- Graphite / Prometheus - we use common analytic systems for monitoring and altering on Money data
 
 ## Should I use Money?
 This depends on the scale of your implementation.  Money _tries_ to serve a wide range of implementations.

--- a/money-core/src/main/resources/reference.conf
+++ b/money-core/src/main/resources/reference.conf
@@ -39,7 +39,9 @@ money {
     jvm-exit-on-fatal-error = off
   }
 
-  metricRegistryFactory = "com.comcast.money.metrics.DefaultMetricRegistryFactory"
+  metrics-registry {
+    class-name = "com.comcast.money.metrics.DefaultMetricRegistryFactory"
+  }
 
   emitter {
     emitters = [

--- a/money-core/src/main/resources/reference.conf
+++ b/money-core/src/main/resources/reference.conf
@@ -39,6 +39,8 @@ money {
     jvm-exit-on-fatal-error = off
   }
 
+  metricRegistryFactory = "com.comcast.money.metrics.DefaultMetricRegistryFactory"
+
   emitter {
     emitters = [
       {

--- a/money-core/src/main/scala/com/comcast/money/metrics/MetricRegistryFactory.scala
+++ b/money-core/src/main/scala/com/comcast/money/metrics/MetricRegistryFactory.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.metrics
+
+import com.typesafe.config.Config
+import akka.actor.{ ActorSystem }
+import com.codahale.metrics.{ MetricRegistry, JmxReporter }
+import scala.util.{ Try, Success, Failure }
+
+/*
+ * Simple factory that tries to delegate to an implementation of this trait itself and announced via
+ * the configuration 'metricRegistryFactory' - requiring that this implementation has a default constructor.
+ *
+ * It is up to the custom metricRegistryFactory what kind of MetricRegistry is created. No action is
+ * performed on this MetricRegistry is performed (i.e. registering reporters) but used/passed back right away.
+ *
+ * If any error occurs (configuration is not set, class can't be loaded etc.) the default behavior
+ * is performed and a fresh MetricRegistry is created and registered with the JmxReporter.
+ *
+ * Note: This trait should be kept as simple as possible so that the resulting interface can also be implemented
+ * by a Java client custom factory.
+ */
+object MetricRegistryFactory {
+
+  def metricRegistry(config: Config): MetricRegistry = {
+    Try({
+      // Try to create an instance of the custom factory, configured via 'metricRegistryFactory'
+      val realFactory = Class.forName(config.getString("metricRegistryFactory"))
+        .newInstance.asInstanceOf[MetricRegistryFactory]
+
+      // Ask the custom factory for an MetricRegistry - and pass in our configuration so that an implementation
+      // can add their settings in the application.conf, too.
+      realFactory.metricRegistry(config)
+    }) match {
+      case Success(metricRegistry) => metricRegistry
+      case Failure(ex) => {
+        // Something went wrong while using the custom factory. Therefore creating the MetricRegistry
+        // on our own and registering it to JMX (previous default behavior)
+        new DefaultMetricRegistryFactory().metricRegistry(config)
+      }
+    }
+  }
+}
+
+class DefaultMetricRegistryFactory extends MetricRegistryFactory {
+  override def metricRegistry(config: Config): MetricRegistry = {
+    val registry = new MetricRegistry
+    val jmxReporter = JmxReporter.forRegistry(registry).build()
+    jmxReporter.start()
+
+    registry
+  }
+}
+
+trait MetricRegistryFactory {
+  def metricRegistry(config: Config): MetricRegistry
+}

--- a/money-core/src/main/scala/com/comcast/money/metrics/MoneyMetrics.scala
+++ b/money-core/src/main/scala/com/comcast/money/metrics/MoneyMetrics.scala
@@ -40,15 +40,6 @@ object MoneyMetrics
     extends ExtensionId[MoneyMetricsImpl]
     with ExtensionIdProvider {
 
-  val registry: MetricRegistry = new MetricRegistry()
-  // register metrics
-  val activeSpans = registry.counter("active.spans")
-  val timedOutSpans = registry.counter("timed.out.spans")
-  val spanDurations = registry.timer("span.duration")
-
-  val jmxReporter = JmxReporter.forRegistry(registry).build()
-  jmxReporter.start()
-
   //The lookup method is required by ExtensionIdProvider,
   // so we return ourselves here, this allows us
   // to configure our extension to be loaded when
@@ -57,5 +48,14 @@ object MoneyMetrics
 
   //This method will be called by Akka
   // to instantiate our Extension
-  override def createExtension(system: ExtendedActorSystem) = new MoneyMetricsImpl(activeSpans, timedOutSpans, spanDurations)
+  override def createExtension(system: ExtendedActorSystem) = {
+
+    val registry = MetricRegistryFactory.metricRegistry(system.settings.config)
+    // register metrics
+    val activeSpans = registry.counter("active.spans")
+    val timedOutSpans = registry.counter("timed.out.spans")
+    val spanDurations = registry.timer("span.duration")
+
+    new MoneyMetricsImpl(activeSpans, timedOutSpans, spanDurations)
+  }
 }

--- a/money-core/src/test/scala/com/comcast/money/metrics/MetricRegistryFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/metrics/MetricRegistryFactorySpec.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.metrics
+
+import com.codahale.metrics.MetricRegistry
+import com.typesafe.config.Config
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest._
+import Matchers._
+
+object MockMetricRegistryFactory extends MetricRegistryFactory with MockitoSugar {
+  val mockRegistry = mock[MetricRegistry]
+
+  def metricRegistry(config: Config): MetricRegistry = ???
+}
+class MockMetricRegistryFactory extends MetricRegistryFactory {
+  def metricRegistry(config: Config): MetricRegistry = MockMetricRegistryFactory.mockRegistry
+}
+
+class MetricRegistryFactorySpec extends WordSpecLike with BeforeAndAfter with MockitoSugar {
+
+  private val conf = mock[Config]
+
+  "The MetricRegistry" when {
+    "use the DefaultMetricRegistryFactory" should {
+      "creating MetricRegistries" in {
+
+        doReturn("com.comcast.money.metrics.DefaultMetricRegistryFactory").when(conf).getString("metricRegistryFactory")
+
+        val registry = MetricRegistryFactory.metricRegistry(conf)
+
+        registry shouldNot be(null)
+      }
+    }
+  }
+
+  "fall back to the DefaultMetricRegistryFactory" should {
+    "when the config is broken" in {
+
+      doReturn("lorem ipsum").when(conf).getString("metricRegistryFactory")
+
+      val registry = MetricRegistryFactory.metricRegistry(conf)
+
+      registry shouldNot be(null)
+    }
+  }
+
+  "use the MockMetricRegistryFactory" should {
+    "when configured so" in {
+
+      doReturn("com.comcast.money.metrics.MockMetricRegistryFactory").when(conf).getString("metricRegistryFactory")
+
+      val registry1 = MetricRegistryFactory.metricRegistry(conf)
+      val registry2 = MetricRegistryFactory.metricRegistry(conf)
+
+      registry1 should be theSameInstanceAs registry2
+    }
+  }
+}

--- a/money-core/src/test/scala/com/comcast/money/metrics/MetricRegistryFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/metrics/MetricRegistryFactorySpec.scala
@@ -24,9 +24,10 @@ import org.scalatest._
 import Matchers._
 
 object MockMetricRegistryFactory extends MetricRegistryFactory with MockitoSugar {
-  val mockRegistry = mock[MetricRegistry]
+  lazy val mockRegistry = mock[MetricRegistry]
 
   def metricRegistry(config: Config): MetricRegistry = ???
+
 }
 class MockMetricRegistryFactory extends MetricRegistryFactory {
   def metricRegistry(config: Config): MetricRegistry = MockMetricRegistryFactory.mockRegistry
@@ -40,7 +41,7 @@ class MetricRegistryFactorySpec extends WordSpecLike with BeforeAndAfter with Mo
     "use the DefaultMetricRegistryFactory" should {
       "creating MetricRegistries" in {
 
-        doReturn("com.comcast.money.metrics.DefaultMetricRegistryFactory").when(conf).getString("metricRegistryFactory")
+        doReturn("com.comcast.money.metrics.DefaultMetricRegistryFactory").when(conf).getString("metrics-registry.class-name")
 
         val registry = MetricRegistryFactory.metricRegistry(conf)
 
@@ -52,18 +53,18 @@ class MetricRegistryFactorySpec extends WordSpecLike with BeforeAndAfter with Mo
   "fall back to the DefaultMetricRegistryFactory" should {
     "when the config is broken" in {
 
-      doReturn("lorem ipsum").when(conf).getString("metricRegistryFactory")
+      doReturn("lorem ipsum").when(conf).getString("metrics-registry.class-name")
 
-      val registry = MetricRegistryFactory.metricRegistry(conf)
-
-      registry shouldNot be(null)
+      intercept[ClassNotFoundException] {
+        val registry = MetricRegistryFactory.metricRegistry(conf)
+      }
     }
   }
 
   "use the MockMetricRegistryFactory" should {
     "when configured so" in {
 
-      doReturn("com.comcast.money.metrics.MockMetricRegistryFactory").when(conf).getString("metricRegistryFactory")
+      doReturn("com.comcast.money.metrics.MockMetricRegistryFactory").when(conf).getString("metrics-registry.class-name")
 
       val registry1 = MetricRegistryFactory.metricRegistry(conf)
       val registry2 = MetricRegistryFactory.metricRegistry(conf)

--- a/money-core/src/test/scala/com/comcast/money/metrics/MoneyMetricsSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/metrics/MoneyMetricsSpec.scala
@@ -48,15 +48,4 @@ class MoneyMetricsSpec extends WordSpec with Matchers with MockitoSugar with One
       verify(timedOutSpans).inc()
     }
   }
-
-  "MoneyMetrics Extension" should {
-    "initialize all metrics" in {
-      val eas = mock[ExtendedActorSystem]
-      val mm = MoneyMetrics.lookup().createExtension(eas)
-
-      MoneyMetrics.registry.getCounters.get("active.spans") shouldNot be(null)
-      MoneyMetrics.registry.getCounters.get("timed.out.spans") shouldNot be(null)
-      MoneyMetrics.registry.getTimers.get("span.duration") shouldNot be(null)
-    }
-  }
 }

--- a/money-core/src/test/scala/com/comcast/money/metrics/SpanMetricsSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/metrics/SpanMetricsSpec.scala
@@ -123,11 +123,4 @@ class SpanMetricsSpec extends AkkaTestJawn with FeatureSpecLike with Matchers wi
       verifyZeroInteractions(errorMetric)
     }
   }
-
-  feature("Span Metrics Object") {
-    scenario("registry") {
-      val reg = SpanMetrics.registry
-      reg shouldBe a[MetricRegistry]
-    }
-  }
 }

--- a/money-core/src/test/scala/com/comcast/money/metrics/SpanMetricsSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/metrics/SpanMetricsSpec.scala
@@ -29,6 +29,8 @@ import org.scalatest.{ FeatureSpecLike, GivenWhenThen, Matchers }
 class SpanMetricsSpec extends AkkaTestJawn with FeatureSpecLike with Matchers with GivenWhenThen with MockitoSugar {
 
   val conf = mock[Config]
+  doReturn("com.comcast.money.metrics.MockMetricRegistryFactory").when(conf).getString("metrics-registry.class-name")
+
   feature("Span Metrics Collector") {
     scenario("A span arrives for a new span name that we haven't seen yet") {
       Given("a span metrics collector is registered")


### PR DESCRIPTION
This patchset allows to configure a different way on how
`MetricRegistry` objects are created:

Up to now these were created within money itself with no exposition to
the rest of the system. That makes it impossible to register other
Dropwizzard reporters or exporters on it.

With this patchset it is now possible to provide a custom `MetricRegistry`
factory and do the required initialization of/with the `MetricRegistry`
object.

It is compatible to Java so even Java clients (using the Scala money)
can implement and configure a custom factory.
