### PR TITLE
Add money tracing support to AmazonWebServiceClient.

### DIFF
--- a/money-aws-java-sdk/README.md
+++ b/money-aws-java-sdk/README.md
@@ -1,0 +1,46 @@
+## Money: Amazon Web Service Client. 
+### Amazon Web Service Client support for Money trace data.
+
+Are you already using money to trace calls in your application? Would you like to do the same for your AWS calls so you can deep-link a user-request to a aws platform request in your logs? Then this money module is for you!
+
+This module adds money trace data as a header to Amazon Web Service Client. The Amazon Web Service Client is used internally in the Amazon Web Service Java SDK to allow clients to talk to AWS platform.
+
+## Show me how to do it, please!
+
+Add a dependency as follows for maven:
+
+```xml
+   <dependency>
+      <groupId>com.comcast.money</groupId>
+      <artifactId>money-aws-java-sdk</artifactId>
+      <version>0.8.14</version>
+   </dependency>
+   <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk</artifactId>
+      <version>1.10.57</version>
+   </dependency>
+```
+
+And here is a dependency for SBT:
+
+```scala
+    resolvers += "CIM Nexus Repository" at "http://repo.dev.cim.comcast.net/nexus/content/repositories/releases"
+
+    libraryDependencies += "com.comcast.money" %% "money-aws-java-sdk" % "0.8.14"
+```
+
+Then in your application, when you instantiate the AmazonDynamoDBClient, add one line of code:
+
+```java
+        ClientConfiguration clientConfiguration = new ClientConfiguration();
+        clientConfiguration.setProtocol(Protocol.HTTPS);
+        clientConfiguration.setMaxErrorRetry(1);
+        this.client = new AmazonDynamoDBClient(new ClasspathPropertiesFileCredentialsProvider("PulsarCredentials.properties"),
+                clientConfiguration);
+        client.setEndpoint(pulsarUrl);
+        client.addRequestHandler(new AmazonWebServiceClientMoneyTraceRequestHandler("myapp-pulsar"));
+```
+
+Done.
+

--- a/money-aws-java-sdk/src/main/scala/com/comcast/money/java/AmazonWebServiceClientMoneyTraceRequestHandler.java
+++ b/money-aws-java-sdk/src/main/scala/com/comcast/money/java/AmazonWebServiceClientMoneyTraceRequestHandler.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.java;
+
+import com.amazonaws.Request;
+import com.amazonaws.Response;
+import com.amazonaws.handlers.RequestHandler2;
+import com.comcast.money.core.SpanId;
+import com.comcast.money.internal.SpanLocal;
+import com.comcast.money.japi.JMoney;
+
+import scala.Option;
+
+public class AmazonWebServiceClientMoneyTraceRequestHandler extends RequestHandler2 {
+
+    public static final String MONEY_TRACE_HEADER = "X-MoneyTrace";
+
+    private final String spanName;
+
+    public AmazonWebServiceClientMoneyTraceRequestHandler(String spanName) {
+
+        this.spanName = spanName;
+    }
+
+    @Override
+    public void beforeRequest(Request<?> request) {
+
+        super.beforeRequest(request);
+
+        if (!JMoney.isEnabled()) {
+            return;
+        }
+
+        JMoney.startSpan(spanName);
+        Option<SpanId> spanId = SpanLocal.current();
+        if (spanId.isDefined()) {
+            request.addHeader(MONEY_TRACE_HEADER, spanId.get().toHttpHeader());
+        }
+    }
+
+    @Override
+    public void afterResponse(Request<?> request, Response<?> response) {
+
+        super.afterResponse(request, response);
+
+        if (!JMoney.isEnabled()) {
+            return;
+        }
+
+        JMoney.stopSpan(true);
+    }
+
+    @Override
+    public void afterError(Request<?> request, Response<?> response, Exception e) {
+
+        super.afterError(request, response, e);
+
+        if (!JMoney.isEnabled()) {
+            return;
+        }
+
+        JMoney.stopSpan(false);
+    }
+}

--- a/money-aws-java-sdk/src/main/scala/com/comcast/money/java/AmazonWebServiceClientMoneyTraceRequestHandler.java
+++ b/money-aws-java-sdk/src/main/scala/com/comcast/money/java/AmazonWebServiceClientMoneyTraceRequestHandler.java
@@ -39,14 +39,13 @@ public class AmazonWebServiceClientMoneyTraceRequestHandler extends RequestHandl
     @Override
     public void beforeRequest(Request<?> request) {
 
-        super.beforeRequest(request);
-
-        if (!JMoney.isEnabled()) {
+        if (!isMoneyEnabled()) {
             return;
         }
 
-        JMoney.startSpan(spanName);
-        Option<SpanId> spanId = SpanLocal.current();
+        startSpan(spanName);
+
+        Option<SpanId> spanId = getCurrentSpan();
         if (spanId.isDefined()) {
             request.addHeader(MONEY_TRACE_HEADER, spanId.get().toHttpHeader());
         }
@@ -55,24 +54,40 @@ public class AmazonWebServiceClientMoneyTraceRequestHandler extends RequestHandl
     @Override
     public void afterResponse(Request<?> request, Response<?> response) {
 
-        super.afterResponse(request, response);
-
-        if (!JMoney.isEnabled()) {
+        if (!isMoneyEnabled()) {
             return;
         }
 
-        JMoney.stopSpan(true);
+        stopSpan(true);
     }
 
     @Override
     public void afterError(Request<?> request, Response<?> response, Exception e) {
 
-        super.afterError(request, response, e);
-
-        if (!JMoney.isEnabled()) {
+        if (!isMoneyEnabled()) {
             return;
         }
 
-        JMoney.stopSpan(false);
+        stopSpan(false);
+    }
+
+    protected boolean isMoneyEnabled() {
+
+        return JMoney.isEnabled();
+    }
+
+    protected void startSpan(String spanName) {
+
+        JMoney.startSpan(spanName);
+    }
+
+    protected void stopSpan(boolean status) {
+
+        JMoney.stopSpan(status);
+    }
+
+    protected Option<SpanId> getCurrentSpan() {
+
+        return SpanLocal.current();
     }
 }

--- a/money-aws-java-sdk/src/test/scala/com/comcast/money/java/AmazonWebServiceClientMoneyTraceRequestHandlerTest.java
+++ b/money-aws-java-sdk/src/test/scala/com/comcast/money/java/AmazonWebServiceClientMoneyTraceRequestHandlerTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.java;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.amazonaws.Request;
+import com.amazonaws.Response;
+import com.comcast.money.core.SpanId;
+import com.comcast.money.internal.SpanLocal;
+import com.comcast.money.japi.JMoney;
+
+import scala.Option;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({JMoney.class, SpanLocal.class, Request.class, Response.class})
+public class AmazonWebServiceClientMoneyTraceRequestHandlerTest {
+
+    private AmazonWebServiceClientMoneyTraceRequestHandler handler;
+
+    private final String clientName = "clientName";
+
+    @Before
+    public void setUp() {
+
+        handler = new AmazonWebServiceClientMoneyTraceRequestHandler(clientName);
+    }
+
+    @Test
+    public void testAmazonWebServiceClientMoneyTraceRequestHandler() {
+
+        assertNotNull(handler);
+    }
+
+    @Test
+    public void testBeforeRequestRequestOfQ_moneyNotEnabled() {
+
+        PowerMockito.mockStatic(JMoney.class, SpanLocal.class);
+        Request<?> request = PowerMockito.mock(Request.class);
+
+        PowerMockito.when(JMoney.isEnabled()).thenReturn(false);
+
+        handler.beforeRequest(request);
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        JMoney.isEnabled();
+
+        PowerMockito.verifyZeroInteractions(SpanLocal.class, request);
+    }
+
+    @Test
+    public void testBeforeRequestRequestOfQ_moneyEnabledCurrentSpanIdAvailable() {
+
+        PowerMockito.mockStatic(JMoney.class, SpanLocal.class);
+        Request<?> request = PowerMockito.mock(Request.class);
+        SpanId spanId = PowerMockito.mock(SpanId.class);
+
+        PowerMockito.when(JMoney.isEnabled()).thenReturn(true);
+        PowerMockito.when(SpanLocal.current()).thenReturn(Option.apply(spanId));
+        PowerMockito.when(spanId.toHttpHeader()).thenReturn("headerValue");
+
+        handler.beforeRequest(request);
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        JMoney.isEnabled();
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        JMoney.startSpan(clientName);
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        SpanLocal.current();
+
+        Mockito.verify(spanId).toHttpHeader();
+        Mockito.verify(request).addHeader(AmazonWebServiceClientMoneyTraceRequestHandler.MONEY_TRACE_HEADER, "headerValue");;
+    }
+
+    @Test
+    public void testBeforeRequestRequestOfQ_moneyEnabledCurrentSpanIdNotAvailable() {
+
+        PowerMockito.mockStatic(JMoney.class, SpanLocal.class);
+        Request<?> request = PowerMockito.mock(Request.class);
+        SpanId spanId = PowerMockito.mock(SpanId.class);
+
+        PowerMockito.when(JMoney.isEnabled()).thenReturn(true);
+        Option<SpanId> emptySpan = Option.empty();
+        PowerMockito.when(SpanLocal.current()).thenReturn(emptySpan);
+
+        handler.beforeRequest(request);
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        JMoney.isEnabled();
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        JMoney.startSpan(clientName);
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        SpanLocal.current();
+
+        Mockito.verifyZeroInteractions(spanId, request);
+    }
+
+    @Test
+    public void testAfterResponseRequestOfQResponseOfQ_moneyNotEnabled() {
+
+        PowerMockito.mockStatic(JMoney.class, SpanLocal.class);
+        Request<?> request = PowerMockito.mock(Request.class);
+        Response<?> response = PowerMockito.mock(Response.class);
+
+        PowerMockito.when(JMoney.isEnabled()).thenReturn(false);
+
+        handler.beforeRequest(request);
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        JMoney.isEnabled();
+
+        PowerMockito.verifyNoMoreInteractions(JMoney.class);
+        PowerMockito.verifyZeroInteractions(request, response);
+
+    }
+
+    @Test
+    public void testAfterResponseRequestOfQResponseOfQ_moneyEnabled() {
+
+        PowerMockito.mockStatic(JMoney.class, SpanLocal.class);
+        Request<?> request = PowerMockito.mock(Request.class);
+        Response<?> response = PowerMockito.mock(Response.class);
+
+        PowerMockito.when(JMoney.isEnabled()).thenReturn(true);
+
+        handler.afterResponse(request, response);
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        JMoney.isEnabled();
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        JMoney.stopSpan(true);
+
+        PowerMockito.verifyZeroInteractions(request, response);
+
+    }
+
+    @Test
+    public void testAfterErrorRequestOfQResponseOfQException_moneyNotEnabled() {
+
+        PowerMockito.mockStatic(JMoney.class, SpanLocal.class);
+        Request<?> request = PowerMockito.mock(Request.class);
+        Response<?> response = PowerMockito.mock(Response.class);
+        Exception exception = PowerMockito.mock(Exception.class);
+
+        PowerMockito.when(JMoney.isEnabled()).thenReturn(false);
+
+        handler.afterError(request, response, exception);
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        JMoney.isEnabled();
+
+        PowerMockito.verifyNoMoreInteractions(JMoney.class);
+        PowerMockito.verifyZeroInteractions(request, response);
+    }
+
+    @Test
+    public void testAfterErrorRequestOfQResponseOfQException_moneyEnabled() {
+
+        PowerMockito.mockStatic(JMoney.class, SpanLocal.class);
+        Request<?> request = PowerMockito.mock(Request.class);
+        Response<?> response = PowerMockito.mock(Response.class);
+        Exception exception = PowerMockito.mock(Exception.class);
+
+        PowerMockito.when(JMoney.isEnabled()).thenReturn(true);
+
+        handler.afterError(request, response, exception);
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        JMoney.isEnabled();
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        JMoney.stopSpan(false);
+
+        PowerMockito.verifyZeroInteractions(request, response);
+    }
+
+}

--- a/project/MoneyBuild.scala
+++ b/project/MoneyBuild.scala
@@ -204,9 +204,7 @@ object MoneyBuild extends Build {
           Seq(
             awsJavaSdk,
             mockito,
-            junit,
-            powermockJunit,
-            powermockMockito
+            junit
           )
         },
         testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
@@ -371,8 +369,6 @@ object MoneyBuild extends Build {
 
     // Test
     val mockito = "org.mockito" % "mockito-core" % "1.9.5" % "test"
-    val powermockMockito = "org.powermock" % "powermock-api-mockito" % "1.6.3" % "test"
-    val powermockJunit = "org.powermock" % "powermock-module-junit4" % "1.6.3" % "test"
     val scalaTest = "org.scalatest" %% "scalatest" % "2.2.3" % "it,test"
     val junit = "junit" % "junit" % "4.11" % "test"
     val junitInterface = "com.novocode" % "junit-interface" % "0.11" % "test->default"

--- a/project/MoneyBuild.scala
+++ b/project/MoneyBuild.scala
@@ -25,7 +25,7 @@ object MoneyBuild extends Build {
     publishLocal := {},
     publish := {}
   )
-  .aggregate(moneyCore, moneyAspectj, moneyHttpClient, moneyJavaServlet, moneyKafka, moneySpring, moneySpring3, moneyWire)
+  .aggregate(moneyCore, moneyAspectj, moneyHttpClient, moneyJavaServlet, moneyKafka, moneySpring, moneySpring3, moneyWire,moneyAwsJavaSdk)
 
   lazy val moneyCore =
     Project("money-core", file("./money-core"))
@@ -195,6 +195,24 @@ object MoneyBuild extends Build {
       )
       .dependsOn(moneyCore)
 
+  lazy val moneyAwsJavaSdk =
+    Project("money-aws-java-sdk", file("./money-aws-java-sdk"))
+      .configs(IntegrationTest)
+      .settings(projectSettings: _*)
+      .settings(
+        libraryDependencies <++= (scalaVersion) { v: String =>
+          Seq(
+            awsJavaSdk,
+            mockito,
+            junit,
+            powermockJunit,
+            powermockMockito
+          )
+        },
+        testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
+      )
+      .dependsOn(moneyCore)
+
   def projectSettings = basicSettings ++ Seq(
     ScoverageKeys.coverageHighlighting := true,
     ScoverageKeys.coverageMinimum := 90,
@@ -349,8 +367,12 @@ object MoneyBuild extends Build {
     val springAop3 = "org.springframework" % "spring-aop" % "3.2.6.RELEASE"
     val springContext = "org.springframework" % "spring-context" % "4.1.1.RELEASE"
 
+    val awsJavaSdk = "com.amazonaws" % "aws-java-sdk" % "1.10.57" % "provided"
+
     // Test
     val mockito = "org.mockito" % "mockito-core" % "1.9.5" % "test"
+    val powermockMockito = "org.powermock" % "powermock-api-mockito" % "1.6.3" % "test"
+    val powermockJunit = "org.powermock" % "powermock-module-junit4" % "1.6.3" % "test"
     val scalaTest = "org.scalatest" %% "scalatest" % "2.2.3" % "it,test"
     val junit = "junit" % "junit" % "4.11" % "test"
     val junitInterface = "com.novocode" % "junit-interface" % "0.11" % "test->default"


### PR DESCRIPTION
- AmazonWebServiceClient is what most aws-java-sdk platform services use internally.
DynamoDB client is a good example that makes use of this client.
- AmazonWebServiceClient encapsulates the actual instance of the HttpClient and does not
want its clients to interact with it directly. The only way you can do so is through RequestHandlers.
- This implements a request handler to AmazonWebServiceClient that sends the money trace data
to the platform as a HTTP request header. Once the platform service reads the trace data from
the client request object, it is supposed to span on that.
- This was tested just with the AmazonDynamoDBClient but it should work with any of the other
 AWS platform services that make use of the AmazonWebServiceClient internally.