### PR TITLE
Money core scala

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ scala:
   - 2.11.7
 
 script:
-  -  sbt ++$TRAVIS_SCALA_VERSION clean coverage test it:test coverageAggregate
+  -  sbt ++$TRAVIS_SCALA_VERSION clean coverage test it:test coverageReport coverageAggregate
 
 after_success:
   - pip install --user codecov && codecov

--- a/money-api/src/main/java/com/comcast/money/api/Span.java
+++ b/money-api/src/main/java/com/comcast/money/api/Span.java
@@ -16,8 +16,6 @@
 
 package com.comcast.money.api;
 
-import java.util.Map;
-
 /**
  * A Span is a container that represents a unit of work.  It could be a long running operation or sequence of
  * statements in process, or a remote system call.
@@ -40,7 +38,7 @@ public interface Span {
      * Ends a span, moving it to a Stopped state
      * @param result The result of the span (success or failure)
      */
-    void stop(boolean result);
+    void stop(Boolean result);
 
     /**
      * Records a given note onto the span.  If the note was already present, it will be overwritten
@@ -63,67 +61,7 @@ public interface Span {
     void stopTimer(String timerKey);
 
     /**
-      * @return a map of all of the notes that were recorded on the span.  Implementers should enforce
-     * that the map returned is a copy of the notes
+     * @return The current state of the Span
      */
-    Map<String, Note<?>> notes();
-
-    /**
-     * @return the time in milliseconds when this span was started
-     */
-    Long startTime();
-
-    /**
-     * @return the time in microseconds when this span was started
-     */
-    Long startInstant();
-
-    /**
-     * @return the time in milliseconds when this span was ended.  Will return
-     * null if the span is still open
-     */
-    Long endTime();
-
-    /**
-     * @return the time in microseconds when this span was stopped.
-     */
-    Long endInstant();
-
-    /**
-     * @return the result of the span.  Will return null if the span was never stopped.
-     */
-    Boolean success();
-
-    /**
-     * @return the SpanId of the span.
-     */
-    SpanId id();
-
-    /**
-     * @return the name of the span
-     */
-    String name();
-
-    /**
-     * @return how long since the span was started.  Once it is stopped, the duration should reperesent
-     * how long the span was open for.
-     */
-    Long duration();
-
-    /**
-     * Creates a new child from this span
-     *
-     * @param childName The name of the child to create
-     * @param sticky True if the sticky notes from this span should be passed to the child
-     * @return A new Span that is a child of this span
-     */
-    Span childSpan(String childName, boolean sticky);
-
-    /**
-     * Creates a new child from this span
-     *
-     * @param childName The name of the child to create
-     * @return A new Span that is a child of this span
-     */
-    Span childSpan(String childName);
+    SpanInfo info();
 }

--- a/money-api/src/main/java/com/comcast/money/api/SpanHandler.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanHandler.java
@@ -28,7 +28,7 @@ public interface SpanHandler {
     /**
      * Handles a span that has been stopped.
      *
-     * @param span {@link Span} that has been stopped and is ready for processing
+     * @param {@link SpanInfo} that contains the information for the completed span
      */
-    void handle(Span span);
+    void handle(SpanInfo span);
 }

--- a/money-api/src/main/java/com/comcast/money/api/SpanId.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanId.java
@@ -73,7 +73,7 @@ public class SpanId {
         return selfId;
     }
 
-    public SpanId newChild() {
+    public SpanId newChildId() {
         return new SpanId(traceId, selfId);
     }
 

--- a/money-api/src/main/java/com/comcast/money/api/SpanInfo.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanInfo.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.api;
+
+import java.util.Map;
+
+public interface SpanInfo {
+
+    /**
+     * @return a map of all of the notes that were recorded on the span.  Implementers should enforce
+     * that the map returned is a copy of the notes
+     */
+    Map<String, Note<?>> notes();
+
+    /**
+     * @return the time in milliseconds when this span was started
+     */
+    Long startTimeMillis();
+
+    /**
+     * @return the time in microseconds when this span was started
+     */
+    Long startTimeMicros();
+
+    /**
+     * @return the time in milliseconds when this span was ended.  Will return
+     * null if the span is still open
+     */
+    Long endTimeMillis();
+
+    /**
+     * @return the time in microseconds when this span was stopped.
+     */
+    Long endTimeMicros();
+
+    /**
+     * @return the result of the span.  Will return null if the span was never stopped.
+     */
+    Boolean success();
+
+    /**
+     * @return the SpanId of the span.
+     */
+    SpanId id();
+
+    /**
+     * @return the name of the span
+     */
+    String name();
+
+    /**
+     * @return how long since the span was started.  Once it is stopped, the duration should reperesent
+     * how long the span was open for.
+     */
+    Long durationMicros();
+
+    /**
+     * @return the current application name
+     */
+    String appName();
+
+    /**
+     * @return the host name or ip
+     */
+    String host();
+}

--- a/money-core-scala/src/main/resources/reference.conf
+++ b/money-core-scala/src/main/resources/reference.conf
@@ -1,0 +1,29 @@
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+money {
+  enabled = true
+  mdc.enabled = true
+  application-name = "unknown"
+
+  handling = {
+    async = true
+    handlers = [
+      {
+        class = "com.comcast.money.core.handlers.LoggingSpanHandler"
+        log-level = "INFO"
+      }
+    ]
+  }
+}

--- a/money-core-scala/src/main/scala/com/comcast/money/core/CoreSpan.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/CoreSpan.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core
+
+import java.lang.Long
+
+import com.comcast.money.api._
+
+import scala.collection.JavaConversions._
+import scala.collection.concurrent.TrieMap
+
+/**
+ * A mutable implementation of the Span that also includes SpanInfo
+ *
+ * @param id The [[SpanId]]
+ * @param name The name of the span
+ * @param handler The [[SpanHandler]] responsible for processing the span once it is stopped
+ */
+case class CoreSpan(
+    id: SpanId,
+    name: String,
+    handler: SpanHandler
+) extends Span {
+
+  private var startTimeMillis: Long = 0L
+  private var startTimeMicros: Long = 0L
+  private var endTimeMillis: Long = 0L
+  private var endTimeMicros: Long = 0L
+  private var success: java.lang.Boolean = true
+
+  // use concurrent maps
+  private val timers = new TrieMap[String, Long]()
+  private val noted = new TrieMap[String, Note[_]]()
+
+  def start(): Unit = {
+    startTimeMillis = System.currentTimeMillis
+    startTimeMicros = System.nanoTime / 1000
+  }
+
+  def stop(): Unit = stop(true)
+
+  def stop(result: java.lang.Boolean): Unit = {
+    endTimeMillis = System.currentTimeMillis
+    endTimeMicros = System.nanoTime / 1000
+    this.success = result
+
+    handler.handle(info)
+  }
+
+  def stopTimer(timerKey: String): Unit =
+    timers.remove(timerKey) foreach {
+      timerStartInstant =>
+        record(Note.of(timerKey, System.nanoTime - timerStartInstant))
+    }
+
+  def record(note: Note[_]): Unit = noted += note.name -> note
+
+  def startTimer(timerKey: String): Unit = timers += timerKey -> System.nanoTime
+
+  def info(): SpanInfo =
+    CoreSpanInfo(
+      id,
+      name,
+      startTimeMillis,
+      startTimeMicros,
+      endTimeMillis,
+      endTimeMicros,
+      calculateDuration,
+      success,
+      noted.toMap[String, Note[_]]
+    )
+
+  private def calculateDuration: Long =
+    if (endTimeMicros <= 0L && startTimeMicros <= 0L)
+      0L
+    else if (endTimeMicros <= 0L)
+      (System.nanoTime() / 1000) - startTimeMicros
+    else
+      endTimeMicros - startTimeMicros
+}

--- a/money-core-scala/src/main/scala/com/comcast/money/core/CoreSpanFactory.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/CoreSpanFactory.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core
+
+import com.comcast.money.api.{ Span, SpanFactory, SpanHandler, SpanId }
+
+import scala.collection.JavaConversions._
+
+class CoreSpanFactory(handler: SpanHandler) extends SpanFactory {
+
+  def newSpan(spanName: String): Span = newSpan(new SpanId(), spanName)
+
+  def childSpan(childName: String, span: Span): Span = childSpan(childName, span, false)
+
+  def childSpan(childName: String, span: Span, sticky: Boolean): Span = {
+    val info = span.info
+    val child = newSpan(info.id.newChildId, childName)
+
+    if (sticky) {
+      info.notes.values
+        .filter(_.isSticky)
+        .foreach(child.record)
+    }
+
+    child
+  }
+
+  def newSpan(spanId: SpanId, spanName: String): Span =
+    new CoreSpan(
+      id = spanId,
+      name = spanName,
+      handler = handler
+    )
+}

--- a/money-core-scala/src/main/scala/com/comcast/money/core/CoreSpanInfo.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/CoreSpanInfo.scala
@@ -14,15 +14,20 @@
  * limitations under the License.
  */
 
-package com.comcast.money.api;
+package com.comcast.money.core
 
-public interface SpanFactory {
+import com.comcast.money.api.{ Note, SpanId, SpanInfo }
 
-    Span newSpan(String spanName);
-
-    Span newSpan(SpanId spanId, String spanName);
-
-    Span childSpan(String childName, Span span);
-
-    Span childSpan(String childName, Span span, boolean sticky);
-}
+case class CoreSpanInfo(
+  id: SpanId,
+  name: String,
+  startTimeMillis: java.lang.Long = 0L,
+  startTimeMicros: java.lang.Long = 0L,
+  endTimeMillis: java.lang.Long = 0L,
+  endTimeMicros: java.lang.Long = 0L,
+  durationMicros: java.lang.Long = 0L,
+  success: java.lang.Boolean = true,
+  notes: java.util.Map[String, Note[_]] = new java.util.HashMap[String, Note[_]](),
+  appName: String = Money.Environment.applicationName,
+  host: String = Money.Environment.hostName
+) extends SpanInfo

--- a/money-core-scala/src/main/scala/com/comcast/money/core/Disabled.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/Disabled.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core
+
+import com.comcast.money.api._
+
+// $COVERAGE-OFF
+object DisabledSpanHandler extends SpanHandler {
+
+  def handle(spanInfo: SpanInfo): Unit = ()
+}
+
+object DisabledTracer extends Tracer {
+
+  val spanFactory: SpanFactory = DisabledSpanFactory
+
+  override def startSpan(key: String): Unit = ()
+
+  override def time(key: String): Unit = ()
+
+  override def record(key: String, measure: Double): Unit = ()
+
+  override def record(key: String, measure: Double, propogate: Boolean): Unit = ()
+
+  override def record(key: String, measure: String): Unit = ()
+
+  override def record(key: String, measure: String, propogate: Boolean): Unit = ()
+
+  override def record(key: String, measure: Long): Unit = ()
+
+  override def record(key: String, measure: Long, propogate: Boolean): Unit = ()
+
+  override def record(key: String, measure: Boolean): Unit = ()
+
+  override def record(key: String, measure: Boolean, propogate: Boolean): Unit = ()
+
+  override def record(note: Note[_]): Unit = ()
+
+  override def stopSpan(result: Boolean): Unit = ()
+
+  override def startTimer(key: String): Unit = ()
+
+  override def stopTimer(key: String): Unit = ()
+
+  override def close(): Unit = ()
+}
+
+object DisabledSpanFactory extends SpanFactory {
+
+  def newSpan(spanName: String): Span = DisabledSpan
+
+  def childSpan(childName: String, span: Span): Span = DisabledSpan
+
+  def childSpan(childName: String, span: Span, sticky: Boolean): Span = DisabledSpan
+
+  def newSpan(spanId: SpanId, spanName: String): Span = DisabledSpan
+}
+
+object DisabledSpan extends Span {
+
+  def start(): Unit = ()
+
+  def stop(): Unit = ()
+
+  def stop(result: java.lang.Boolean): Unit = ()
+
+  def stopTimer(timerKey: String): Unit = ()
+
+  def record(note: Note[_]): Unit = ()
+
+  def startTimer(timerKey: String): Unit = ()
+
+  def info(): SpanInfo = null
+}
+// $COVERAGE-ON$

--- a/money-core-scala/src/main/scala/com/comcast/money/core/Money.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/Money.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core
+
+import java.net.InetAddress
+
+import com.comcast.money.api.{ SpanFactory, SpanHandler }
+import com.comcast.money.core.handlers.HandlerChain
+import com.typesafe.config.{ Config, ConfigFactory }
+
+case class Money(
+  enabled: Boolean,
+  handler: SpanHandler,
+  applicationName: String,
+  hostName: String,
+  factory: SpanFactory,
+  tracer: Tracer
+)
+
+object Money {
+
+  lazy val Environment = apply(ConfigFactory.load().getConfig("money"))
+
+  def apply(conf: Config): Money = {
+    val applicationName = conf.getString("application-name")
+    val enabled = conf.getBoolean("enabled")
+    val hostName = InetAddress.getLocalHost.getCanonicalHostName
+
+    if (enabled) {
+      val handler = HandlerChain(conf.getConfig("handling"))
+      val spanFactory: SpanFactory = new CoreSpanFactory(handler)
+      val tracer = new Tracer {
+        val spanFactory: SpanFactory = spanFactory
+      }
+      Money(enabled, handler, applicationName, hostName, spanFactory, tracer)
+    } else {
+      disabled(applicationName, hostName)
+    }
+
+  }
+
+  private def disabled(applicationName: String, hostName: String): Money =
+    Money(false, DisabledSpanHandler, applicationName, hostName, DisabledSpanFactory, DisabledTracer)
+}

--- a/money-core-scala/src/main/scala/com/comcast/money/core/handlers/AsyncSpanHandler.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/handlers/AsyncSpanHandler.scala
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
-package com.comcast.money.api;
+package com.comcast.money.core.handlers
 
-public interface SpanFactory {
+import com.comcast.money.api.{ SpanHandler, SpanInfo }
 
-    Span newSpan(String spanName);
+import scala.concurrent.{ ExecutionContext, Future }
 
-    Span newSpan(SpanId spanId, String spanName);
+/**
+ * Makes sure that a child process is handled asynchronously
+ *
+ * @param ec The execution context used to handle the span asynchronously
+ * @param wrapped The [[SpanHandler]] which will be invoked asynchronously
+ */
+class AsyncSpanHandler(val ec: ExecutionContext, val wrapped: SpanHandler) extends SpanHandler {
 
-    Span childSpan(String childName, Span span);
+  implicit val executor: ExecutionContext = ec
 
-    Span childSpan(String childName, Span span, boolean sticky);
+  def handle(spanInfo: SpanInfo): Unit = Future(wrapped.handle(spanInfo))
 }

--- a/money-core-scala/src/main/scala/com/comcast/money/core/handlers/ConfigurableHandler.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/handlers/ConfigurableHandler.scala
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-package com.comcast.money.api;
+package com.comcast.money.core.handlers
 
-public interface SpanFactory {
+import com.comcast.money.api.SpanHandler
+import com.typesafe.config.Config
 
-    Span newSpan(String spanName);
+trait ConfigurableHandler extends SpanHandler {
 
-    Span newSpan(SpanId spanId, String spanName);
-
-    Span childSpan(String childName, Span span);
-
-    Span childSpan(String childName, Span span, boolean sticky);
+  def configure(config: Config): Unit
 }

--- a/money-core-scala/src/main/scala/com/comcast/money/core/handlers/HandlerChain.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/handlers/HandlerChain.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.handlers
+
+import com.comcast.money.api.{ SpanHandler, SpanInfo }
+import com.typesafe.config.Config
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConversions._
+
+case class HandlerChain(handlers: Seq[SpanHandler]) extends SpanHandler {
+
+  private val logger = LoggerFactory.getLogger(classOf[HandlerChain])
+
+  def handle(spanInfo: SpanInfo): Unit =
+    handlers.foreach { handler =>
+      try {
+        handler.handle(spanInfo)
+      } catch {
+        case e: Throwable =>
+          logger.error("Error handling span", e)
+      }
+    }
+}
+
+object HandlerChain {
+
+  import HandlerFactory.create
+
+  def apply(config: Config): SpanHandler = {
+    val handlers = config.getConfigList("handlers").map(create)
+
+    if (config.getBoolean("async")) {
+      new AsyncSpanHandler(scala.concurrent.ExecutionContext.global, HandlerChain(handlers))
+    } else {
+      HandlerChain(handlers)
+    }
+  }
+}

--- a/money-core-scala/src/main/scala/com/comcast/money/core/handlers/HandlerFactory.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/handlers/HandlerFactory.scala
@@ -14,15 +14,24 @@
  * limitations under the License.
  */
 
-package com.comcast.money.api;
+package com.comcast.money.core.handlers
 
-public interface SpanFactory {
+import com.comcast.money.api.SpanHandler
+import com.typesafe.config.Config
 
-    Span newSpan(String spanName);
+object HandlerFactory {
 
-    Span newSpan(SpanId spanId, String spanName);
+  def create(config: Config): SpanHandler = {
+    val className = config.getString("class")
 
-    Span childSpan(String childName, Span span);
+    val handlerInstance = Class.forName(className).newInstance().asInstanceOf[SpanHandler]
 
-    Span childSpan(String childName, Span span, boolean sticky);
+    handlerInstance match {
+      case configurable: ConfigurableHandler =>
+        configurable.configure(config)
+        configurable
+
+      case _ => handlerInstance
+    }
+  }
 }

--- a/money-core-scala/src/main/scala/com/comcast/money/core/handlers/LoggingSpanHandler.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/handlers/LoggingSpanHandler.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.handlers
+
+import com.comcast.money.api.{ SpanHandler, SpanInfo }
+import com.typesafe.config.Config
+import org.slf4j.{ Logger, LoggerFactory }
+
+import scala.collection.JavaConversions._
+
+object LoggingSpanHandler {
+
+  type LogFunction = String => Unit
+
+  val HEADER_FORMAT: String = "Span: [ span-id=%s ][ trace-id=%s ][ parent-id=%s ][ span-name=%s ][ " +
+    "app-name=%s ][ start-time=%s ][ span-duration=%s ][ span-success=%s ] [ host=%s ]"
+  val NOTE_BEGIN = "[ "
+  val NOTE_END = " ]"
+  val EQ = "="
+  val NULL: String = "NULL"
+}
+
+class LoggingSpanHandler(val logger: Logger) extends ConfigurableHandler {
+
+  def this() = this(LoggerFactory.getLogger(classOf[LoggingSpanHandler]))
+
+  import LoggingSpanHandler._
+
+  private var logFunction: LogFunction = logger.info
+
+  def configure(config: Config): Unit = {
+
+    if (config.hasPath("log-level")) {
+      val level = config.getString("log-level").toUpperCase
+
+      // set the log level based on the configured value
+      level match {
+        case "ERROR" => logFunction = logger.error
+        case "WARN" => logFunction = logger.warn
+        case "INFO" => logFunction = logger.info
+        case "DEBUG" => logFunction = logger.debug
+        case "TRACE" => logFunction = logger.trace
+      }
+    }
+  }
+
+  def handle(spanInfo: SpanInfo): Unit = {
+
+    val sb: StringBuilder = new StringBuilder
+    sb.append(
+      HEADER_FORMAT.format(
+        spanInfo.id.selfId, spanInfo.id.traceId, spanInfo.id.parentId, spanInfo.name, spanInfo.appName,
+        spanInfo.startTimeMillis, spanInfo.durationMicros, spanInfo.success, spanInfo.host
+      )
+    )
+
+    for (note <- spanInfo.notes.values) {
+      sb.append(NOTE_BEGIN)
+        .append(note.name)
+        .append(EQ)
+        .append(valueOrNull(note.value))
+        .append(NOTE_END)
+    }
+
+    logFunction(sb.toString)
+  }
+
+  private def valueOrNull[T](value: T) =
+    if (value == null)
+      NULL
+    else
+      value
+}
+

--- a/money-core-scala/src/main/scala/com/comcast/money/core/internal/MDCSupport.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/internal/MDCSupport.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.internal
+
+import java.util.Map
+
+import com.comcast.money.api.SpanId
+import com.comcast.money.core.Money
+import org.slf4j.MDC
+
+object MDCSupport {
+
+  val LogFormat = "[ span-id=%s ][ trace-id=%s ][ parent-id=%s ]"
+
+  def format(spanId: SpanId) = LogFormat.format(spanId.selfId, spanId.traceId, spanId.parentId)
+}
+
+/**
+ * Adds the ability to store a span in MDC for a magical logging experience
+ * @param enabled True if mdc is enabled, false if it is disabled
+ */
+class MDCSupport(enabled: Boolean = Money.Environment.enabled) {
+
+  private val MoneyTraceKey = "moneyTrace"
+  private val SpanNameKey = "spanName"
+
+  def setSpanMDC(spanId: Option[SpanId]): Unit = if (enabled) {
+    spanId match {
+      case Some(id) => MDC.put(MoneyTraceKey, MDCSupport.format(id))
+      case None => MDC.remove(MoneyTraceKey)
+    }
+  }
+
+  def propogateMDC(submittingThreadsContext: Option[Map[_, _]]): Unit = if (enabled) {
+    submittingThreadsContext match {
+      case Some(context: Map[_, _]) => MDC.setContextMap(context)
+      case None => MDC.clear()
+    }
+  }
+
+  def setSpanNameMDC(spanName: Option[String]) =
+    if (enabled) {
+      spanName match {
+        case Some(name) => MDC.put(SpanNameKey, name)
+        case None => MDC.remove(SpanNameKey)
+      }
+    }
+
+  def getSpanNameMDC: Option[String] = Option(MDC.get(SpanNameKey))
+}

--- a/money-core-scala/src/main/scala/com/comcast/money/core/internal/SpanLocal.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/internal/SpanLocal.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.internal
+
+import com.comcast.money.api.Span
+
+import scala.collection.mutable.Stack
+
+/**
+ * Provides a thread local context for storing SpanIds.  Keeps a stack of trace ids so that we
+ * an roll back to the parent once a span completes
+ */
+object SpanLocal {
+
+  // A stack of span ids for the current thread
+  private[this] val threadLocalCtx = new ThreadLocal[Stack[Span]]
+
+  private lazy val mdcSupport = new MDCSupport()
+
+  import mdcSupport._
+
+  def current: Option[Span] = {
+    Option(threadLocalCtx.get).flatMap(_.headOption)
+  }
+
+  def push(span: Span): Unit = {
+    if (span != null) {
+      Option(threadLocalCtx.get) match {
+        case Some(stack) =>
+          stack.push(span)
+          setSpanMDC(Some(span.info.id))
+        case None =>
+          threadLocalCtx.set(new Stack[Span]())
+          push(span)
+      }
+    }
+  }
+
+  def pop(): Option[Span] = {
+    Option(threadLocalCtx.get).map {
+      stack =>
+        // remove the current span in scope for this thread
+        val spanId = stack.pop()
+
+        // rolls back the mdc span to the parent if present, if none then it will be cleared
+        setSpanMDC(stack.headOption.map(_.info.id))
+
+        spanId
+    }
+  }
+
+  /**
+   * Clears the entire call stack for the thread
+   */
+  def clear() = {
+    if (threadLocalCtx != null) {
+      threadLocalCtx.remove()
+    }
+    setSpanMDC(None)
+  }
+}

--- a/money-core-scala/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core
+
+import com.comcast.money.api.{ Note, SpanHandler, SpanId }
+import com.comcast.money.core.handlers.TestData
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{ Matchers, WordSpec }
+
+class CoreSpanFactorySpec extends WordSpec with Matchers with MockitoSugar with TestData {
+
+  val handler = mock[SpanHandler]
+  val underTest = new CoreSpanFactory(handler)
+
+  "CoreSpanFactory" should {
+    "create a new span" in {
+      val result = underTest.newSpan("foo").asInstanceOf[CoreSpan]
+
+      result.info.name shouldBe "foo"
+      result.handler shouldBe handler
+    }
+
+    "create a new span given an existing span id" in {
+      val existingId = new SpanId()
+      val result = underTest.newSpan(existingId, "foo").asInstanceOf[CoreSpan]
+
+      result.id shouldBe existingId
+    }
+
+    "create a child span whos id descends from an existing span" in {
+      val result = underTest.childSpan("child", testSpan)
+
+      val parent = testSpan.info
+      val child = result.info
+
+      child.id.traceId shouldBe parent.id.traceId
+      child.id.parentId shouldBe parent.id.selfId
+    }
+
+    "propagate sticky notes to a child span" in {
+
+      val parentSpan = underTest.newSpan("parent")
+      val stickyNote = Note.of("foo", "bar", true)
+      val nonStickyNote = Note.of("other", "one", false)
+      parentSpan.record(stickyNote)
+      parentSpan.record(nonStickyNote)
+
+      val childSpan = underTest.childSpan("child", parentSpan, true)
+      val childInfo = childSpan.info
+
+      childInfo.notes should contain value stickyNote
+      childInfo.notes shouldNot contain value nonStickyNote
+    }
+  }
+}

--- a/money-core-scala/src/test/scala/com/comcast/money/core/CoreSpanInfoSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/CoreSpanInfoSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core
+
+import com.comcast.money.api.SpanId
+import org.scalatest.{ Matchers, WordSpec }
+
+class CoreSpanInfoSpec extends WordSpec with Matchers {
+
+  "CoreSpanInfo" should {
+    "have acceptable default values" in {
+      val spanId = new SpanId()
+      val underTest = CoreSpanInfo(spanId, "test")
+
+      underTest.id shouldBe spanId
+      underTest.name shouldBe "test"
+      underTest.appName shouldBe Money.Environment.applicationName
+      underTest.host shouldBe Money.Environment.hostName
+      underTest.notes shouldBe empty
+      underTest.success shouldBe true
+      underTest.durationMicros shouldBe 0L
+      underTest.startTimeMicros shouldBe 0L
+      underTest.startTimeMillis shouldBe 0L
+      underTest.endTimeMicros shouldBe 0L
+      underTest.endTimeMillis shouldBe 0L
+    }
+  }
+}

--- a/money-core-scala/src/test/scala/com/comcast/money/core/CoreSpanSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/CoreSpanSpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core
+
+import com.comcast.money.api.{ SpanInfo, SpanHandler, Note, SpanId }
+import com.comcast.money.core.handlers.TestData
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{ Matchers, WordSpec }
+
+class CoreSpanSpec extends WordSpec with Matchers with TestData with MockitoSugar {
+
+  "CoreSpan" should {
+    "set the startTimeMillis and startTimeMicros when started" in {
+      val underTest = CoreSpan(new SpanId(), "test", null)
+      underTest.start()
+
+      val state = underTest.info
+
+      state.startTimeMicros.toInt should not be 0
+      state.startTimeMillis.toInt should not be 0
+    }
+
+    "record a timer" in {
+      val underTest = CoreSpan(new SpanId(), "test", null)
+
+      underTest.startTimer("foo")
+      underTest.stopTimer("foo")
+
+      underTest.info.notes should contain key "foo"
+    }
+
+    "record a note" in {
+      val underTest = CoreSpan(new SpanId(), "test", null)
+
+      underTest.record(testLongNote)
+
+      underTest.info.notes should contain value testLongNote
+    }
+
+    "set the endTimeMillis and endTimeMicros when stopped" in {
+      val handler = mock[SpanHandler]
+      val underTest = CoreSpan(new SpanId(), "test", handler)
+
+      underTest.stop(true)
+
+      val state = underTest.info
+
+      state.endTimeMicros.toInt should not be 0
+      state.endTimeMillis.toInt should not be 0
+    }
+
+    "invoke the span handler when stopped" in {
+      val handler = mock[SpanHandler]
+      val handleCaptor = ArgumentCaptor.forClass(classOf[SpanInfo])
+      val underTest = CoreSpan(new SpanId(), "test", handler)
+
+      underTest.start()
+      underTest.record(testLongNote)
+      underTest.stop(true)
+
+      verify(handler).handle(handleCaptor.capture())
+
+      val handledInfo = handleCaptor.getValue
+
+      handledInfo.id shouldBe underTest.id
+      handledInfo.startTimeMicros.toInt should not be 0
+      handledInfo.startTimeMillis.toInt should not be 0
+      handledInfo.endTimeMicros.toInt should not be 0
+      handledInfo.endTimeMillis.toInt should not be 0
+      handledInfo.notes should contain value testLongNote
+    }
+  }
+}

--- a/money-core-scala/src/test/scala/com/comcast/money/core/MoneySpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/MoneySpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core
+
+import java.net.InetAddress
+
+import com.comcast.money.core.handlers.AsyncSpanHandler
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{ Matchers, WordSpec }
+
+class MoneySpec extends WordSpec with Matchers {
+
+  val defaultConfig = ConfigFactory.load().getConfig("money")
+  "Money" should {
+    "load the reference config by default" in {
+      val result = Money.Environment
+
+      result.applicationName shouldBe "unknown"
+      result.enabled shouldBe true
+      result.factory shouldBe a[CoreSpanFactory]
+      result.handler shouldBe an[AsyncSpanHandler]
+      result.hostName shouldBe InetAddress.getLocalHost.getCanonicalHostName
+      result.tracer should not be DisabledTracer
+    }
+
+    "load a Disabled Environment if money is disabled" in {
+      val config = ConfigFactory.parseString(
+        """
+          |money {
+          | enabled = false
+          | application-name = "unknown"
+          |}
+        """.stripMargin
+      )
+
+      val result = Money(config.getConfig("money"))
+      result.tracer shouldBe DisabledTracer
+      result.factory shouldBe DisabledSpanFactory
+      result.handler shouldBe DisabledSpanHandler
+      result.enabled shouldBe false
+    }
+  }
+}

--- a/money-core-scala/src/test/scala/com/comcast/money/core/TracerSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/TracerSpec.scala
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core
+
+import com.comcast.money.api.{ Note, SpanId, Span, SpanFactory }
+import com.comcast.money.core.handlers.TestData
+import com.comcast.money.core.internal.SpanLocal
+import org.mockito.ArgumentCaptor
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{ OneInstancePerTest, BeforeAndAfterEach, Matchers, WordSpec }
+
+class TracerSpec extends WordSpec
+    with Matchers with MockitoSugar with TestData with BeforeAndAfterEach with OneInstancePerTest {
+
+  val mockSpanFactory = mock[SpanFactory]
+  val mockSpan = mock[Span]
+  val noteCaptor = ArgumentCaptor.forClass(classOf[Note[_]])
+  val underTest = new Tracer {
+    val spanFactory = mockSpanFactory
+  }
+
+  override def beforeEach() = {
+    SpanLocal.clear()
+
+    doReturn(mockSpan).when(mockSpanFactory).newSpan(any[SpanId], anyString())
+    doReturn(mockSpan).when(mockSpanFactory).newSpan(anyString())
+    doReturn(mockSpan).when(mockSpanFactory).childSpan(anyString(), any[Span])
+    doReturn(testSpanInfo).when(mockSpan).info()
+  }
+
+  "Tracer" should {
+    "start a new span when no span exists" in {
+      underTest.startSpan("foo")
+
+      verify(mockSpan).start()
+
+      SpanLocal.current shouldBe Some(mockSpan)
+    }
+
+    "start a child span if a span already exsits" in {
+      SpanLocal.push(testSpan)
+
+      underTest.startSpan("bar")
+
+      verify(mockSpanFactory).childSpan("bar", testSpan)
+      verify(mockSpan).start()
+
+      SpanLocal.current shouldBe Some(mockSpan)
+    }
+
+    "record a time" in {
+      SpanLocal.push(mockSpan)
+
+      underTest.time("foo")
+
+      verify(mockSpan).record(any[Note[_]])
+    }
+
+    "record a double" in {
+      SpanLocal.push(mockSpan)
+
+      underTest.record("dbl", 1.2)
+
+      verify(mockSpan).record(noteCaptor.capture())
+
+      val note = noteCaptor.getValue
+
+      note.name shouldBe "dbl"
+      note.value shouldBe 1.2
+    }
+
+    "record a sticky double" in {
+      SpanLocal.push(mockSpan)
+
+      underTest.record("dbl", 1.2, true)
+
+      verify(mockSpan).record(noteCaptor.capture())
+
+      val note = noteCaptor.getValue
+
+      note.name shouldBe "dbl"
+      note.value shouldBe 1.2
+      note.isSticky shouldBe true
+    }
+
+    "record a string" in {
+      SpanLocal.push(mockSpan)
+
+      underTest.record("str", "bar")
+
+      verify(mockSpan).record(noteCaptor.capture())
+
+      val note = noteCaptor.getValue
+
+      note.name shouldBe "str"
+      note.value shouldBe "bar"
+    }
+
+    "record a sticky string" in {
+      SpanLocal.push(mockSpan)
+
+      underTest.record("str", "bar", true)
+
+      verify(mockSpan).record(noteCaptor.capture())
+
+      val note = noteCaptor.getValue
+
+      note.name shouldBe "str"
+      note.value shouldBe "bar"
+      note.isSticky shouldBe true
+    }
+
+    "record a long" in {
+      SpanLocal.push(mockSpan)
+
+      underTest.record("lng", 100L)
+
+      verify(mockSpan).record(noteCaptor.capture())
+
+      val note = noteCaptor.getValue
+
+      note.name shouldBe "lng"
+      note.value shouldBe 100L
+    }
+
+    "record a sticky long" in {
+      SpanLocal.push(mockSpan)
+
+      underTest.record("lng", 100L, true)
+
+      verify(mockSpan).record(noteCaptor.capture())
+
+      val note = noteCaptor.getValue
+
+      note.name shouldBe "lng"
+      note.value shouldBe 100L
+      note.isSticky shouldBe true
+    }
+
+    "record a boolean" in {
+      SpanLocal.push(mockSpan)
+
+      underTest.record("bool", true)
+
+      verify(mockSpan).record(noteCaptor.capture())
+
+      val note = noteCaptor.getValue
+
+      note.name shouldBe "bool"
+      note.value shouldBe true
+    }
+
+    "record a sticky boolean" in {
+      SpanLocal.push(mockSpan)
+
+      underTest.record("bool", true, true)
+
+      verify(mockSpan).record(noteCaptor.capture())
+
+      val note = noteCaptor.getValue
+
+      note.name shouldBe "bool"
+      note.value shouldBe true
+      note.isSticky shouldBe true
+    }
+
+    "record a note" in {
+      SpanLocal.push(mockSpan)
+
+      underTest.record(testLongNote)
+
+      verify(mockSpan).record(noteCaptor.capture())
+
+      val note = noteCaptor.getValue
+
+      note.name shouldBe testLongNote.name
+      note.value shouldBe testLongNote.value
+    }
+
+    "stop the current span" in {
+      SpanLocal.push(mockSpan)
+
+      underTest.stopSpan(true)
+
+      verify(mockSpan).stop(true)
+    }
+
+    "start a timer" in {
+      SpanLocal.push(mockSpan)
+
+      underTest.startTimer("timer")
+
+      verify(mockSpan).startTimer("timer")
+    }
+
+    "stop a timer" in {
+      SpanLocal.push(mockSpan)
+
+      underTest.stopTimer("t")
+
+      verify(mockSpan).stopTimer("t")
+    }
+
+    "stop the span on close" in {
+      SpanLocal.push(mockSpan)
+
+      underTest.close()
+
+      verify(mockSpan).stop(true)
+    }
+  }
+}

--- a/money-core-scala/src/test/scala/com/comcast/money/core/handlers/AsyncSpanHandlerSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/handlers/AsyncSpanHandlerSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.handlers
+
+import com.comcast.money.api.{ SpanInfo, SpanHandler }
+import org.scalatest.concurrent.Eventually._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{ Matchers, WordSpec }
+
+class AsyncSpanHandlerSpec extends WordSpec with Matchers with MockitoSugar with TestData {
+
+  class Wrapped extends SpanHandler {
+    var called = false
+    override def handle(span: SpanInfo): Unit = called = true
+  }
+
+  "AsyncSpanHandler" should {
+    "asynchronously invoke the span handler" in {
+      val spanHandler = new Wrapped()
+      val underTest = new AsyncSpanHandler(scala.concurrent.ExecutionContext.global, spanHandler)
+
+      underTest.handle(testSpanInfo)
+
+      eventually {
+        spanHandler.called shouldBe true
+      }
+    }
+  }
+}

--- a/money-core-scala/src/test/scala/com/comcast/money/core/handlers/HandlerChainSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/handlers/HandlerChainSpec.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.handlers
+
+import com.comcast.money.api.SpanHandler
+import com.typesafe.config.ConfigFactory
+import org.mockito.Mockito
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{ Matchers, WordSpec }
+
+class HandlerChainSpec extends WordSpec with Matchers with MockitoSugar with TestData {
+
+  "HandlerChain" should {
+
+    "invoke all handlers in the chain in order" in {
+      val handler1 = mock[SpanHandler]
+      val handler2 = mock[SpanHandler]
+      val handler3 = mock[SpanHandler]
+
+      val ordered = Mockito.inOrder(handler1, handler2, handler3)
+
+      val underTest = HandlerChain(Seq(handler1, handler2, handler3))
+
+      underTest.handle(testSpanInfo)
+
+      ordered.verify(handler1).handle(testSpanInfo)
+      ordered.verify(handler2).handle(testSpanInfo)
+      ordered.verify(handler3).handle(testSpanInfo)
+    }
+
+    "continues invocation of chain if one of the handlers throws an exception" in {
+
+      val handler1 = mock[SpanHandler]
+      val handler2 = mock[SpanHandler]
+      val handler3 = mock[SpanHandler]
+
+      doThrow(classOf[RuntimeException]).when(handler1).handle(testSpanInfo)
+      val ordered = Mockito.inOrder(handler1, handler2, handler3)
+
+      val underTest = HandlerChain(Seq(handler1, handler2, handler3))
+
+      underTest.handle(testSpanInfo)
+
+      ordered.verify(handler1).handle(testSpanInfo)
+      ordered.verify(handler2).handle(testSpanInfo)
+      ordered.verify(handler3).handle(testSpanInfo)
+    }
+
+    "create a sequence of handlers" in {
+      val config = ConfigFactory.parseString(
+        """
+          |{
+          | async = false
+          | handlers = [
+          |   {
+          |     class = "com.comcast.money.core.handlers.ConfiguredHandler"
+          |   },
+          |   {
+          |     class = "com.comcast.money.core.handlers.ConfiguredHandler"
+          |   },
+          |   {
+          |     class = "com.comcast.money.core.handlers.NonConfiguredHandler"
+          |   }
+          | ]
+          |}
+        """.stripMargin
+      )
+
+      val result = HandlerChain(config)
+
+      result shouldBe a[HandlerChain]
+      result.asInstanceOf[HandlerChain].handlers should have size 3
+    }
+
+    "wrap the handler chain in an async handler if async is set to true" in {
+      val config = ConfigFactory.parseString(
+        """
+          |{
+          | async = true
+          | handlers = [
+          |   {
+          |     class = "com.comcast.money.core.handlers.ConfiguredHandler"
+          |   },
+          |   {
+          |     class = "com.comcast.money.core.handlers.ConfiguredHandler"
+          |   },
+          |   {
+          |     class = "com.comcast.money.core.handlers.NonConfiguredHandler"
+          |   }
+          | ]
+          |}
+        """.stripMargin
+      )
+
+      val result = HandlerChain(config)
+
+      result shouldBe an[AsyncSpanHandler]
+      result.asInstanceOf[AsyncSpanHandler]
+        .wrapped.asInstanceOf[HandlerChain]
+        .handlers should have size 3
+    }
+  }
+}

--- a/money-core-scala/src/test/scala/com/comcast/money/core/handlers/HandlerFactorySpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/handlers/HandlerFactorySpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.handlers
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{ Matchers, WordSpec }
+
+class HandlerFactorySpec extends WordSpec with Matchers {
+
+  "HandlerFactory" should {
+    "create a span handler based on class" in {
+      val config = ConfigFactory.parseString(s"class=${classOf[NonConfiguredHandler].getCanonicalName}")
+
+      val createdHandler = HandlerFactory.create(config)
+      createdHandler shouldBe a[NonConfiguredHandler]
+    }
+
+    "create a configurable span handle and call configure on it" in {
+      val config = ConfigFactory.parseString(s"class=${classOf[ConfiguredHandler].getCanonicalName}")
+
+      val createdHandler = HandlerFactory.create(config)
+      createdHandler shouldBe a[ConfiguredHandler]
+
+      createdHandler.asInstanceOf[ConfiguredHandler].calledConfigure shouldBe true
+    }
+  }
+}

--- a/money-core-scala/src/test/scala/com/comcast/money/core/handlers/LoggingSpanHandlerSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/handlers/LoggingSpanHandlerSpec.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.handlers
+
+import com.comcast.money.api.Note
+import com.typesafe.config.ConfigFactory
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{ Matchers, OneInstancePerTest, WordSpec }
+import org.slf4j.Logger
+
+import scala.collection.JavaConversions._
+
+class LoggingSpanHandlerSpec extends WordSpec
+    with Matchers with MockitoSugar with OneInstancePerTest with TestData {
+
+  val mockLogger = mock[Logger]
+  val logEntryCaptor = ArgumentCaptor.forClass(classOf[String])
+  val underTest = new LoggingSpanHandler(mockLogger)
+
+  "LoggingSpanHandler" should {
+    "log span info" in {
+      underTest.handle(testSpanInfo)
+
+      verify(mockLogger).info(logEntryCaptor.capture())
+
+      val logEntry = logEntryCaptor.getValue
+
+      logEntry should include(s"span-id=${testSpanInfo.id.selfId}")
+      logEntry should include(s"parent-id=${testSpanInfo.id.parentId}")
+      logEntry should include(s"trace-id=${testSpanInfo.id.traceId}")
+      logEntry should include(s"span-duration=${testSpanInfo.durationMicros}")
+      logEntry should include(s"start-time=${testSpanInfo.startTimeMillis}")
+      logEntry should include(s"span-duration=${testSpanInfo.durationMicros}")
+      logEntry should include(s"host=${testSpanInfo.host}")
+      logEntry should include(s"app-name=${testSpanInfo.appName}")
+      logEntry should include(s"span-name=${testSpanInfo.name}")
+      logEntry should include(s"span-success=${testSpanInfo.success}")
+
+      for (note <- testSpanInfo.notes.values) {
+        logEntry should include(s"${note.name}=${note.value}")
+      }
+    }
+
+    "log a NULL if the value of a note is null" in {
+
+      val nullTest = testSpanInfo.copy(
+        notes = Map("nullStr" -> Note.of("nullStr", null.asInstanceOf[String]))
+      )
+
+      underTest.handle(nullTest)
+
+      verify(mockLogger).info(logEntryCaptor.capture())
+
+      val logEntry = logEntryCaptor.getValue
+
+      logEntry should include("nullStr=NULL")
+    }
+
+    "be configurable" in {
+      underTest shouldBe a[ConfigurableHandler]
+    }
+
+    "be configured to use error" in {
+      val config = ConfigFactory.parseString("log-level=ERROR")
+
+      underTest.configure(config)
+      underTest.handle(testSpanInfo)
+
+      verify(mockLogger).error(logEntryCaptor.capture())
+    }
+
+    "be configured to use warn" in {
+      val config = ConfigFactory.parseString("log-level=WARN")
+
+      underTest.configure(config)
+      underTest.handle(testSpanInfo)
+
+      verify(mockLogger).warn(logEntryCaptor.capture())
+    }
+
+    "be configured to use info" in {
+      val config = ConfigFactory.parseString("log-level=INFO")
+
+      underTest.configure(config)
+      underTest.handle(testSpanInfo)
+
+      verify(mockLogger).info(logEntryCaptor.capture())
+    }
+
+    "be configured to use debug" in {
+      val config = ConfigFactory.parseString("log-level=DEBUG")
+
+      underTest.configure(config)
+      underTest.handle(testSpanInfo)
+
+      verify(mockLogger).debug(logEntryCaptor.capture())
+    }
+
+    "be configured to use trace" in {
+      val config = ConfigFactory.parseString("log-level=TRACE")
+
+      underTest.configure(config)
+      underTest.handle(testSpanInfo)
+
+      verify(mockLogger).trace(logEntryCaptor.capture())
+    }
+
+    "be configured to default to info" in {
+      val config = ConfigFactory.parseString("no-configure=true")
+
+      underTest.configure(config)
+      underTest.handle(testSpanInfo)
+
+      verify(mockLogger).info(logEntryCaptor.capture())
+    }
+  }
+}

--- a/money-core-scala/src/test/scala/com/comcast/money/core/handlers/TestData.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/handlers/TestData.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.handlers
+
+import com.comcast.money.api.{ SpanHandler, SpanInfo, Note, SpanId }
+import com.comcast.money.core.{ CoreSpan, CoreSpanInfo }
+import com.typesafe.config.Config
+
+class ConfiguredHandler extends ConfigurableHandler {
+
+  var calledConfigure = false
+
+  def configure(config: Config): Unit = calledConfigure = true
+  def handle(span: SpanInfo): Unit = ()
+}
+
+class NonConfiguredHandler extends SpanHandler {
+  def handle(span: SpanInfo): Unit = ()
+}
+
+trait TestData {
+
+  import scala.collection.JavaConversions._
+
+  val testStringNote = Note.of("str", "bar")
+  val testLongNote = Note.of("lng", 200L)
+  val testDoubleNote = Note.of("dbl", 1.2)
+  val testBooleanNote = Note.of("bool", true)
+
+  val testSpanInfo = CoreSpanInfo(
+    id = new SpanId(),
+    startTimeMillis = System.currentTimeMillis,
+    startTimeMicros = System.nanoTime() / 1000,
+    endTimeMillis = System.currentTimeMillis,
+    endTimeMicros = System.nanoTime / 1000,
+    durationMicros = 123456L,
+    name = "test-span",
+    appName = "test",
+    host = "localhost",
+    notes = Map("str" -> testStringNote, "lng" -> testLongNote, "dbl" -> testDoubleNote, "bool" -> testBooleanNote)
+  )
+
+  val testSpan = CoreSpan(new SpanId(), "test-span", null)
+}

--- a/money-core-scala/src/test/scala/com/comcast/money/core/internal/MDCSupportSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/internal/MDCSupportSpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.internal
+
+import com.comcast.money.api.SpanId
+import org.scalatest.{ BeforeAndAfterEach, Matchers, OneInstancePerTest, WordSpec }
+import org.slf4j.MDC
+
+import scala.collection.mutable
+
+class MDCSupportSpec extends WordSpec with Matchers with BeforeAndAfterEach with OneInstancePerTest {
+
+  val testMDCSupport = new MDCSupport
+  val spanId = new SpanId()
+
+  override def beforeEach() = {
+    SpanLocal.clear()
+  }
+
+  "MDCSupport" should {
+    "set the span in MDC when provide" in {
+      testMDCSupport.setSpanMDC(Some(spanId))
+      MDC.get("moneyTrace") shouldEqual MDCSupport.format(spanId)
+    }
+    "clear the MDC value when set to None" in {
+      testMDCSupport.setSpanMDC(Some(spanId))
+      MDC.get("moneyTrace") shouldEqual MDCSupport.format(spanId)
+
+      testMDCSupport.setSpanMDC(None)
+      MDC.get("moneyTrace") shouldBe null
+    }
+    "not be run if tracing is disabled" in {
+      val disabled = new MDCSupport(false)
+      disabled.setSpanMDC(Some(spanId))
+      MDC.get("moneyTrace") shouldBe null
+    }
+    "not propogate MDC if disabled" in {
+      import scala.collection.JavaConversions._
+
+      val mdcContext: mutable.Map[_, _] = mutable.HashMap("FINGERPRINT" -> "print")
+      val disabled = new MDCSupport(false)
+      disabled.propogateMDC(Some(mdcContext))
+      MDC.get("FINGERPRINT") shouldBe null
+    }
+    "propogate MDC if not disabled" in {
+      import scala.collection.JavaConversions._
+
+      val mdcContext: mutable.Map[_, _] = mutable.HashMap("FINGERPRINT" -> "print")
+
+      testMDCSupport.propogateMDC(Some(mdcContext))
+      MDC.get("FINGERPRINT") shouldBe "print"
+    }
+    "clear MDC if given an empty context" in {
+      MDC.put("FINGERPRINT", "print")
+      testMDCSupport.propogateMDC(None)
+      MDC.get("FINGERPRINT") shouldBe null
+    }
+    "set span name" in {
+      testMDCSupport.setSpanNameMDC(Some("foo"))
+      MDC.get("spanName") shouldBe "foo"
+      testMDCSupport.getSpanNameMDC shouldBe Some("foo")
+    }
+    "clear span name from MDC when given an empty value" in {
+      MDC.put("spanName", "shouldBeRemoved")
+      testMDCSupport.setSpanNameMDC(None)
+      MDC.get("spanName") shouldBe null
+      testMDCSupport.getSpanNameMDC shouldBe None
+    }
+  }
+}

--- a/money-core-scala/src/test/scala/com/comcast/money/core/internal/SpanLocalSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/internal/SpanLocalSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.internal
+
+import com.comcast.money.api.SpanId
+import com.comcast.money.core.handlers.TestData
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{ OneInstancePerTest, BeforeAndAfterEach, Matchers, WordSpec }
+import org.slf4j.MDC
+
+class SpanLocalSpec extends WordSpec
+    with Matchers with OneInstancePerTest with BeforeAndAfterEach with MockitoSugar with TestData {
+
+  override def afterEach() = {
+    SpanLocal.clear()
+  }
+
+  "SpanLocal" when {
+    "an item exists in span local" should {
+      "return the span local value" in {
+        SpanLocal.push(testSpan)
+        SpanLocal.current shouldEqual Some(testSpan)
+      }
+      "clear the stored value" in {
+        SpanLocal.push(testSpan)
+
+        SpanLocal.clear()
+        SpanLocal.current shouldEqual None
+      }
+      "do nothing if trying to push a null value" in {
+        SpanLocal.push(testSpan)
+        SpanLocal.push(null)
+        SpanLocal.current shouldEqual Some(testSpan)
+      }
+      "add to the existing call stack" in {
+        val nested = testSpan.copy(new SpanId())
+
+        SpanLocal.push(testSpan)
+        SpanLocal.push(nested)
+        SpanLocal.current shouldEqual Some(nested)
+      }
+      "pop the last added item from the call stack" in {
+        val nested = testSpan.copy(new SpanId())
+        SpanLocal.push(testSpan)
+        SpanLocal.push(nested)
+
+        val popped = SpanLocal.pop()
+        popped shouldEqual Some(nested)
+        SpanLocal.current shouldEqual Some(testSpan)
+      }
+      "set the MDC value on push" in {
+        SpanLocal.push(testSpan)
+
+        MDC.get("moneyTrace") shouldEqual MDCSupport.format(testSpan.id)
+      }
+      "remove the MDC value on pop" in {
+        SpanLocal.push(testSpan)
+        SpanLocal.pop()
+
+        MDC.get("moneyTrace") shouldBe null
+      }
+      "remove the MDC value on clear" in {
+        SpanLocal.push(testSpan)
+
+        MDC.get("moneyTrace") shouldEqual MDCSupport.format(testSpan.id)
+        SpanLocal.clear()
+
+        MDC.get("moneyTrace") shouldBe null
+      }
+    }
+  }
+}

--- a/money-core/src/main/java/com/comcast/money/japi/JMoney.java
+++ b/money-core/src/main/java/com/comcast/money/japi/JMoney.java
@@ -58,11 +58,11 @@ public class JMoney {
      * Records a note in the current trace span if one is present
      * @param noteName The name of the note to record
      * @param value The value to be recorded on the note
-     * @param propagate whether or not to propagate note to children spans
+     * @param sticky whether or not to sticky note to children spans
      */
-    public static void record(String noteName, Double value, boolean propagate) {
+    public static void record(String noteName, Double value, boolean sticky) {
 
-        tracer().record(noteName, value, propagate);
+        tracer().record(noteName, value, sticky);
     }
 
     /**
@@ -79,11 +79,11 @@ public class JMoney {
      * Records a note in the current trace span if one is present
      * @param noteName The name of the note to record
      * @param value The value to be recorded on the note
-     * @param propagate whether or not to propagate note to children spans
+     * @param sticky whether or not to sticky note to children spans
      */
-    public static void record(String noteName, String value, boolean propagate) {
+    public static void record(String noteName, String value, boolean sticky) {
 
-        tracer().record(noteName, value, propagate);
+        tracer().record(noteName, value, sticky);
     }
 
     /**
@@ -100,11 +100,11 @@ public class JMoney {
      * Records a note in the current trace span if one is present
      * @param noteName The name of the note to record
      * @param value The value to be recorded on the note
-     * @param propagate whether or not to propagate note to children spans
+     * @param sticky whether or not to sticky note to children spans
      */
-    public static void record(String noteName, Long value, boolean propagate) {
+    public static void record(String noteName, Long value, boolean sticky) {
 
-        tracer().record(noteName, value, propagate);
+        tracer().record(noteName, value, sticky);
     }
 
     /**
@@ -121,11 +121,11 @@ public class JMoney {
      * Records a note in the current trace span if one is present
      * @param noteName The name of the note to record
      * @param value The value to be recorded on the note
-     * @param propagate whether or not to propagate note to children spans
+     * @param sticky whether or not to sticky note to children spans
      */
-    public static void record(String noteName, boolean value, boolean propagate) {
+    public static void record(String noteName, boolean value, boolean sticky) {
 
-        tracer().record(noteName, value, propagate);
+        tracer().record(noteName, value, sticky);
     }
 
     /**
@@ -134,11 +134,11 @@ public class JMoney {
      * String Note, and perform a "toString" on the value.
      * @param noteName The name of the note to record
      * @param value The value to be recorded on the note
-     * @param propagate whether or not to propagate the note to child spans
+     * @param sticky whether or not to sticky the note to child spans
      */
-    public static void record(String noteName, Object value, boolean propagate) {
+    public static void record(String noteName, Object value, boolean sticky) {
 
-        tracer().record(toNote(noteName, value, propagate));
+        tracer().record(toNote(noteName, value, sticky));
     }
 
     /**
@@ -264,21 +264,21 @@ public class JMoney {
         }
     }
 
-    private static Note<?> toNote(String name, Object value, Boolean propagate) {
+    private static Note<?> toNote(String name, Object value, Boolean sticky) {
 
         if (value == null) {
-            return Note.of(name, null, propagate, DateTimeUtil.microTime());
+            return Note.of(name, null, sticky, DateTimeUtil.microTime());
         } else if (value instanceof Boolean) {
             Boolean bool = (Boolean)value;
-            return Note.of(name, bool, propagate, DateTimeUtil.microTime());
+            return Note.of(name, bool, sticky, DateTimeUtil.microTime());
         } else if (value instanceof Double) {
             Double dbl = (Double)value;
-            return Note.of(name, dbl, propagate, DateTimeUtil.microTime());
+            return Note.of(name, dbl, sticky, DateTimeUtil.microTime());
         } else if (value instanceof Long) {
             Long lng = (Long)value;
-            return Note.of(name, lng, propagate, DateTimeUtil.microTime());
+            return Note.of(name, lng, sticky, DateTimeUtil.microTime());
         } else {
-            return Note.of(name, value.toString(), propagate, DateTimeUtil.microTime());
+            return Note.of(name, value.toString(), sticky, DateTimeUtil.microTime());
         }
     }
 }

--- a/money-core/src/main/scala/com/comcast/money/concurrent/Futures.scala
+++ b/money-core/src/main/scala/com/comcast/money/concurrent/Futures.scala
@@ -107,7 +107,7 @@ object Futures {
     case None =>
       new SpanId()
     case Some(existingSpanId) =>
-      existingSpanId.newChild()
+      existingSpanId.newChildId()
   }
 }
 

--- a/project/MoneyBuild.scala
+++ b/project/MoneyBuild.scala
@@ -4,6 +4,7 @@ import com.typesafe.sbt.SbtScalariform
 import sbt.Keys._
 import sbt._
 import sbtavro.SbtAvro._
+import scoverage.ScoverageKeys
 import scoverage.ScoverageSbtPlugin._
 import de.heikoseeberger.sbtheader.HeaderPlugin
 import de.heikoseeberger.sbtheader.AutomateHeaderPlugin
@@ -25,7 +26,7 @@ object MoneyBuild extends Build {
     publishLocal := {},
     publish := {}
   )
-  .aggregate(moneyApi, moneyCore, moneyAspectj, moneyHttpClient, moneyJavaServlet, moneyKafka, moneySpring, moneySpring3, moneyWire)
+  .aggregate(moneyApi, moneyCoreScala, moneyCore, moneyAspectj, moneyHttpClient, moneyJavaServlet, moneyKafka, moneySpring, moneySpring3, moneyWire)
 
   lazy val moneyApi =
     Project("money-api", file("./money-api"))
@@ -39,6 +40,22 @@ object MoneyBuild extends Build {
         )
       }
       )
+
+  lazy val moneyCoreScala =
+    Project("money-core-scala", file("./money-core-scala"))
+      .configs( IntegrationTest )
+      .settings(projectSettings: _*)
+      .settings(
+        libraryDependencies ++= {
+          Seq(
+            slf4j,
+            log4jbinding,
+            typesafeConfig,
+            scalaTest,
+            mockito
+          )
+        }
+      ).dependsOn(moneyApi)
 
   lazy val moneyCore =
     Project("money-core", file("./money-core"))
@@ -366,7 +383,7 @@ object MoneyBuild extends Build {
 
     // Test
     val mockito = "org.mockito" % "mockito-core" % "1.9.5" % "test"
-    val scalaTest = "org.scalatest" %% "scalatest" % "2.2.3" % "it,test"
+    val scalaTest = "org.scalatest" %% "scalatest" % "2.2.6" % "it,test"
     val junit = "junit" % "junit" % "4.11" % "test"
     val junitInterface = "com.novocode" % "junit-interface" % "0.11" % "test->default"
     val springTest = ("org.springframework" % "spring-test" % "3.2.6.RELEASE")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ logLevel := Level.Warn
 // The Typesafe repository
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.0.1")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.3.5")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-aspectj" % "0.9.4")
 


### PR DESCRIPTION
This is the initial WIP of a *NEW* version of money core.

* Please avoid nit-picking at this time.  I did not write unit tests, integration tests, and commented very little.  I want to get eyes on the design rather than the actual code *

I decided to create a new module for the time being called `money-core-scala`.   Having a separate module will allow us to do A/B testing against the existing money-core, plus we can review this without being distracted from a bunch of change/delete code lines in the current money-core.

### API CHANGES
I wanted to make a few small API changes once I got rolling here:

- Moved creation of child spans to the SpanFactory.  It became evident that there could be some complexity in creating spans, and that responsibility rightly belongs in the factory.
- Separated the span data from the span itself.  There is a new type `SpanInfo` that houses the state/result of a Span.  I did not like sending a `Span` to a `SpanHandler` as that would give developers the opportunity to do stupid things like call `start` and `stop` on a span that was already completed.  Plus, the `SpanInfo` is immutable, which gives additional safety
- Changed the `stop` method to take a `Boolean` (capital B), this simplified implementation in Scala

### NEW CORE
So, the new Core will keep the existing Tracer interface to remain backward compatible.  As such, I mostly copied over the `Tracer` and the `SpanLocal` from the current money-core module.

Of course, the new money-core-scala module uses our new API and the SpanFactory.

The base core is very simple:

- Tracer - creates Spans using the SpanFactory provided and manages them in ThreadLocal (SpanLocal)
- CoreSpan - simple interface; on `stop` will call a `SpanHandler`
- CoreSpanFactory - creates spans and child spans.  You will see that it joins the Span to the SpanHandler so that the CoreSpan `stop` can invoke the SpanHandler

That is the simple part, the complexity is introduced in constructing the Span Handlers based on configuration.  This prototype supports:

- configuring `async`; if async is configured then the handler will be wrapped in an `AsyncSpanHandler`
- setting up a chain of handlers - this is similar to our array of Emitters we have today.  We iterate when we handle spans as opposed to tossing everything into its own future, but that is a small detail that we can change
- HandlerFactory - will create instances of each handler that is configured.  If the handler implements `Configurable`, then that method will be invoked before the handler is done being created

Finally, there is a new `Money` implementation.  No, it is not fully built yet, but I didn't want to add unnecessary complexity until everyone reviewed this implementation.  Any needed things will be moved over.  The new money stuff provides a `Money.Environment`, this will ease testability of the application.  You can see that it supports basic money environment loading, including a disabled environment.

