### PR TITLE
Updating Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ scala:
   - 2.11.7
 
 script:
-  -  sbt ++$TRAVIS_SCALA_VERSION clean coverage test it:test coverageReport coverageAggregate
+  -  sbt ++$TRAVIS_SCALA_VERSION clean coverage test it:test coverageReport
+  -  sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
 
 after_success:
   - pip install --user codecov && codecov

--- a/money-spring3/src/main/scala/com/comcast/money/spring3/SpringTracer.scala
+++ b/money-spring3/src/main/scala/com/comcast/money/spring3/SpringTracer.scala
@@ -16,7 +16,6 @@
 
 package com.comcast.money.spring3
 
-import akka.actor.ActorRef
 import com.comcast.money.api.Note
 import com.comcast.money.core._
 import org.springframework.stereotype.Component

--- a/project/MoneyBuild.scala
+++ b/project/MoneyBuild.scala
@@ -26,7 +26,7 @@ object MoneyBuild extends Build {
     publishLocal := {},
     publish := {}
   )
-  .aggregate(moneyApi, moneyCoreScala, moneyCore, moneyAspectj, moneyHttpClient, moneyJavaServlet, moneyKafka, moneySpring, moneySpring3, moneyWire)
+  .aggregate(moneyApi, moneyCoreScala, moneyAspectj, moneyHttpClient, moneyJavaServlet, moneyKafka, moneySpring, moneySpring3, moneyWire)
 
   lazy val moneyApi =
     Project("money-api", file("./money-api"))
@@ -85,9 +85,6 @@ object MoneyBuild extends Build {
     .settings(
       libraryDependencies <++= (scalaVersion) { v: String =>
         Seq(
-          akkaActor(v),
-          akkaSlf4j(v),
-          akkaTestkit(v),
           typesafeConfig,
           scalaTest,
           mockito
@@ -103,9 +100,6 @@ object MoneyBuild extends Build {
       .settings(
         libraryDependencies <++= (scalaVersion){v: String =>
           Seq(
-            akkaActor(v),
-            akkaSlf4j(v),
-            akkaTestkit(v),
             apacheHttpClient,
             scalaTest,
             mockito
@@ -121,10 +115,7 @@ object MoneyBuild extends Build {
       .settings(
         libraryDependencies <++= (scalaVersion){v: String =>
           Seq(
-            akkaActor(v),
-            akkaSlf4j(v),
             javaxServlet,
-            akkaTestkit(v),
             scalaTest,
             mockito
           )
@@ -162,8 +153,6 @@ object MoneyBuild extends Build {
       .settings(
         libraryDependencies <++= (scalaVersion){v: String =>
           Seq(
-            akkaActor(v),
-            akkaSlf4j(v),
             kafka,
             bijectionCore,
             bijectionAvro,
@@ -186,9 +175,6 @@ object MoneyBuild extends Build {
       .settings(
         libraryDependencies <++= (scalaVersion) { v: String =>
           Seq(
-            akkaActor(v),
-            akkaSlf4j(v),
-            akkaTestkit(v),
             typesafeConfig,
             scalaTest,
             mockito,
@@ -205,9 +191,6 @@ object MoneyBuild extends Build {
       .settings(
         libraryDependencies <++= (scalaVersion) { v: String =>
           Seq(
-            akkaActor(v),
-            akkaSlf4j(v),
-            akkaTestkit(v),
             typesafeConfig,
             scalaTest,
             mockito,
@@ -239,7 +222,7 @@ object MoneyBuild extends Build {
     organization := "com.comcast.money",
     version := "0.8.12-SNAPSHOT",
     crossScalaVersions := Seq("2.10.6", "2.11.7"),
-    scalaVersion := "2.10.6",
+    scalaVersion := "2.11.7",
     resolvers ++= Seq(
       "spray repo" at "http://repo.spray.io/",
       "Sonatype OSS Releases" at "http://oss.sonatype.org/content/repositories/releases/"


### PR DESCRIPTION
Removing lagging akka references, changing travis build to run
coverageAggregate after coverageReport, which is the recommended method
with the latest scoverage plugin.