### PR TITLE
Fix adding traceHeader to execute methods with responsehandlers

### DIFF
--- a/money-http-client/src/main/scala/com/comcast/money/http/client/TraceFriendlyHttpClient.scala
+++ b/money-http-client/src/main/scala/com/comcast/money/http/client/TraceFriendlyHttpClient.scala
@@ -104,20 +104,24 @@ class TraceFriendlyHttpClient(wrapee: HttpClient) extends HttpClient with java.i
    */
 
   override def execute[T](request: HttpUriRequest, responseHandler: ResponseHandler[_ <: T]): T = {
+    addTraceHeader(request)
     wrapee.execute(request, responseHandler)
   }
 
   override def execute[T](request: HttpUriRequest, responseHandler: ResponseHandler[_ <: T],
     context: HttpContext): T = {
+    addTraceHeader(request)
     wrapee.execute(request, responseHandler, context)
   }
 
   override def execute[T](target: HttpHost, request: HttpRequest, responseHandler: ResponseHandler[_ <: T]): T = {
+    addTraceHeader(request)
     wrapee.execute(target, request, responseHandler)
   }
 
   override def execute[T](target: HttpHost, request: HttpRequest, responseHandler: ResponseHandler[_ <: T],
     context: HttpContext): T = {
+    addTraceHeader(request)
     wrapee.execute(target, request, responseHandler, context)
   }
 

--- a/money-http-client/src/test/scala/com/comcast/money/http/client/TraceFriendlyHttpClientSpec.scala
+++ b/money-http-client/src/test/scala/com/comcast/money/http/client/TraceFriendlyHttpClientSpec.scala
@@ -101,18 +101,22 @@ class TraceFriendlyHttpClientSpec extends WordSpec
     "simply call the wrapped client when execute(HttpUriRequest, ResponseHandler)" in {
       underTest.execute(httpUriRequest, testHttpResponseHandler)
       verify(httpClient).execute(httpUriRequest, testHttpResponseHandler)
+      verify(httpUriRequest).setHeader("X-MoneyTrace", spanId.toHttpHeader)
     }
     "simply call the wrapped client when execute(HttpUriRequest, ResponseHandler, HttpContext)" in {
       underTest.execute(httpUriRequest, testHttpResponseHandler, httpContext)
       verify(httpClient).execute(httpUriRequest, testHttpResponseHandler, httpContext)
+      verify(httpUriRequest).setHeader("X-MoneyTrace", spanId.toHttpHeader)
     }
     "simply call the wrapped client when execute(HttpHost, HttpRequest, ResponseHandler)" in {
       underTest.execute(httpHost, httpUriRequest, testHttpResponseHandler)
       verify(httpClient).execute(httpHost, httpUriRequest, testHttpResponseHandler)
+      verify(httpUriRequest).setHeader("X-MoneyTrace", spanId.toHttpHeader)
     }
     "simply call the wrapped client when execute(HttpHost, HttpRequest, ResponseHandler, HttpContext)" in {
       underTest.execute(httpHost, httpUriRequest, testHttpResponseHandler, httpContext)
       verify(httpClient).execute(httpHost, httpUriRequest, testHttpResponseHandler, httpContext)
+      verify(httpUriRequest).setHeader("X-MoneyTrace", spanId.toHttpHeader)
     }
     "records a zero for a status code on exception" in {
       when(httpClient.execute(httpUriRequest)).thenThrow(new RuntimeException("bad"))


### PR DESCRIPTION
Fix adding traceHeader to execute methods with responsehandlers in TraceFriendlyHttpClient