### PR TITLE
adds new factory method for creating a child span from an x-moneytrace header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ensime*
 .cache
 */target/**
 */.idea

--- a/money-api/src/main/java/com/comcast/money/api/SpanFactory.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanFactory.java
@@ -31,7 +31,7 @@ public interface SpanFactory {
      * @return a child span with trace id and parent id from trace context header or a new root span if the
      * traceContextHeader is malformed.
      */
-    Span childOrRootSpan(String childName, String traceContextHeader);
+    Span newSpanFromHeader(String childName, String traceContextHeader);
 
     Span childSpan(String childName, Span span);
 

--- a/money-api/src/main/java/com/comcast/money/api/SpanFactory.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanFactory.java
@@ -22,6 +22,17 @@ public interface SpanFactory {
 
     Span newSpan(SpanId spanId, String spanName);
 
+    /**
+     * Continues a trace by creating a child span from the given x-moneytrace header
+     * value.
+     *
+     * @param childName - the name of the child span to create
+     * @param traceContextHeader - value of x-moneytrace header
+     * @return a child span with trace id and parent id from trace context header or a new root span if the
+     * traceContextHeader is malformed.
+     */
+    Span childOrRootSpan(String childName, String traceContextHeader);
+
     Span childSpan(String childName, Span span);
 
     Span childSpan(String childName, Span span, boolean sticky);

--- a/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
@@ -63,7 +63,7 @@ object DisabledSpanFactory extends SpanFactory {
 
   def newSpan(spanName: String): Span = DisabledSpan
 
-  def childOrRootSpan(childName: String, traceContextHeader: String): Span = DisabledSpan
+  def newSpanFromHeader(childName: String, traceContextHeader: String): Span = DisabledSpan
 
   def childSpan(childName: String, span: Span): Span = DisabledSpan
 

--- a/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
@@ -63,6 +63,8 @@ object DisabledSpanFactory extends SpanFactory {
 
   def newSpan(spanName: String): Span = DisabledSpan
 
+  def childOrRootSpan(childName: String, traceContextHeader: String): Span = DisabledSpan
+
   def childSpan(childName: String, span: Span): Span = DisabledSpan
 
   def childSpan(childName: String, span: Span, sticky: Boolean): Span = DisabledSpan

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
@@ -70,7 +70,7 @@ class CoreSpanFactorySpec extends WordSpec with Matchers with MockitoSugar with 
     "create a child span from a well-formed x-moneytrace header" in {
       val parentSpan = underTest.newSpan("parent")
       val traceContextHeader = Formatters.toHttpHeader(parentSpan.info.id)
-      val childSpan = underTest.childOrRootSpan("child", traceContextHeader)
+      val childSpan = underTest.newSpanFromHeader("child", traceContextHeader)
 
       childSpan.info.id.traceId shouldBe parentSpan.info.id.traceId
       childSpan.info.id.parentId shouldBe parentSpan.info.id.selfId
@@ -80,7 +80,7 @@ class CoreSpanFactorySpec extends WordSpec with Matchers with MockitoSugar with 
     "create a root span from a malformed x-moneytrace header" in {
       val parentSpan = underTest.newSpan("parent")
       val traceContextHeader = "mangled header value"
-      val childSpan = underTest.childOrRootSpan("child", traceContextHeader)
+      val childSpan = underTest.newSpanFromHeader("child", traceContextHeader)
 
       childSpan.info.id.traceId == parentSpan.info.id.traceId shouldBe false
       childSpan.info.id.parentId == parentSpan.info.id.selfId shouldBe false


### PR DESCRIPTION
Adds a new method `childOrRootSpan` on `SpanFactory` that makes it easy to create a child span from a given `x-moneytrace` context header.

If the given `x-moneytrace` header is well formed then a new child span is created with the trace ID and parent ID from the header.

If the `x-moneytrace` header is malformed then a new root span is created.

This removes the need for client code to parse the `x-moneytrace` header and ensure a child span is created using the trace and parent IDs from the header.