### PR TITLE
Update stop span to take a boolean

### DIFF
--- a/money-core/src/main/scala/com/comcast/money/core/Money.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Money.scala
@@ -153,7 +153,7 @@ object Money {
 
       override def record(key: String, measure: Boolean, propogate: Boolean): Unit = {}
 
-      override def stopSpan(result: Note[Boolean] = Result.success) = {}
+      override def stopSpan(result: Boolean = true) = {}
 
       override def close() = {}
 

--- a/money-core/src/main/scala/com/comcast/money/core/Note.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Note.scala
@@ -59,6 +59,6 @@ object Note {
 }
 
 object Result {
-  def failed: Note[Boolean] = Note("span-success", false)
-  def success: Note[Boolean] = Note("span-success", true)
+  def failed: Boolean = false
+  def success: Boolean = true
 }

--- a/money-core/src/main/scala/com/comcast/money/core/Tracer.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Tracer.scala
@@ -303,7 +303,7 @@ trait Tracer extends Closeable {
    * }}}
    * @param result The result of the span, this will be Result.success or Result.failed
    */
-  def stopSpan(result: Note[Boolean] = Result.success) = withSpanId { spanId =>
+  def stopSpan(result: Boolean = true) = withSpanId { spanId =>
     SpanLocal.pop()
     spanSupervisorRef ! SpanMessage(spanId, Stop(result, DateTimeUtil.microTime))
   }

--- a/money-core/src/main/scala/com/comcast/money/internal/SpanFSM.scala
+++ b/money-core/src/main/scala/com/comcast/money/internal/SpanFSM.scala
@@ -50,7 +50,7 @@ object SpanFSMProtocol {
 
   case object Query extends SpanCommand
 
-  case class Stop(result: Note[Boolean], timeStamp: Long = DateTimeUtil.microTime) extends SpanCommand
+  case class Stop(result: Boolean, timeStamp: Long = DateTimeUtil.microTime) extends SpanCommand
 
 }
 
@@ -181,7 +181,7 @@ class SpanFSM(val emitterSupervisor: ActorRef, val openSpanTimeout: FiniteDurati
       }
       spanContext.timers.clear()
 
-      spanContext.setSuccess(result.value.getOrElse(true))
+      spanContext.setSuccess(result)
 
       goto(Stopped)
     case Event(StateTimeout, spanContext: SpanContext) =>
@@ -207,7 +207,7 @@ class SpanFSM(val emitterSupervisor: ActorRef, val openSpanTimeout: FiniteDurati
     case Event(Stop(result, stopTime), spanContext: SpanContext) =>
       log.debug("Stopped -> Stop")
       // Add the result, the basic premise here is that the last one in wins
-      spanContext.setSuccess(result.value.getOrElse(true))
+      spanContext.setSuccess(result)
 
       // Need to update the span duration
       val duration = stopTime - spanContext.startTime

--- a/money-core/src/test/scala/com/comcast/money/concurrent/FuturesSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/concurrent/FuturesSpec.scala
@@ -27,7 +27,7 @@ import org.scalatest._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{ Await, Future }
 
 class FuturesSpec extends AkkaTestJawn
     with FeatureSpecLike

--- a/money-core/src/test/scala/com/comcast/money/core/TracerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/TracerSpec.scala
@@ -55,11 +55,10 @@ class TracerSpec
   val spanSupervisor = new TestProbe(system) {
     def expectSpanMsg(tm: SpanCommand) {
       expectMsgPF() {
-        case SpanMessage(spanId, Stop(note, timeStamp)) =>
+        case SpanMessage(spanId, Stop(result, timeStamp)) =>
           tm shouldBe a[Stop]
-          val tmNote = tm.asInstanceOf[Stop].result
-          note.name shouldEqual tmNote.name
-          note.value shouldEqual tmNote.value
+          val tmResult = tm.asInstanceOf[Stop].result
+          tmResult shouldEqual result
         case SpanMessage(spanId, Start(innerSpanId, spanName, timeStamp, _)) =>
           tm shouldBe a[Start]
           tm.asInstanceOf[Start].spanName shouldEqual spanName
@@ -175,7 +174,7 @@ class TracerSpec
       spanSupervisor.expectSpanMsg(Start(new SpanId("foo", 1L), "foo"))
 
       Then("the failed result is sent along with the stop message")
-      spanSupervisor.expectSpanMsg(Stop(Note("span-success", false)))
+      spanSupervisor.expectSpanMsg(Stop(false))
     }
     scenario("stopping a span with a success result") {
       moneyTracer.startSpan("foo")
@@ -183,7 +182,7 @@ class TracerSpec
       spanSupervisor.expectSpanMsg(Start(new SpanId("foo", 1L), "foo"))
 
       Then("the failed result is sent along with the stop message")
-      spanSupervisor.expectSpanMsg(Stop(Note("span-success", true)))
+      spanSupervisor.expectSpanMsg(Stop(true))
     }
   }
   feature("recording a Note on a span") {

--- a/money-core/src/test/scala/com/comcast/money/core/TracersSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/TracersSpec.scala
@@ -54,7 +54,7 @@ class TracersSpec extends FeatureSpec
 
       Then("Start and Stop span are called on the tracer")
       verify(moneyTracer).startSpan("bob")
-      verify(moneyTracer).stopSpan(Note("span-success", true, 1L))
+      verify(moneyTracer).stopSpan(true)
     }
     scenario("The function being traced throws an exception") {
       When("a method is executed using the traced swag and it throws an exception")
@@ -68,7 +68,7 @@ class TracersSpec extends FeatureSpec
       verify(moneyTracer).startSpan("fail")
 
       And("the stop span is called with a failure result")
-      verify(moneyTracer).stopSpan(Note("span-success", false, 1L))
+      verify(moneyTracer).stopSpan(false)
     }
   }
   feature("Timed api") {

--- a/money-core/src/test/scala/com/comcast/money/internal/SpanFSMSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/internal/SpanFSMSpec.scala
@@ -75,7 +75,7 @@ class SpanFSMSpec extends AkkaTestJawn with WordSpecLike with BeforeAndAfter wit
         )
       )
 
-      span ! Stop(Note("span-success", true, 3L), 3L)
+      span ! Stop(true, 3L)
 
       Then("it should emit a span record")
       expectMsg(
@@ -195,7 +195,7 @@ class SpanFSMSpec extends AkkaTestJawn with WordSpecLike with BeforeAndAfter wit
       span ! StartTimer("timer-test", 1L)
 
       When("the span is stopped")
-      span ! Stop(Note("span-success", true, 2L), 2L)
+      span ! Stop(true, 2L)
 
       Then("any unstopped timers are stopped and removed from the span context")
       val spanState = span.underlyingActor.asInstanceOf[SpanFSM].stateData.asInstanceOf[SpanContext]
@@ -215,10 +215,10 @@ class SpanFSMSpec extends AkkaTestJawn with WordSpecLike with BeforeAndAfter wit
       span ! Start(new SpanId("foo", 1L, 1L), "happy span")
 
       And("the span is stopped")
-      span ! Stop(Note("span-success", true, 2L), 2L)
+      span ! Stop(true, 2L)
 
       When("another stop message arrives sometime later")
-      span ! Stop(Note("span-success", false, 4L), 4L)
+      span ! Stop(false, 4L)
 
       And("the span is finished and emitted")
       Then("the span duration that is emitted includes the time from the start to the last stop message")
@@ -236,7 +236,7 @@ class SpanFSMSpec extends AkkaTestJawn with WordSpecLike with BeforeAndAfter wit
     val span = system.actorOf(Props(classOf[SpanFSM], testActor))
     Given("a Start and Stop with a result")
     span ! Start(new SpanId("foo", 1L, 1L), "happy span")
-    span ! Stop(Note("span-success", true, 2L), 2L)
+    span ! Stop(true, 2L)
 
     When("the span data is emitted")
     Then("the span data contains the result passed in on the Stop message")

--- a/money-spring3/src/main/scala/com/comcast/money/spring3/SpringTracer.scala
+++ b/money-spring3/src/main/scala/com/comcast/money/spring3/SpringTracer.scala
@@ -243,7 +243,7 @@ class SpringTracer extends Tracer {
    * }}}
    * @param result The result of the span, this will be Result.success or Result.failed
    */
-  override def stopSpan(result: Note[Boolean]): Unit = tracer.stopSpan(result)
+  override def stopSpan(result: Boolean = true): Unit = tracer.stopSpan(result)
 
   /**
    * Starts a new timer on the current Span for the key provided

--- a/money-spring3/src/test/java/com/comcast/money/spring3/TracedMethodInterceptorSpec.java
+++ b/money-spring3/src/test/java/com/comcast/money/spring3/TracedMethodInterceptorSpec.java
@@ -52,7 +52,7 @@ public class TracedMethodInterceptorSpec {
     private SpringTracer springTracer;
 
     @Captor
-    private ArgumentCaptor<Note<Object>> spanResultCaptor;
+    private ArgumentCaptor<Boolean> spanResultCaptor;
 
     @Before
     public void setUp() {
@@ -155,7 +155,7 @@ public class TracedMethodInterceptorSpec {
     private void verifySpanResultsIn(Boolean result) {
 
         verify(springTracer).stopSpan(spanResultCaptor.capture());
-        Note<Object> spanResult = spanResultCaptor.getValue();
-        assertThat(spanResult.value().get()).isEqualTo(result);
+        Boolean spanResult = spanResultCaptor.getValue();
+        assertThat(spanResult).isEqualTo(result);
     }
 }


### PR DESCRIPTION
Instead of taking a Note.  This is part of refactoring to use the new
api.Note.  When I did the initial refactoring, a lot of inconsequential
code changes were necessary because the existing stopSpan method
required a Note.  By moving this to a boolean instead, I will reduce the
amount of code changes needed when I actually move to the new Note.