### PR TITLE
Correcting typo in variable name

### DIFF
--- a/money-java-servlet/src/main/scala/com/comcast/money/java/servlet/TraceFilter.scala
+++ b/money-java-servlet/src/main/scala/com/comcast/money/java/servlet/TraceFilter.scala
@@ -44,13 +44,13 @@ class TraceFilter extends Filter {
 
     SpanLocal.clear()
     val httpRequest = new HttpServletRequestWrapper(request.asInstanceOf[HttpServletRequest])
-    val incomingTraceId = Option(httpRequest.getHeader(MoneyTraceHeader)) map { incTrcaceId =>
+    val incomingTraceId = Option(httpRequest.getHeader(MoneyTraceHeader)) map { incTraceId =>
       // attempt to parse the incoming trace id (its a Try)
-      fromHttpHeader(incTrcaceId) match {
+      fromHttpHeader(incTraceId) match {
         case Success(spanId) => SpanLocal.push(factory.newSpan(spanId, "servlet"))
-        case Failure(ex) => logger.warn("Unable to parse money trace for request header '{}'", incTrcaceId)
+        case Failure(ex) => logger.warn("Unable to parse money trace for request header '{}'", incTraceId)
       }
-      incTrcaceId
+      incTraceId
     }
 
     incomingTraceId.foreach { traceId =>


### PR DESCRIPTION
I noticed com.comcast.money.java.servlet.TraceFilter made repeated
reference to an incTrcaceId.  The pedant and copy editor trapped inside
this programmer's body could not let this alone.

This change is solely to correct this typo and restore some sense of
inner peace to myself and any other similarly afflicted folks who may
happen upon this source code.