### PR TITLE
Removing Note Wrapper

### DIFF
--- a/money-core/src/main/java/com/comcast/money/japi/JMoney.java
+++ b/money-core/src/main/java/com/comcast/money/japi/JMoney.java
@@ -138,7 +138,7 @@ public class JMoney {
      */
     public static void record(String noteName, Object value, boolean propagate) {
 
-        tracer().record(toNote(noteName, value), propagate);
+        tracer().record(toNote(noteName, value, propagate));
     }
 
     /**
@@ -264,21 +264,21 @@ public class JMoney {
         }
     }
 
-    private static Note<?> toNote(String name, Object value) {
+    private static Note<?> toNote(String name, Object value, Boolean propagate) {
 
         if (value == null) {
-            return Note.of(name, null, DateTimeUtil.microTime());
+            return Note.of(name, null, propagate, DateTimeUtil.microTime());
         } else if (value instanceof Boolean) {
             Boolean bool = (Boolean)value;
-            return Note.of(name, bool, DateTimeUtil.microTime());
+            return Note.of(name, bool, propagate, DateTimeUtil.microTime());
         } else if (value instanceof Double) {
             Double dbl = (Double)value;
-            return Note.of(name, dbl, DateTimeUtil.microTime());
+            return Note.of(name, dbl, propagate, DateTimeUtil.microTime());
         } else if (value instanceof Long) {
             Long lng = (Long)value;
-            return Note.of(name, lng, DateTimeUtil.microTime());
+            return Note.of(name, lng, propagate, DateTimeUtil.microTime());
         } else {
-            return Note.of(name, value.toString(), DateTimeUtil.microTime());
+            return Note.of(name, value.toString(), propagate, DateTimeUtil.microTime());
         }
     }
 }

--- a/money-core/src/main/scala/com/comcast/money/core/Tracer.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Tracer.scala
@@ -140,7 +140,7 @@ trait Tracer extends Closeable {
    * @param propogate propogate to children
    */
   def record(key: String, measure: Double, propogate: Boolean): Unit = withSpanId { spanId =>
-    spanSupervisorRef ! SpanMessage(spanId, AddNote(Note.of(key, measure), propogate))
+    spanSupervisorRef ! SpanMessage(spanId, AddNote(Note.of(key, measure, propogate)))
   }
 
   /**
@@ -177,7 +177,7 @@ trait Tracer extends Closeable {
    * @param propogate propogate to children
    */
   def record(key: String, measure: String, propogate: Boolean): Unit = withSpanId { spanId =>
-    spanSupervisorRef ! SpanMessage(spanId, AddNote(Note.of(key, measure), propogate))
+    spanSupervisorRef ! SpanMessage(spanId, AddNote(Note.of(key, measure, propogate)))
   }
 
   /**
@@ -214,7 +214,7 @@ trait Tracer extends Closeable {
    * @param propogate propogate to children
    */
   def record(key: String, measure: Long, propogate: Boolean): Unit = withSpanId { spanId =>
-    spanSupervisorRef ! SpanMessage(spanId, AddNote(Note.of(key, measure), propogate))
+    spanSupervisorRef ! SpanMessage(spanId, AddNote(Note.of(key, measure, propogate)))
   }
 
   /**
@@ -251,7 +251,7 @@ trait Tracer extends Closeable {
    * @param propogate propogate to children
    */
   def record(key: String, measure: Boolean, propogate: Boolean): Unit = withSpanId { spanId =>
-    spanSupervisorRef ! SpanMessage(spanId, AddNote(Note.of(key, measure), propogate))
+    spanSupervisorRef ! SpanMessage(spanId, AddNote(Note.of(key, measure, propogate)))
   }
 
   /**
@@ -268,24 +268,7 @@ trait Tracer extends Closeable {
    * @param note the [[com.comcast.money.api.Note]] to be added
    */
   def record(note: Note[_]) = withSpanId { spanId =>
-    spanSupervisorRef ! SpanMessage(spanId, AddNote(note, note.isSticky))
-  }
-
-  /**
-   * Adds a new [[com.comcast.money.api.Note]] directly to the current Span if one is present in context.
-   * {{{
-   *   import com.comcast.money.core.Money._
-   *   def recordMe() {
-   *     ...
-   *     tracer.record(Result.success)
-   *     tracer.record(Note("that", "thang"))
-   *     ...
-   *  }
-   * }}}
-   * @param note the [[com.comcast.money.api.Note]] to be added
-   */
-  def record(note: Note[_], propogate: Boolean) = withSpanId { spanId =>
-    spanSupervisorRef ! SpanMessage(spanId, AddNote(note, propogate))
+    spanSupervisorRef ! SpanMessage(spanId, AddNote(note))
   }
 
   /**

--- a/money-core/src/test/scala/com/comcast/money/core/TracerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/TracerSpec.scala
@@ -70,7 +70,7 @@ class TracerSpec
           tm shouldBe a[StopTimer]
           val tmStop = tm.asInstanceOf[StopTimer]
           tmStop.name shouldEqual name
-        case SpanMessage(spanId, AddNote(note, _)) =>
+        case SpanMessage(spanId, AddNote(note)) =>
           tm shouldBe an[AddNote]
           val tmNote = tm.asInstanceOf[AddNote]
           tmNote.note.name shouldEqual note.name

--- a/money-spring3/src/main/scala/com/comcast/money/spring3/SpringTracer.scala
+++ b/money-spring3/src/main/scala/com/comcast/money/spring3/SpringTracer.scala
@@ -215,21 +215,6 @@ class SpringTracer extends Tracer {
   override def record(note: Note[_]): Unit = tracer.record(note)
 
   /**
-   * Adds a new [[com.comcast.money.api.Note]] directly to the current Span if one is present in context.
-   * {{{
-   *   import com.comcast.money.core.Money._
-   *   def recordMe() {
-   *     ...
-   *     tracer.record(Result.success)
-   *     tracer.record(Note.of("that", "thang"))
-   *     ...
-   *  }
-   * }}}
-   * @param note the [[com.comcast.money.api.Note]] to be added
-   */
-  override def record(note: Note[_], propogate: Boolean): Unit = tracer.record(note, propogate)
-
-  /**
    * Stops the current span, adding a note that indicates whether it succeeded or failed.
    * {{{
    *   import com.comcast.money.core.Money._


### PR DESCRIPTION
The new API joins the sticky / propgate value with the Note itself.
They are no longer separate things.

This commit removes the NoteWrapper from the SpanFSM, and removes the
propagate field from the AddNote message.