### PR TITLE
Actor support

### DIFF
--- a/money-api/src/main/java/com/comcast/money/annotations/Timed.java
+++ b/money-api/src/main/java/com/comcast/money/annotations/Timed.java
@@ -26,11 +26,11 @@ import java.lang.annotation.Target;
  * <p>
  * This annotation can be used on any method that you want to trace.  Typically this will be
  * used on the controller to indicate a new request trace, as well as external service methods
- * <p>
+ * </p><p>
  * Before the method is called, the a new trace will be started.  If there is an existing
  * trace in context, the existing trace will automatically become the parent trace for the new trace
  * After the method completes, even on exception, the tracer will stop tracing.
- * <p>
+ * </p>
  * <pre>
  *     {@code
  *     {@literal @}WithTracing

--- a/money-api/src/main/java/com/comcast/money/annotations/Traced.java
+++ b/money-api/src/main/java/com/comcast/money/annotations/Traced.java
@@ -23,11 +23,11 @@ import java.lang.annotation.*;
  * <p>
  * This annotation can be used on any method that you want to trace.  Typically this will be
  * used on the controller to indicate a new request trace, as well as external service methods
- * <p>
+ * </p><p>
  * Before the method is called, the a new trace will be started.  If there is an existing
  * trace in context, the existing trace will automatically become the parent trace for the new trace
  * After the method completes, even on exception, the tracer will stop tracing.
- * <p>
+ * </p>
  * <pre>
  *     {@code
  *     {@literal @}Traced

--- a/money-api/src/main/java/com/comcast/money/annotations/TracedData.java
+++ b/money-api/src/main/java/com/comcast/money/annotations/TracedData.java
@@ -27,10 +27,10 @@ import java.lang.annotation.Target;
  * <p>
  * By including this annotation on a parameter, the parameter name
  * and value will be added to the request trace before the method is called.
- * <p>
+ * </p><p>
  * This is equivalent to calling requestTracer.addTracingData at the beginning
  * of a method
- * <pre>
+ * </p><pre>
  *     {@code
  *     {@literal @}Traced
  *      public void measureMePlease(@TracedData("TracMe") String traceMe) {

--- a/money-aspectj/src/main/scala/com/comcast/money/aspectj/TraceAspect.scala
+++ b/money-aspectj/src/main/scala/com/comcast/money/aspectj/TraceAspect.scala
@@ -18,7 +18,7 @@ package com.comcast.money.aspectj
 
 import com.comcast.money.annotations.{ Timed, Traced }
 import com.comcast.money.core._
-import com.comcast.money.core.internal.MDCSupport
+import com.comcast.money.core.internal.{ MDCSupport, ThreadLocalSpanTracer }
 import com.comcast.money.core.logging.TraceLogging
 import com.comcast.money.core.reflect.Reflections
 import org.aspectj.lang.annotation.{ Around, Aspect, Pointcut }
@@ -26,7 +26,7 @@ import org.aspectj.lang.reflect.MethodSignature
 import org.aspectj.lang.{ JoinPoint, ProceedingJoinPoint }
 
 @Aspect
-class TraceAspect extends Reflections with TraceLogging {
+class TraceAspect extends Reflections with TraceLogging with ThreadLocalSpanTracer {
 
   val tracer: Tracer = Money.Environment.tracer
   val mdcSupport: MDCSupport = new MDCSupport()

--- a/money-core-scala/src/main/scala/com/comcast/money/core/Disabled.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/Disabled.scala
@@ -17,6 +17,7 @@
 package com.comcast.money.core
 
 import com.comcast.money.api._
+import com.comcast.money.core.internal.ThreadLocalSpanTracer
 
 // $COVERAGE-OFF
 object DisabledSpanHandler extends SpanHandler {
@@ -24,7 +25,7 @@ object DisabledSpanHandler extends SpanHandler {
   def handle(spanInfo: SpanInfo): Unit = ()
 }
 
-object DisabledTracer extends Tracer {
+object DisabledTracer extends Tracer with ThreadLocalSpanTracer {
 
   val spanFactory: SpanFactory = DisabledSpanFactory
 

--- a/money-core-scala/src/main/scala/com/comcast/money/core/Money.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/Money.scala
@@ -20,6 +20,7 @@ import java.net.InetAddress
 
 import com.comcast.money.api.{ SpanFactory, SpanHandler }
 import com.comcast.money.core.handlers.HandlerChain
+import com.comcast.money.core.internal.ThreadLocalSpanTracer
 import com.typesafe.config.{ Config, ConfigFactory }
 
 case class Money(
@@ -44,7 +45,7 @@ object Money {
     if (enabled) {
       val handler = HandlerChain(conf.getConfig("handling"))
       val factory: SpanFactory = new CoreSpanFactory(handler)
-      val tracer = new Tracer {
+      val tracer = new Tracer with ThreadLocalSpanTracer {
         override val spanFactory: SpanFactory = factory
       }
       val logExceptions = conf.getBoolean("log-exceptions")
@@ -55,6 +56,6 @@ object Money {
 
   }
 
-  private def disabled(applicationName: String, hostName: String): Money =
+  def disabled(applicationName: String, hostName: String): Money =
     Money(false, DisabledSpanHandler, applicationName, hostName, DisabledSpanFactory, DisabledTracer)
 }

--- a/money-core-scala/src/main/scala/com/comcast/money/core/Tracer.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/Tracer.scala
@@ -268,10 +268,7 @@ trait Tracer extends Closeable {
    * @param result The result of the span, this will be Result.success or Result.failed
    */
   def stopSpan(result: Boolean = true): Unit = {
-    SpanLocal.pop() foreach {
-      span =>
-        span.stop(result)
-    }
+    SpanLocal.pop() foreach (_.stop(result))
   }
 
   /**

--- a/money-core-scala/src/main/scala/com/comcast/money/core/Tracer.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/Tracer.scala
@@ -19,12 +19,14 @@ package com.comcast.money.core
 import java.io.Closeable
 
 import com.comcast.money.api.{ Note, Span, SpanFactory }
+import com.comcast.money.core.internal.SpanLocal
 
 /**
  * Primary API to be used for tracing
  */
 trait Tracer extends Closeable {
 
+  val SpanLocal: SpanLocal
   val spanFactory: SpanFactory
 
   /**

--- a/money-core-scala/src/main/scala/com/comcast/money/core/Tracer.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/Tracer.scala
@@ -19,7 +19,6 @@ package com.comcast.money.core
 import java.io.Closeable
 
 import com.comcast.money.api.{ Note, Span, SpanFactory }
-import com.comcast.money.core.internal.SpanLocal
 
 /**
  * Primary API to be used for tracing
@@ -42,6 +41,7 @@ trait Tracer extends Closeable {
    *    }
    *  }
    * }}}
+   *
    * @param key an identifier for the span
    */
   def startSpan(key: String) = {
@@ -68,6 +68,7 @@ trait Tracer extends Closeable {
    *     ...
    *  }
    * }}}
+   *
    * @param key the identifier for the timestamp being captured
    */
   def time(key: String) = withSpan { span =>
@@ -85,6 +86,7 @@ trait Tracer extends Closeable {
    *     ...
    *  }
    * }}}
+   *
    * @param key the identifier for the data being captured
    * @param measure the value being captured
    */
@@ -103,6 +105,7 @@ trait Tracer extends Closeable {
    *     ...
    *  }
    * }}}
+   *
    * @param key the identifier for the data being captured
    * @param measure the value being captured
    * @param propogate propogate to children
@@ -122,6 +125,7 @@ trait Tracer extends Closeable {
    *     ...
    *  }
    * }}}
+   *
    * @param key the identifier for the data being captured
    * @param measure the value being captured
    */
@@ -140,6 +144,7 @@ trait Tracer extends Closeable {
    *     ...
    *  }
    * }}}
+   *
    * @param key the identifier for the data being captured
    * @param measure the value being captured
    * @param propogate propogate to children
@@ -159,6 +164,7 @@ trait Tracer extends Closeable {
    *     ...
    *  }
    * }}}
+   *
    * @param key the identifier for the data being captured
    * @param measure the value being captured
    */
@@ -177,6 +183,7 @@ trait Tracer extends Closeable {
    *     ...
    *  }
    * }}}
+   *
    * @param key the identifier for the data being captured
    * @param measure the value being captured
    * @param propogate propogate to children
@@ -196,6 +203,7 @@ trait Tracer extends Closeable {
    *     ...
    *  }
    * }}}
+   *
    * @param key the identifier for the data being captured
    * @param measure the value being captured
    */
@@ -214,6 +222,7 @@ trait Tracer extends Closeable {
    *     ...
    *  }
    * }}}
+   *
    * @param key the identifier for the data being captured
    * @param measure the value being captured
    * @param propogate propogate to children
@@ -233,6 +242,7 @@ trait Tracer extends Closeable {
    *     ...
    *  }
    * }}}
+   *
    * @param note the [[com.comcast.money.api.Note]] to be added
    */
   def record(note: Note[_]) = withSpan { span =>
@@ -252,6 +262,7 @@ trait Tracer extends Closeable {
    *    }
    *  }
    * }}}
+   *
    * @param result The result of the span, this will be Result.success or Result.failed
    */
   def stopSpan(result: Boolean = true): Unit = {
@@ -275,6 +286,7 @@ trait Tracer extends Closeable {
    *   }
    * }
    * }}}
+   *
    * @param key the identifier for the timer
    */
   def startTimer(key: String) = withSpan { span =>
@@ -297,6 +309,7 @@ trait Tracer extends Closeable {
    *   }
    * }
    * }}}
+   *
    * @param key the identifier for the timer
    */
   def stopTimer(key: String) = withSpan { span =>

--- a/money-core-scala/src/main/scala/com/comcast/money/core/Tracers.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/Tracers.scala
@@ -16,6 +16,7 @@
 
 package com.comcast.money.core
 
+import com.comcast.money.core.internal.SpanLocal
 import com.comcast.money.core.logging.TraceLogging
 
 object Tracers extends TraceLogging {

--- a/money-core-scala/src/main/scala/com/comcast/money/core/akka/MoneyActor.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/akka/MoneyActor.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.akka
+
+import scala.collection.mutable.{ Buffer, Stack }
+import akka.actor.{ Actor, ActorSystem }
+import com.comcast.money.api.Span
+import com.comcast.money.core.Tracer
+import com.comcast.money.core.internal.SpanLocal
+
+import scala.collection.IterableLike
+
+/** Stack-like structure to collect Spans.  */
+trait SpanCarrier extends SpanLocal with IterableLike[SpanCarrier, SpanCarrier] {
+  protected[akka] var spanId: Stack[Span] = new Stack()
+  protected[akka] var parent: Option[SpanCarrier] = None
+
+  override def current: Option[Span] = spanId.headOption orElse (parent.flatMap(_.current))
+
+  override def pop(): Option[Span] = {
+    val filledSpanId = iterator.find(spanCarrier => !spanCarrier.spanId.isEmpty)
+    filledSpanId.flatMap(spanCarrier => {
+      val retValue = spanCarrier.spanId.headOption
+      filledSpanId.get.spanId = spanCarrier.spanId.drop(1)
+      retValue
+    })
+  }
+
+  override def push(span: Span): Unit = {
+    spanId.push(span)
+  }
+
+  override def clear() = {
+    spanId = new Stack()
+    parent = None
+  }
+
+  def iterator: Iterator[SpanCarrier] = new Iterator[SpanCarrier]() {
+    var it: Option[SpanCarrier] = Some(SpanCarrier.this)
+
+    def next(): SpanCarrier = {
+      val retValue = it
+      it = it.flatMap(_.parent)
+      retValue.get
+    }
+
+    def hasNext(): Boolean = it.isDefined
+  }
+
+  def seq: scala.collection.TraversableOnce[SpanCarrier] = {
+    val buf = Buffer[SpanCarrier]()
+    val it = iterator
+    while (it.hasNext) {
+      buf.append(it.next())
+    }
+    buf
+  }
+
+  protected[this] def newBuilder: scala.collection.mutable.Builder[SpanCarrier, SpanCarrier] = ???
+
+  override def addString(b: StringBuilder, start: String, sep: String, end: String): StringBuilder = {
+    b append start
+    b append spanId
+    b append sep
+    b append parent
+    b append end
+  }
+}
+
+object SpanCarrier {
+  /** Just a global SpanCarrier to be used in test cases or simmilar */
+  def root: SpanCarrier = Implicits.root
+  /* Pattern inspired by scala.concurrent.ExecutionContext */
+  object Implicits {
+    implicit lazy val root: SpanCarrier = new RootSpanCarrier
+  }
+
+  def tracing[T](spanName: String, f: (Tracer) => T)(implicit spanCarrier: SpanCarrier, system: ActorSystem): T = {
+    val tracer = MoneyExtension(system).tracer(spanCarrier)
+    tracer.startSpan(spanName)
+    try f(tracer) finally tracer.stopSpan(true)
+  }
+}
+
+/**
+ * Use this abstract class to extend your existing message case classes with.
+ * This allows the usage of the {@code tracer()} in {@code MoneyActor}.
+ *
+ * It is a stack-like structure with a parent stack.
+ */
+class BaseSpanCarrier(implicit parentSpanCarrier: SpanCarrier) extends SpanCarrier {
+  parent = Some(parentSpanCarrier)
+}
+
+/** Wrapper around {@code SpanCarrier} for better naming */
+class RootSpanCarrier extends SpanCarrier {
+}
+
+trait MoneyActor {
+  self: Actor =>
+
+  private lazy val moneyExtension = MoneyExtension(context.system)
+
+  // Exposing Money functionality to the actor
+  def tracer(implicit spanCarrier: SpanCarrier) = moneyExtension.tracer(spanCarrier)
+
+}

--- a/money-core-scala/src/main/scala/com/comcast/money/core/akka/MoneyExtension.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/akka/MoneyExtension.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.akka
+
+import java.net.InetAddress
+
+import akka.actor.{ ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
+import com.comcast.money.api.{ SpanFactory, SpanHandler }
+import com.comcast.money.core.handlers.HandlerChain
+import com.comcast.money.core.internal.SpanThreadLocal
+import com.comcast.money.core.{ CoreSpanFactory, Money, Tracer }
+import com.typesafe.config.{ Config, ConfigFactory, ConfigValue, ConfigValueFactory }
+
+object MoneyExtension extends ExtensionId[MoneyExtensionImpl] with ExtensionIdProvider {
+  //The lookup method is required by ExtensionIdProvider,
+  // so we return ourselves here, this allows us
+  // to configure our extension to be loaded when
+  // the ActorSystem starts up
+  override def lookup = MoneyExtension
+
+  //This method will be called by Akka
+  // to instantiate our Extension
+  override def createExtension(system: ExtendedActorSystem): MoneyExtensionImpl =
+    new MoneyExtensionImpl(system.settings.config.getConfig("money"))
+
+  override def get(system: ActorSystem): MoneyExtensionImpl = super.get(system)
+}
+
+class MoneyExtensionImpl(originalConf: Config) extends Extension {
+  // Since this Extension is a shared instance
+  // per ActorSystem we need to be threadsafe
+  private val conf = originalConf.withValue(
+    "mdc.enabled",
+    ConfigValueFactory.fromAnyRef(false, "SLF4J's MDC is not supported in an actor system")
+  )
+
+  val applicationName = conf.getString("application-name")
+  val enabled = conf.getBoolean("enabled")
+  val hostName = InetAddress.getLocalHost.getCanonicalHostName
+
+  private val (innerHandler: SpanHandler, innerFactory: SpanFactory, innerTracer: ((SpanCarrier) => Tracer), innerLogExceptions: Boolean) = if (enabled) {
+    val handler = HandlerChain(conf.getConfig("handling"))
+    val factory: SpanFactory = new CoreSpanFactory(handler)
+    def tracer(spanCarrier: SpanCarrier): Tracer = {
+      new Tracer {
+        override val SpanLocal = spanCarrier
+        override val spanFactory: SpanFactory = factory
+      }
+    }
+
+    val logExceptions = conf.getBoolean("log-exceptions")
+
+    (handler, factory, (spanCarrier: SpanCarrier) => tracer(spanCarrier), logExceptions)
+  } else {
+    val disabled = Money.disabled(applicationName, hostName)
+    (disabled.handler, disabled.factory, () => disabled.tracer, disabled.logExceptions)
+  }
+
+  val handler = innerHandler
+  val factory = innerFactory
+  def tracer(implicit spanCarrier: SpanCarrier) = {
+    innerTracer(spanCarrier)
+  }
+  val logExceptions = innerLogExceptions
+}

--- a/money-core-scala/src/main/scala/com/comcast/money/core/concurrent/TraceFriendlyExecutionContextExecutor.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/concurrent/TraceFriendlyExecutionContextExecutor.scala
@@ -16,7 +16,7 @@
 
 package com.comcast.money.core.concurrent
 
-import com.comcast.money.core.internal.{ MDCSupport, SpanLocal }
+import com.comcast.money.core.internal.{ MDCSupport, SpanLocal, SpanThreadLocal }
 import com.comcast.money.core.logging.TraceLogging
 import org.slf4j.MDC
 
@@ -25,6 +25,7 @@ import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
 class TraceFriendlyExecutionContextExecutor(wrapped: ExecutionContext)
     extends ExecutionContextExecutor with TraceLogging {
 
+  lazy val SpanLocal = SpanThreadLocal
   lazy val mdcSupport = new MDCSupport()
 
   override def execute(task: Runnable): Unit = {

--- a/money-core-scala/src/main/scala/com/comcast/money/core/concurrent/TraceFriendlyThreadPoolExecutor.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/concurrent/TraceFriendlyThreadPoolExecutor.scala
@@ -18,7 +18,7 @@ package com.comcast.money.core.concurrent
 
 import java.util.concurrent._
 
-import com.comcast.money.core.internal.{ MDCSupport, SpanLocal }
+import com.comcast.money.core.internal.{ MDCSupport, SpanLocal, SpanThreadLocal }
 import com.comcast.money.core.logging.TraceLogging
 import org.slf4j.MDC
 
@@ -55,6 +55,7 @@ class TraceFriendlyThreadPoolExecutor(corePoolSize: Int, maximumPoolSize: Int, k
     with TraceLogging {
 
   lazy val mdcSupport = new MDCSupport()
+  lazy val SpanLocal: SpanLocal = SpanThreadLocal
 
   def this(corePoolSize: Int, maximumPoolSize: Int, keepAliveTime: Long, unit: TimeUnit,
     workQueue: BlockingQueue[Runnable], threadFactory: ThreadFactory,

--- a/money-core-scala/src/main/scala/com/comcast/money/core/reflect/Reflections.scala
+++ b/money-core-scala/src/main/scala/com/comcast/money/core/reflect/Reflections.scala
@@ -22,6 +22,7 @@ import java.lang.reflect.Method
 import com.comcast.money.annotations.TracedData
 import com.comcast.money.api.Note
 import com.comcast.money.core._
+import com.comcast.money.core.internal.SpanLocal
 
 trait Reflections {
 

--- a/money-core-scala/src/test/scala/com/comcast/money/core/TracerSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/TracerSpec.scala
@@ -16,14 +16,14 @@
 
 package com.comcast.money.core
 
-import com.comcast.money.api.{ Note, SpanId, Span, SpanFactory }
+import com.comcast.money.api.{ Note, Span, SpanFactory, SpanId }
 import com.comcast.money.core.handlers.TestData
-import com.comcast.money.core.internal.SpanLocal
+import com.comcast.money.core.internal.{ SpanLocal, SpanThreadLocal, ThreadLocalSpanTracer }
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
-import org.scalatest.{ OneInstancePerTest, BeforeAndAfterEach, Matchers, WordSpec }
+import org.scalatest.{ BeforeAndAfterEach, Matchers, OneInstancePerTest, WordSpec }
 
 class TracerSpec extends WordSpec
     with Matchers with MockitoSugar with TestData with BeforeAndAfterEach with OneInstancePerTest {
@@ -31,9 +31,11 @@ class TracerSpec extends WordSpec
   val mockSpanFactory = mock[SpanFactory]
   val mockSpan = mock[Span]
   val noteCaptor = ArgumentCaptor.forClass(classOf[Note[_]])
-  val underTest = new Tracer {
+  val underTest = new Tracer with ThreadLocalSpanTracer {
     val spanFactory = mockSpanFactory
   }
+
+  val SpanLocal: SpanLocal = SpanThreadLocal
 
   override def beforeEach() = {
     SpanLocal.clear()

--- a/money-core-scala/src/test/scala/com/comcast/money/core/akka/MoneyActorSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/akka/MoneyActorSpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.akka
+
+import com.comcast.money.api.{ Span, SpanId }
+import com.comcast.money.core.CoreSpan
+import com.comcast.money.core.handlers.HandlerChain
+import org.scalatest._
+import org.scalatest.mock.MockitoSugar
+
+class MoneyActorSpec extends WordSpecLike with Matchers with BeforeAndAfterEach with MockitoSugar {
+
+  override def beforeEach() {
+    SpanCarrier.Implicits.root.clear
+  }
+
+  "SpanCarrier" must {
+    "allow simple stacking" in {
+
+      val rootSpan = mock[Span]
+      val childSpan = mock[Span]
+
+      val underTest = new RootSpanCarrier
+
+      underTest.current should be(None)
+      underTest.pop() should be(None)
+
+      underTest.push(rootSpan)
+
+      underTest.pop().get should be(rootSpan)
+      underTest.pop() should be(None)
+
+      underTest.push(rootSpan)
+
+      val child = new BaseSpanCarrier()(underTest)
+      child.push(childSpan)
+
+      child.pop().get should be(childSpan)
+      child.pop().get should be(rootSpan)
+      child.pop() should be(None)
+
+    }
+    "support a reasonable toString method" in {
+      val underTest = new RootSpanCarrier()
+      val child = new BaseSpanCarrier()(underTest)
+      child.push(new CoreSpan(new SpanId("traceId", 23, 42), "StringTest", new HandlerChain(List())))
+
+      underTest.toString should be("RootSpanCarrier(Stack(), None)")
+      child.toString should be("BaseSpanCarrier(Stack(CoreSpan(SpanId~traceId~23~42,StringTest,HandlerChain(List()))), Some(RootSpanCarrier(Stack(), None)))")
+    }
+
+    "support empty iterations" in {
+      val underTest = new RootSpanCarrier()
+
+      underTest.count(span => true) should be(1)
+      underTest.foldLeft(0)(_ + _.spanId.size) should be(0)
+    }
+
+    "support simple iterations" in {
+      val underTest = new RootSpanCarrier()
+      val child = new BaseSpanCarrier()(underTest)
+      underTest.push(mock[Span])
+
+      child.push(mock[Span])
+      child.push(mock[Span])
+
+      // There are two SpanCarrier
+      child.count(span => true) should be(2)
+      // should behave the same:
+      child.seq.size should be(2)
+
+      // And three Spans in total
+      child.foldLeft(0)(_ + _.spanId.size) should be(3)
+
+      child.clear()
+      child.foldLeft(0)(_ + _.spanId.size) should be(0)
+    }
+
+    "support a global SpanCarrier" in {
+      SpanCarrier.Implicits.root.push(mock[Span])
+      SpanCarrier.root.push(mock[Span])
+
+      // It is the same stack - thus they should add up
+      SpanCarrier.Implicits.root.spanId.size should be(2)
+    }
+  }
+}

--- a/money-core-scala/src/test/scala/com/comcast/money/core/akka/MoneyExtensionSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/akka/MoneyExtensionSpec.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.akka
+
+import scala.collection.mutable.ListBuffer
+import akka.actor.{ Actor, ActorLogging, ActorRef, ActorSystem, Props }
+import akka.testkit.{ ImplicitSender, TestKit }
+import com.comcast.money.api.{ SpanHandler, SpanInfo }
+import com.comcast.money.core.handlers.HandlerChain
+import com.typesafe.config.ConfigFactory
+import org.scalatest._
+
+case class ChildTestMessage(val value: Int, originalSender: ActorRef)(implicit parent: SpanCarrier) extends BaseSpanCarrier()(parent)
+
+case class TestMessage(val value: Int) extends RootSpanCarrier
+
+class ChildEchoMoneyActor extends Actor with ActorLogging with MoneyActor {
+  override def receive = {
+    case msg: ChildTestMessage => {
+      implicit val parent = msg
+      tracer.startSpan("MyChildSpan")
+      tracer.record("ChildKey", "child")
+
+      tracer.stopSpan(true)
+      sender ! ChildTestMessage(msg.value + 1, msg.originalSender)
+    }
+  }
+}
+
+class RootEchoMoneyActor extends Actor with ActorLogging with MoneyActor {
+  val childProps = Props[ChildEchoMoneyActor]
+  override def receive = {
+    case msg: ChildTestMessage => {
+      implicit val messag = msg
+
+      tracer.record("FromChild", msg.value)
+      tracer.stopSpan(true)
+      msg.originalSender ! TestMessage(msg.value + 1)
+    }
+    case msg: TestMessage => {
+      implicit val message = msg
+
+      tracer.startSpan("MyRootSpan")
+      tracer.record("MyKey", msg.value)
+
+      context.actorOf(childProps, "ChildActor") ! ChildTestMessage(msg.value, sender)
+    }
+  }
+}
+
+class CollectingSpanHandler extends SpanHandler {
+  val buf = ListBuffer[SpanInfo]()
+  override def handle(span: SpanInfo) = buf += span
+}
+
+class MoneyExtensionSpec() extends TestKit(ActorSystem(
+  "money",
+  ConfigFactory.parseString("""
+                            | money {
+                            |  handling = {
+                            |    async = false
+                            |    handlers = [
+                            |    {
+                            |      class = "com.comcast.money.core.akka.CollectingSpanHandler"
+                            |      log-level = "INFO"
+                            |    }]
+                            |  }
+                            | }""".stripMargin)
+)) with ImplicitSender
+    with WordSpecLike with Matchers with BeforeAndAfterEach with BeforeAndAfterAll {
+
+  override def beforeEach() {
+    SpanCarrier.Implicits.root.clear
+
+    MoneyExtension(system).handler.asInstanceOf[HandlerChain]
+      .handlers(0).asInstanceOf[CollectingSpanHandler].buf.clear()
+  }
+
+  override def afterAll {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  "SpanCarrier" should {
+    "support a simple tracing method" in {
+      import SpanCarrier.Implicits.root
+      val input = 23
+      val actual = SpanCarrier.tracing("Sample Span", tracer => {
+        tracer.record("input", 23)
+        input * 2
+      })
+
+      actual should be(46)
+
+      val spans = MoneyExtension(system).handler.asInstanceOf[HandlerChain]
+        .handlers(0).asInstanceOf[CollectingSpanHandler].buf
+      spans.size should be(1)
+
+      val tracedSpan = spans(0)
+      tracedSpan.name should be("Sample Span")
+      tracedSpan.startTimeMillis() should not be (0)
+      tracedSpan.durationMicros() should not be (0)
+    }
+  }
+
+  "MoneyExtension" must {
+
+    "allow simple Span handling" in {
+      val echo = system.actorOf(Props[RootEchoMoneyActor], "mainactor")
+      echo ! TestMessage(1)
+
+      val x = expectMsg(TestMessage(3))
+
+      val spans = MoneyExtension(system).handler.asInstanceOf[HandlerChain]
+        .handlers(0).asInstanceOf[CollectingSpanHandler].buf
+      spans.size should be(2)
+
+      val actualChildSpan = spans(0)
+      actualChildSpan.name should be("MyChildSpan")
+      actualChildSpan.notes().size should be(1)
+      actualChildSpan.notes().containsKey("ChildKey") should be(true)
+      actualChildSpan.notes().get("ChildKey").value() should be("child")
+
+      val actualRootSpan = spans(1)
+      actualRootSpan.name should be("MyRootSpan")
+      actualRootSpan.notes().size should be(2)
+      actualRootSpan.notes().containsKey("MyKey") should be(true)
+      actualRootSpan.notes().get("MyKey").value() should be(1)
+      actualRootSpan.notes().containsKey("FromChild") should be(true)
+      actualRootSpan.notes().get("FromChild").value() should be(2)
+
+      actualChildSpan.success should be(actualRootSpan.success)
+      actualChildSpan.startTimeMillis() should be >= (actualRootSpan.startTimeMillis())
+      actualChildSpan.id.parentId should be(actualRootSpan.id.selfId)
+    }
+  }
+}

--- a/money-core-scala/src/test/scala/com/comcast/money/core/concurrent/ConcurrentSupport.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/concurrent/ConcurrentSupport.scala
@@ -19,7 +19,7 @@ package com.comcast.money.core.concurrent
 import java.util.concurrent.Callable
 
 import com.comcast.money.api.SpanId
-import com.comcast.money.core.internal.SpanLocal
+import com.comcast.money.core.internal.{ SpanLocal, SpanThreadLocal }
 
 trait ConcurrentSupport {
 
@@ -38,7 +38,7 @@ trait SpanAware {
   def spanId: Option[SpanId] = savedSpanId
 
   def captureCurrentSpan(): Option[SpanId] = {
-    savedSpanId = SpanLocal.current.map(_.info.id)
+    savedSpanId = SpanThreadLocal.current.map(_.info.id)
     savedSpanId
   }
 }

--- a/money-core-scala/src/test/scala/com/comcast/money/core/concurrent/TraceFriendlyExecutionContextExecutorSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/concurrent/TraceFriendlyExecutionContextExecutorSpec.scala
@@ -18,7 +18,7 @@ package com.comcast.money.core.concurrent
 
 import com.comcast.money.api.SpanId
 import com.comcast.money.core.SpecHelpers
-import com.comcast.money.core.internal.SpanLocal
+import com.comcast.money.core.internal.{ SpanLocal, SpanThreadLocal }
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ BeforeAndAfterEach, Matchers, OneInstancePerTest, WordSpec }
@@ -36,6 +36,7 @@ class TraceFriendlyExecutionContextExecutorSpec extends WordSpec
     with BeforeAndAfterEach {
 
   import com.comcast.money.core.concurrent.TraceFriendlyExecutionContextExecutor.Implicits.global
+  val SpanLocal: SpanLocal = SpanThreadLocal
 
   override def beforeEach() = {
     SpanLocal.clear()

--- a/money-core-scala/src/test/scala/com/comcast/money/core/concurrent/TraceFriendlyThreadPoolExecutorSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/concurrent/TraceFriendlyThreadPoolExecutorSpec.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.{ Callable, ExecutorService }
 
 import com.comcast.money.api.SpanId
 import com.comcast.money.core.SpecHelpers
-import com.comcast.money.core.internal.SpanLocal
+import com.comcast.money.core.internal.{ SpanLocal, SpanThreadLocal }
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ Matchers, OneInstancePerTest, WordSpecLike }
 import org.slf4j.MDC
@@ -30,6 +30,7 @@ class TraceFriendlyThreadPoolExecutorSpec
     with MockitoSugar with Matchers with ConcurrentSupport with OneInstancePerTest with SpecHelpers {
 
   val executor: ExecutorService = TraceFriendlyThreadPoolExecutor.newCachedThreadPool
+  val SpanLocal: SpanLocal = SpanThreadLocal
 
   "TraceFriendlyThreadPoolExecutor cachedThreadPool" should {
     "propagate the current span local value" in {

--- a/money-core-scala/src/test/scala/com/comcast/money/core/internal/MDCSupportSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/internal/MDCSupportSpec.scala
@@ -28,7 +28,7 @@ class MDCSupportSpec extends WordSpec with Matchers with BeforeAndAfterEach with
   val spanId = new SpanId()
 
   override def beforeEach() = {
-    SpanLocal.clear()
+    SpanThreadLocal.clear()
   }
 
   "MDCSupport" should {

--- a/money-core-scala/src/test/scala/com/comcast/money/core/internal/SpanLocalSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/internal/SpanLocalSpec.scala
@@ -25,6 +25,8 @@ import org.slf4j.MDC
 class SpanLocalSpec extends WordSpec
     with Matchers with OneInstancePerTest with BeforeAndAfterEach with MockitoSugar with TestData {
 
+  val SpanLocal: SpanLocal = SpanThreadLocal
+
   override def afterEach() = {
     SpanLocal.clear()
   }

--- a/money-core-scala/src/test/scala/com/comcast/money/core/reflect/ReflectionsSpec.scala
+++ b/money-core-scala/src/test/scala/com/comcast/money/core/reflect/ReflectionsSpec.scala
@@ -19,6 +19,7 @@ package com.comcast.money.core.reflect
 import com.comcast.money.annotations.TracedData
 import com.comcast.money.api.Note
 import com.comcast.money.core._
+import com.comcast.money.core.internal.{ SpanLocal, SpanThreadLocal }
 import com.sun.istack.internal.NotNull
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
@@ -32,6 +33,7 @@ class ReflectionsSpec extends WordSpec with Matchers with MockitoSugar with OneI
   val testReflections = new Reflections {
     val tracer: Tracer = mockTracer
   }
+  val spanLocal: SpanLocal = SpanThreadLocal
 
   val samples = new Samples()
   val clazz = samples.getClass

--- a/money-core/src/test/scala/com/comcast/money/reflect/ReflectionsSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/reflect/ReflectionsSpec.scala
@@ -24,6 +24,8 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ Matchers, OneInstancePerTest, WordSpec }
+import com.comcast.money.internal.SpanLocal
+import com.comcast.money.internal.SpanThreadLocal
 
 class ReflectionsSpec extends WordSpec with Matchers with MockitoSugar with OneInstancePerTest {
 
@@ -31,6 +33,7 @@ class ReflectionsSpec extends WordSpec with Matchers with MockitoSugar with OneI
 
   val testReflections = new Reflections {
     val tracer: Tracer = mockTracer
+    val spanLocal: SpanLocal = SpanThreadLocal
   }
 
   val samples = new Samples()

--- a/money-http-client/src/main/scala/com/comcast/money/http/client/HttpTraceAspect.scala
+++ b/money-http-client/src/main/scala/com/comcast/money/http/client/HttpTraceAspect.scala
@@ -18,14 +18,14 @@ package com.comcast.money.http.client
 
 import com.comcast.money.annotations.Traced
 import com.comcast.money.core.{ Formatters, Money, Tracer }
-import com.comcast.money.core.internal.SpanLocal
+import com.comcast.money.core.internal.ThreadLocalSpanTracer
 import org.apache.http.HttpResponse
 import org.apache.http.client.methods.HttpUriRequest
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.{ Around, Aspect, Before, Pointcut }
 
 @Aspect
-class HttpTraceAspect {
+class HttpTraceAspect extends ThreadLocalSpanTracer {
 
   import HttpTraceConfig._
 

--- a/money-http-client/src/main/scala/com/comcast/money/http/client/TraceFriendlyHttpClient.scala
+++ b/money-http-client/src/main/scala/com/comcast/money/http/client/TraceFriendlyHttpClient.scala
@@ -18,20 +18,20 @@ package com.comcast.money.http.client
 
 import java.io.Closeable
 
-import com.comcast.money.core.{ Formatters, Tracer, Money }
+import com.comcast.money.core.{ Formatters, Money, Tracer }
 import com.comcast.money.core.Tracers._
-import com.comcast.money.core.internal.SpanLocal
+import com.comcast.money.core.internal.ThreadLocalSpanTracer
 import org.apache.http.client.methods.HttpUriRequest
 import org.apache.http.client.{ HttpClient, ResponseHandler }
 import org.apache.http.conn.ClientConnectionManager
-import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.params.HttpParams
 import org.apache.http.protocol.HttpContext
 import org.apache.http.{ HttpHost, HttpRequest, HttpResponse }
 
 import scala.util.Try
 
-object TraceFriendlyHttpSupport {
+object TraceFriendlyHttpSupport extends ThreadLocalSpanTracer {
 
   def wrapSimpleExecute(httpRequest: HttpRequest, tracer: Tracer)(f: => HttpResponse): HttpResponse = {
     var responseCode = 0L

--- a/money-http-client/src/test/scala/com/comcast/money/http/client/HttpTraceAspectSpec.scala
+++ b/money-http-client/src/test/scala/com/comcast/money/http/client/HttpTraceAspectSpec.scala
@@ -21,7 +21,7 @@ import java.io.{ ByteArrayInputStream, InputStream }
 import com.comcast.money.annotations.Traced
 import com.comcast.money.api.SpanId
 import com.comcast.money.core._
-import com.comcast.money.core.internal.SpanLocal
+import com.comcast.money.core.internal.{ SpanLocal, SpanThreadLocal }
 import org.apache.http._
 import org.apache.http.client.methods.HttpUriRequest
 import org.apache.http.client.{ HttpClient, ResponseHandler }
@@ -50,6 +50,7 @@ class HttpTraceAspectSpec
   val mockHttpEntity: HttpEntity = mock[HttpEntity]
   val mockHttpResponseHandler: ResponseHandler[String] = mock[ResponseHandler[String]]
   val responseEntityStream: InputStream = new ByteArrayInputStream("test-response".getBytes)
+  val SpanLocal = SpanThreadLocal
 
   // -- SAMPLE METHODS WEAVED BY OUR ASPECT
   @Traced("methodWithHttpCallUsingEntityUtils")

--- a/money-http-client/src/test/scala/com/comcast/money/http/client/TraceFriendlyHttpClientSpec.scala
+++ b/money-http-client/src/test/scala/com/comcast/money/http/client/TraceFriendlyHttpClientSpec.scala
@@ -19,8 +19,8 @@ package com.comcast.money.http.client
 import java.io.Closeable
 
 import com.comcast.money.api.SpanId
-import com.comcast.money.core.{ Formatters => CoreSpanId, SpecHelpers, Tracer }
-import com.comcast.money.core.internal.SpanLocal
+import com.comcast.money.core.{ SpecHelpers, Tracer, Formatters => CoreSpanId }
+import com.comcast.money.core.internal.{ SpanLocal, SpanThreadLocal }
 import org.apache.http.client.methods.{ CloseableHttpResponse, HttpUriRequest }
 import org.apache.http.client.{ HttpClient, ResponseHandler }
 import org.apache.http.impl.client.CloseableHttpClient
@@ -40,6 +40,7 @@ class TraceFriendlyHttpClientSpec extends WordSpec with SpecHelpers
   val httpHost = new HttpHost("localhost")
   val httpContext = mock[HttpContext]
   val spanId = new SpanId()
+  val SpanLocal = SpanThreadLocal
 
   when(httpResponse.getStatusLine).thenReturn(statusLine)
   when(statusLine.getStatusCode).thenReturn(200)

--- a/money-java-servlet/src/main/scala/com/comcast/money/java/servlet/TraceFilter.scala
+++ b/money-java-servlet/src/main/scala/com/comcast/money/java/servlet/TraceFilter.scala
@@ -21,7 +21,7 @@ import javax.servlet.http.{ HttpServletRequest, HttpServletRequestWrapper, HttpS
 
 import com.comcast.money.core.Formatters._
 import com.comcast.money.core.Money
-import com.comcast.money.core.internal.SpanLocal
+import com.comcast.money.core.internal.ThreadLocalSpanTracer
 import org.slf4j.LoggerFactory
 
 import scala.util.{ Failure, Success }
@@ -30,7 +30,7 @@ import scala.util.{ Failure, Success }
  * A Java Servlet 2.5 Filter.  Examines the inbound http request, and will set the
  * trace context for the request if the money trace header is found
  */
-class TraceFilter extends Filter {
+class TraceFilter extends Filter with ThreadLocalSpanTracer {
 
   private val MoneyTraceHeader = "X-MoneyTrace"
   private val logger = LoggerFactory.getLogger(classOf[TraceFilter])

--- a/money-java-servlet/src/test/scala/com/comcast/money/java/servlet/TraceFilterSpec.scala
+++ b/money-java-servlet/src/test/scala/com/comcast/money/java/servlet/TraceFilterSpec.scala
@@ -20,7 +20,7 @@ import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 import javax.servlet.{ FilterChain, FilterConfig }
 
 import com.comcast.money.api.SpanId
-import com.comcast.money.core.internal.SpanLocal
+import com.comcast.money.core.internal.{ SpanLocal, SpanThreadLocal }
 import org.mockito.Mockito._
 import org.scalatest.OptionValues._
 import org.scalatest.mock.MockitoSugar
@@ -33,7 +33,7 @@ class TraceFilterSpec extends WordSpec with Matchers with OneInstancePerTest wit
   val mockFilterChain = mock[FilterChain]
 
   val existingSpanId = new SpanId()
-
+  val SpanLocal = SpanThreadLocal
   val underTest = new TraceFilter()
 
   val MoneyTraceFormat = "trace-id=%s;parent-id=%s;span-id=%s"

--- a/money-spring3/src/main/scala/com/comcast/money/spring3/SpringTracer.scala
+++ b/money-spring3/src/main/scala/com/comcast/money/spring3/SpringTracer.scala
@@ -18,6 +18,7 @@ package com.comcast.money.spring3
 
 import com.comcast.money.api.Note
 import com.comcast.money.core._
+import com.comcast.money.core.internal.ThreadLocalSpanTracer
 import org.springframework.stereotype.Component
 
 /**
@@ -25,7 +26,7 @@ import org.springframework.stereotype.Component
  * Money tracer in the event that Money or tracing is disabled
  */
 @Component
-class SpringTracer extends Tracer {
+class SpringTracer extends Tracer with ThreadLocalSpanTracer {
 
   override val spanFactory = Money.Environment.factory
   private var tracer = Money.Environment.tracer

--- a/money-spring3/src/main/scala/com/comcast/money/spring3/TracedMethodInterceptor.scala
+++ b/money-spring3/src/main/scala/com/comcast/money/spring3/TracedMethodInterceptor.scala
@@ -19,7 +19,7 @@ package com.comcast.money.spring3
 import java.lang.reflect.Method
 
 import com.comcast.money.annotations.Traced
-import com.comcast.money.core.internal.MDCSupport
+import com.comcast.money.core.internal.{ MDCSupport, ThreadLocalSpanTracer }
 import com.comcast.money.core.logging.TraceLogging
 import com.comcast.money.core.reflect.Reflections
 import org.aopalliance.aop.Advice
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Component
 @Component
 class TracedMethodInterceptor @Autowired() (@Qualifier("springTracer") val tracer: SpringTracer)
     extends MethodInterceptor
-    with Reflections with TraceLogging {
+    with Reflections with TraceLogging with ThreadLocalSpanTracer {
 
   val mdcSupport = new MDCSupport()
 

--- a/project/MoneyBuild.scala
+++ b/project/MoneyBuild.scala
@@ -46,8 +46,11 @@ object MoneyBuild extends Build {
       .configs( IntegrationTest )
       .settings(projectSettings: _*)
       .settings(
-        libraryDependencies ++= {
+        libraryDependencies <++= (scalaVersion) { v: String =>
           Seq(
+            akkaActor(v),
+            akkaSlf4j(v),
+            akkaTestkit(v),
             slf4j,
             log4jbinding,
             metricsCore,

--- a/project/MoneyBuild.scala
+++ b/project/MoneyBuild.scala
@@ -51,6 +51,7 @@ object MoneyBuild extends Build {
             akkaActor(v),
             akkaSlf4j(v),
             akkaTestkit(v),
+            spray(v),
             slf4j,
             log4jbinding,
             metricsCore,
@@ -323,6 +324,9 @@ object MoneyBuild extends Build {
     def akkaSlf4j(scalaVersion: String) = "com.typesafe.akka" %% "akka-slf4j" % getAkkaVersion(scalaVersion) % "runtime"
     def akkaTestkit(scalaVersion: String) = "com.typesafe.akka" %% "akka-testkit" % getAkkaVersion(scalaVersion) %
       "it,test"
+
+    // Spray
+    def spray(scalaVersion: String) = "io.spray" %% "spray-can" % "1.3.3"
 
     // Joda
     val jodaTime = "joda-time" % "joda-time" % "2.1"


### PR DESCRIPTION
This is the first part of a PR to support Akka's actor system with money

The first step is to support a consistent storage for span's in the context of actors exchanging messages.
This means spans has to be started and stopped manually as depicted in the test case `MoneyExtensionSpec`.

Further PRs will add convenience methods to support automatic starting & stopping for messages flowing through the actor system
