### PR TITLE
Added additional note factory methods

### DIFF
--- a/money-api/src/main/java/com/comcast/money/api/Note.java
+++ b/money-api/src/main/java/com/comcast/money/api/Note.java
@@ -158,4 +158,119 @@ public class Note<T> {
     public static Note<Double> of(String name, double value, boolean sticky) {
         return new Note<Double>(name, value, sticky);
     }
+
+    /**
+     * Creates a new note that contains a string
+     * @param name The name of the note
+     * @param value The value for the note
+     * @param sticky Indicates whether this Note should be sticky
+     * @param timestamp The timestamp for the note
+     * @return A new {@link Note} that contains a String value
+     */
+    public static Note<String> of(String name, String value, boolean sticky, long timestamp) {
+        return new Note<String>(name, value, timestamp, sticky);
+    }
+
+    /**
+     * Creates a new note that contains a long
+     * @param name The name of the note
+     * @param value The value for the note
+     * @param sticky Indicates whether this Note should be sticky
+     * @param timestamp The timestamp for the note
+     * @return A new {@link Note} that contains a long value
+     */
+    public static Note<Long> of(String name, long value, boolean sticky, long timestamp) {
+        return new Note<Long>(name, value, timestamp, sticky);
+    }
+
+    /**
+     * Creates a new note that contains a boolean
+     * @param name The name of the note
+     * @param value The value for the note
+     * @param sticky Indicates whether this Note should be sticky
+     * @param timestamp The timestamp for the note
+     * @return A new {@link Note} that contains a boolean value
+     */
+    public static Note<Boolean> of(String name, boolean value, boolean sticky, long timestamp) {
+        return new Note<Boolean>(name, value, timestamp, sticky);
+    }
+
+    /**
+     * Creates a new note that contains a double
+     * @param name The name of the note
+     * @param value The value for the note
+     * @param sticky Indicates whether this Note should be sticky
+     * @param timestamp The timestamp for the note
+     * @return A new {@link Note} that contains a double value
+     */
+    public static Note<Double> of(String name, double value, boolean sticky, long timestamp) {
+        return new Note<Double>(name, value, timestamp, sticky);
+    }
+
+    /**
+     * Creates a new note that contains a string
+     * @param name The name of the note
+     * @param value The value for the note
+     * @param timestamp The timestamp for the note
+     * @return A new {@link Note} that contains a String value
+     */
+    public static Note<String> of(String name, String value, long timestamp) {
+        return new Note<String>(name, value, timestamp, false);
+    }
+
+    /**
+     * Creates a new note that contains a long
+     * @param name The name of the note
+     * @param value The value for the note
+     * @param timestamp The timestamp for the note
+     * @return A new {@link Note} that contains a long value
+     */
+    public static Note<Long> of(String name, long value, long timestamp) {
+        return new Note<Long>(name, value, timestamp, false);
+    }
+
+    /**
+     * Creates a new note that contains a boolean
+     * @param name The name of the note
+     * @param value The value for the note
+     * @param timestamp The timestamp for the note
+     * @return A new {@link Note} that contains a boolean value
+     */
+    public static Note<Boolean> of(String name, boolean value, long timestamp) {
+        return new Note<Boolean>(name, value, timestamp, false);
+    }
+
+    /**
+     * Creates a new note that contains a double
+     * @param name The name of the note
+     * @param value The value for the note
+     * @param timestamp The timestamp for the note
+     * @return A new {@link Note} that contains a double value
+     */
+    public static Note<Double> of(String name, double value, long timestamp) {
+        return new Note<Double>(name, value, timestamp, false);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Note<?> note = (Note<?>) o;
+
+        if (timestamp != note.timestamp) return false;
+        if (sticky != note.sticky) return false;
+        if (!name.equals(note.name)) return false;
+        return value != null ? value.equals(note.value) : note.value == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+        result = 31 * result + (sticky ? 1 : 0);
+        return result;
+    }
 }

--- a/money-api/src/test/scala/com/comcast/money/api/NoteSpec.scala
+++ b/money-api/src/test/scala/com/comcast/money/api/NoteSpec.scala
@@ -59,7 +59,7 @@ class NoteSpec extends WordSpec with Matchers {
       note.timestamp should not be 0
     }
 
-    "create String notes with propagated" in {
+    "create String notes with sticky" in {
       val note = Note.of("foo", "bar", true)
 
       note.isSticky shouldBe true
@@ -68,7 +68,7 @@ class NoteSpec extends WordSpec with Matchers {
       note.timestamp should not be 0
     }
 
-    "create Long notes with propagated" in {
+    "create Long notes with sticky" in {
       val note = Note.of("foo", 1L, true)
 
       note.isSticky shouldBe true
@@ -77,7 +77,7 @@ class NoteSpec extends WordSpec with Matchers {
       note.timestamp should not be 0
     }
 
-    "create Double notes with propagated" in {
+    "create Double notes with sticky" in {
       val note = Note.of("foo", 2.2, true)
 
       note.isSticky shouldBe true
@@ -86,13 +86,85 @@ class NoteSpec extends WordSpec with Matchers {
       note.timestamp should not be 0
     }
 
-    "create Boolean notes with propagated" in {
+    "create Boolean notes with sticky" in {
       val note = Note.of("foo", true, true)
 
       note.isSticky shouldBe true
       note.name shouldBe "foo"
       note.value shouldBe true
       note.timestamp should not be 0
+    }
+
+    "create String notes with sticky including timestamp" in {
+      val note = Note.of("foo", "bar", true, 1L)
+
+      note.isSticky shouldBe true
+      note.name shouldBe "foo"
+      note.value shouldBe "bar"
+      note.timestamp shouldBe 1L
+    }
+
+    "create Long notes with sticky including timestamp" in {
+      val note = Note.of("foo", 1L, true, 1L)
+
+      note.isSticky shouldBe true
+      note.name shouldBe "foo"
+      note.value shouldBe 1L
+      note.timestamp shouldBe 1L
+    }
+
+    "create Double notes with sticky including timestamp" in {
+      val note = Note.of("foo", 2.2, true, 1L)
+
+      note.isSticky shouldBe true
+      note.name shouldBe "foo"
+      note.value shouldBe 2.2
+      note.timestamp shouldBe 1L
+    }
+
+    "create Boolean notes with sticky including timestamp" in {
+      val note = Note.of("foo", true, true, 1L)
+
+      note.isSticky shouldBe true
+      note.name shouldBe "foo"
+      note.value shouldBe true
+      note.timestamp shouldBe 1L
+    }
+
+    "create String notes including timestamp without sticky" in {
+      val note = Note.of("foo", "bar", 1L)
+
+      note.isSticky shouldBe false
+      note.name shouldBe "foo"
+      note.value shouldBe "bar"
+      note.timestamp shouldBe 1L
+    }
+
+    "create Long notes including timestamp without sticky" in {
+      val note = Note.of("foo", 1L, 1L)
+
+      note.isSticky shouldBe false
+      note.name shouldBe "foo"
+      note.value shouldBe 1L
+      note.timestamp shouldBe 1L
+    }
+
+    "create Double notes including timestamp without sticky" in {
+      val note = Note.of("foo", 2.2, 1L)
+
+      note.isSticky shouldBe false
+      note.name shouldBe "foo"
+      note.value shouldBe 2.2
+      note.timestamp shouldBe 1L
+    }
+
+    "create Boolean notes including timestamp without sticky" in {
+      val note = Note.of("foo", true, 1L)
+
+      note.isSticky shouldBe false
+      note.name shouldBe "foo"
+      note.value shouldBe true
+      note.timestamp shouldBe 1L
     }
   }
 }


### PR DESCRIPTION
This is another change in advance of refactoring to use the api Note
instead of the existing core note.

There are several factory methods expected in the existing core code
that assume default values.  This PR brings parity to the new api Note
with the existing core Note classes.  This will drastically reduce the
number of changes needed when we do finally update to use the api Note.