### PR TITLE
Add support for tracing methods asynchronously

### DIFF
--- a/money-api/src/main/java/com/comcast/money/annotations/Traced.java
+++ b/money-api/src/main/java/com/comcast/money/annotations/Traced.java
@@ -75,4 +75,11 @@ public @interface Traced {
      * @return The array of exception classes that will be ignored
      */
     Class[] ignoredExceptions() default {};
+
+    /**
+     * Indicates that the method being traced performs an asynchronous task and returns an instance
+     * that would indicate when the task has completed.
+     * @return Whether or not the traced method is asynchronous
+     */
+    boolean async() default false;
 }

--- a/money-core/src/main/resources/META-INF/services/com.comcast.money.core.async.AsyncTracingService
+++ b/money-core/src/main/resources/META-INF/services/com.comcast.money.core.async.AsyncTracingService
@@ -1,0 +1,1 @@
+com.comcast.money.core.async.ScalaFutureTracingService

--- a/money-core/src/main/scala/com/comcast/money/core/async/AsyncTracingService.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/async/AsyncTracingService.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.async
+
+import java.util.ServiceLoader
+
+import scala.collection.JavaConverters._
+
+object AsyncTracingService {
+  private lazy val services = loadServices()
+
+  def findTracingService(future: AnyRef): Option[AsyncTracingService] =
+    services.find(_.supports(future))
+
+  private def loadServices() =
+    ServiceLoader.load(classOf[AsyncTracingService], classOf[AsyncTracingService].getClassLoader).asScala.toList
+}
+
+trait AsyncTracingService {
+  def supports(future: AnyRef): Boolean
+  def whenDone(future: AnyRef, f: (Any, Throwable) => Unit): AnyRef
+}

--- a/money-core/src/main/scala/com/comcast/money/core/async/ScalaFutureTracingService.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/async/ScalaFutureTracingService.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2015 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.async
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+class ScalaFutureTracingService extends AsyncTracingService {
+  implicit private val context: ExecutionContext = ExecutionContext.global
+
+  override def supports(future: AnyRef): Boolean = future != null && future.isInstanceOf[Future[_]]
+
+  override def whenDone(value: AnyRef, f: (Any, Throwable) => Unit): Future[_] = {
+    value.asInstanceOf[Future[_]].transform(result => {
+      f(result, null)
+      result
+    }, throwable => {
+      f(null, throwable)
+      throwable
+    })
+  }
+}


### PR DESCRIPTION
Adds support for tracing methods that return objects indicating asynchronous completion of a given task.  The span itself remains open until the task is completed as determined by an implementation of `AsyncTraceService` that can support the return type of the method and register for completion.  The duration of the method execution itself is logged via a timer on the span.

This PR includes support for Scala's `Future[T]` trait.