### PR TITLE
Add configuration for the LogEmitter format

### DIFF
--- a/money-core/src/main/resources/reference.conf
+++ b/money-core/src/main/resources/reference.conf
@@ -54,6 +54,23 @@ money {
         configuration = {
           emitter = "com.comcast.money.emitters.LogEmitter"
           log-level = "WARN"
+          formatting {
+            span-start = "Span: "
+            null-value = "NULL"
+            log-template = "[ %s=%s ]"
+            span-duration-ms-enabled = "false"
+            keys {
+              span-id = "span-id"
+              trace-id = "trace-id"
+              parent-id = "parent-id"
+              span-name = "span-name"
+              app-name = "app-name"
+              start-time = "start-time"
+              span-duration = "span-duration"
+              span-duration-ms = "span-duration-ms"
+              span-success = "span-success"
+            }
+          }
         }
       },
       {

--- a/money-core/src/main/scala/com/comcast/money/emitters/SpanLogFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/emitters/SpanLogFormatter.scala
@@ -1,0 +1,77 @@
+package com.comcast.money.emitters
+
+import com.comcast.money.core.{ Note, Money, Span }
+import com.typesafe.config.Config
+
+object SpanLogFormatter {
+  def apply(implicit conf: Config) =
+    new SpanLogFormatter(
+      spanStart = configValue("formatting.span-start", "Span: "),
+      nullValue = configValue("formatting.null-value", "NULL"),
+      logTemplate = configValue("formatting.log-template", "[ %s=%s ]"),
+      spanDurationMsEnabled = configEnabled("formatting.span-duration-ms-enabled"),
+      spanIdKey = configValue("formatting.keys.span-id", "span-id"),
+      traceIdKey = configValue("formatting.keys.trace-id", "trace-id"),
+      parentIdKey = configValue("formatting.keys.parent-id", "parent-id"),
+      spanNameKey = configValue("formatting.keys.span-name", "span-name"),
+      appNameKey = configValue("formatting.keys.app-name", "app-name"),
+      startTimeKey = configValue("formatting.keys.start-time", "start-time"),
+      spanDurationKey = configValue("formatting.keys.span-duration", "span-duration"),
+      spanDurationMsKey = configValue("formatting.keys.span-duration-ms", "span-duration-ms"),
+      spanSuccessKey = configValue("formatting.keys.span-success", "span-success")
+    )
+
+  private def configValue(key: String, defaultValue: String)(implicit conf: Config) =
+    if (conf.hasPath(key))
+      conf.getString(key)
+    else
+      defaultValue
+
+  private def configEnabled(key: String)(implicit conf: Config): Boolean =
+    if (conf.hasPath(key))
+      conf.getString(key).toBoolean
+    else
+      false
+}
+
+class SpanLogFormatter(
+    val spanStart: String,
+    val nullValue: String,
+    val logTemplate: String,
+    val spanDurationMsEnabled: Boolean,
+    val spanIdKey: String,
+    val traceIdKey: String,
+    val parentIdKey: String,
+    val spanNameKey: String,
+    val appNameKey: String,
+    val startTimeKey: String,
+    val spanDurationKey: String,
+    val spanDurationMsKey: String,
+    val spanSuccessKey: String
+) {
+
+  def buildMessage(t: Span): String = {
+    implicit val builder = new StringBuilder()
+    builder.append(spanStart)
+    append(spanIdKey, t.spanId.spanId)
+    append(traceIdKey, t.spanId.traceId)
+    append(parentIdKey, t.spanId.parentSpanId)
+    append(spanNameKey, t.spanName)
+    append(appNameKey, Money.applicationName)
+    append(startTimeKey, t.startTime)
+    append(spanDurationKey, t.duration)
+    if (spanDurationMsEnabled)
+      append(spanDurationMsKey, t.duration / 1000)
+    append(spanSuccessKey, t.success)
+    t.notes.toList.sortBy(_._1).foreach {
+      case (name, note) => note match {
+        case n: Note[_] if n.value.isEmpty => append(n.name, nullValue)
+        case n: Note[_] if n.value.isDefined => append(n.name, n.value.get.toString)
+      }
+    }
+    builder.toString()
+  }
+
+  private def append[T](key: String, value: T)(implicit builder: StringBuilder): StringBuilder =
+    builder.append(logTemplate.format(key, value))
+}

--- a/money-core/src/test/scala/com/comcast/money/emitters/LogEmitterSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/emitters/LogEmitterSpec.scala
@@ -33,6 +33,7 @@ class LogEmitterSpec extends AkkaTestJawn with WordSpecLike {
           }
     """
   )
+  val spanLogFormatter = SpanLogFormatter(emitterConf)
 
   "A LogEmitter must" must {
     "log request spans" in {
@@ -42,32 +43,15 @@ class LogEmitterSpec extends AkkaTestJawn with WordSpecLike {
         Map("what" -> Note("what", 1L), "when" -> Note("when", 2L), "bob" -> Note("bob", "craig"))
       )
       val span = EmitSpan(sampleData)
-      val expectedLogMessage = LogEmitter.buildMessage(sampleData)
+      val expectedLogMessage = spanLogFormatter.buildMessage(sampleData)
 
       underTest ! span
       expectLogMessageContaining(expectedLogMessage)
-    }
-    "have a correctly formatted message" in {
-      val sampleData = Span(
-        SpanId(1L), "key", "unknown", "host", 1L, true, 35L,
-        Map("what" -> Note("what", 1L), "when" -> Note("when", 2L), "bob" -> Note("bob", "craig"))
-      )
-      val actualMessage = LogEmitter.buildMessage(sampleData)
-      assert(
-        actualMessage === ("Span: [ span-id=1 ][ trace-id=1 ][ parent-id=1 ][ span-name=key ][ app-name=unknown ][ " +
-          "start-time=1 ][ span-duration=35 ][ span-success=true ][ bob=craig ][ what=1 ][ when=2 ]")
-      )
     }
     "log metrics" in {
       val underTest = system.actorOf(LogEmitter.props(emitterConf))
       underTest ! EmitMetricDouble("bob", 1.0)
       expectLogMessageContaining("bob=1.0")
-    }
-    "log NULL when the note value is None" in {
-      val sampleData = Span(SpanId(1L), "key", "app", "host", 1L, true, 35L, Map("empty" -> StringNote("empty", None)))
-      val expectedLogMessage = LogEmitter.buildMessage(sampleData)
-
-      expectedLogMessage should include("[ empty=NULL ]")
     }
     "parse log level" in {
       LogEmitter.logLevel(emitterConf) shouldBe Logging.InfoLevel

--- a/money-core/src/test/scala/com/comcast/money/emitters/SpanLogFormatterSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/emitters/SpanLogFormatterSpec.scala
@@ -1,0 +1,156 @@
+package com.comcast.money.emitters
+
+import com.comcast.money.core.{ StringNote, Note, SpanId, Span }
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{ Matchers, WordSpec }
+
+class SpanLogFormatterSpec extends WordSpec with Matchers {
+
+  val emitterConf = ConfigFactory.parseString(
+    """
+          {
+            log-level="INFO"
+            emitter="com.comcast.money.emitters.LogRecorder"
+          }
+    """
+  )
+  val spanLogFormatter = SpanLogFormatter(emitterConf)
+
+  "A LogEmitter must" must {
+    "have a correctly formatted message" in {
+      val sampleData = Span(
+        SpanId(1L), "key", "unknown", "host", 1L, true, 35L,
+        Map("what" -> Note("what", 1L), "when" -> Note("when", 2L), "bob" -> Note("bob", "craig"))
+      )
+      val actualMessage = spanLogFormatter.buildMessage(sampleData)
+      assert(
+        actualMessage === ("Span: [ span-id=1 ][ trace-id=1 ][ parent-id=1 ][ span-name=key ][ app-name=unknown ][ " +
+          "start-time=1 ][ span-duration=35 ][ span-success=true ][ bob=craig ][ what=1 ][ when=2 ]")
+      )
+    }
+    "honor key names from the config" in {
+      val conf = ConfigFactory.parseString(
+        """
+              {
+                emitter="com.comcast.money.emitters.LogRecorder"
+                formatting {
+                  keys {
+                    span-id = "spanId"
+                    trace-id = "traceId"
+                    parent-id = "parentId"
+                    span-name = "spanName"
+                    app-name = "appName"
+                    start-time = "startTime"
+                    span-duration = "spanDuration"
+                    span-success = "spanSuccess"
+                  }
+                }
+              }
+        """
+      )
+      val spanLogFormatter = SpanLogFormatter(conf)
+
+      val sampleData = Span(
+        SpanId(1L), "key", "unknown", "host", 1L, true, 35L,
+        Map("what" -> Note("what", 1L), "when" -> Note("when", 2L), "bob" -> Note("bob", "craig"))
+      )
+      val actualMessage = spanLogFormatter.buildMessage(sampleData)
+      assert(
+        actualMessage === ("Span: [ spanId=1 ][ traceId=1 ][ parentId=1 ][ spanName=key ][ appName=unknown ][ " +
+          "startTime=1 ][ spanDuration=35 ][ spanSuccess=true ][ bob=craig ][ what=1 ][ when=2 ]")
+      )
+    }
+    "honor the span-start from the config" in {
+      val conf = ConfigFactory.parseString(
+        """
+              {
+                emitter="com.comcast.money.emitters.LogRecorder"
+                formatting {
+                  span-start = "Start :|: "
+                }
+              }
+        """
+      )
+      val spanLogFormatter = SpanLogFormatter(conf)
+      val sampleData = Span(
+        SpanId(1L), "key", "unknown", "host", 1L, true, 35L,
+        Map("what" -> Note("what", 1L), "when" -> Note("when", 2L), "bob" -> Note("bob", "craig"))
+      )
+      val actualMessage = spanLogFormatter.buildMessage(sampleData)
+      assert(
+        actualMessage === ("Start :|: [ span-id=1 ][ trace-id=1 ][ parent-id=1 ][ span-name=key ][ app-name=unknown ][ " +
+          "start-time=1 ][ span-duration=35 ][ span-success=true ][ bob=craig ][ what=1 ][ when=2 ]")
+      )
+    }
+    "honor the log-template from the config" in {
+      val conf = ConfigFactory.parseString(
+        """
+              {
+                emitter="com.comcast.money.emitters.LogRecorder"
+                formatting {
+                  log-template = "%s=\"%s\" "
+                }
+              }
+        """
+      )
+      val spanLogFormatter = SpanLogFormatter(conf)
+      val sampleData = Span(
+        SpanId(1L), "key", "unknown", "host", 1L, true, 35L,
+        Map("what" -> Note("what", 1L), "when" -> Note("when", 2L), "bob" -> Note("bob", "craig"))
+      )
+      val actualMessage = spanLogFormatter.buildMessage(sampleData)
+      assert(
+        actualMessage === ("""Span: span-id="1" trace-id="1" parent-id="1" span-name="key" """ +
+          """app-name="unknown" start-time="1" span-duration="35" span-success="true" """ +
+          """bob="craig" what="1" when="2" """)
+      )
+    }
+    "honor the span-duration-ms settings in the config" in {
+      val conf = ConfigFactory.parseString(
+        """
+              {
+                emitter="com.comcast.money.emitters.LogRecorder"
+                formatting {
+                  span-duration-ms-enabled = "true"
+                  keys {
+                    span-duration-ms = "spanDurationMs"
+                  }
+                }
+              }
+        """
+      )
+      val spanLogFormatter = SpanLogFormatter(conf)
+      val sampleData = Span(
+        SpanId(1L), "key", "unknown", "host", 1L, true, 35000L,
+        Map("what" -> Note("what", 1L), "when" -> Note("when", 2L), "bob" -> Note("bob", "craig"))
+      )
+      val actualMessage = spanLogFormatter.buildMessage(sampleData)
+
+      actualMessage should include("[ span-duration=35000 ]")
+      actualMessage should include("[ spanDurationMs=35 ]")
+    }
+    "log NULL when the note value is None" in {
+      val sampleData = Span(SpanId(1L), "key", "app", "host", 1L, true, 35L, Map("empty" -> StringNote("empty", None)))
+      val expectedLogMessage = spanLogFormatter.buildMessage(sampleData)
+
+      expectedLogMessage should include("[ empty=NULL ]")
+    }
+    "honor the null value to log from the config" in {
+      val conf = ConfigFactory.parseString(
+        """
+              {
+                emitter="com.comcast.money.emitters.LogRecorder"
+                formatting {
+                  null-value = "null_value"
+                }
+              }
+        """
+      )
+      val spanLogFormatter = SpanLogFormatter(conf)
+      val sampleData = Span(SpanId(1L), "key", "app", "host", 1L, true, 35L, Map("empty" -> StringNote("empty", None)))
+      val expectedLogMessage = spanLogFormatter.buildMessage(sampleData)
+
+      expectedLogMessage should include("[ empty=null_value ]")
+    }
+  }
+}


### PR DESCRIPTION

This change updates the LogEmitter to allow the format and keys to be
configured to allow customization of the log output.  See
https://github.com/Comcast/money/issues/63

All of the configuration values have a fallback to the current value,
leaving the current log format unchanged.

The template for logging individual values can be specified as
a log-template property.  The span-start string and null-value can also
be customized.

Each of the field keys can be cutomized with these properties:
  span-id = "span_id"
  trace-id = "trace_id"
  parent-id = "parent_id"
  span-name = "span_name"
  app-name = "app_name"
  start-time = "start_time"
  span-duration = "span_duration_ns"
  span-duration-ms = "span_duration"
  span-success = "span_success"

Also a new span-duration-ms field is added to allow logging the duration
in ms.  By default it is disabled, however the span-duration-ms-enabled
configuration value can be used to enable it.