### PR TITLE
Remove deprecation warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val money = Project("money", file("."))
   publishLocal := {},
   publish := {}
 )
-.aggregate(moneyApi, moneyCore, moneyAspectj, moneyHttpClient, moneyJavaServlet, moneyKafka, moneySpring, moneySpring3, moneyWire)
+.aggregate(moneyApi, moneyCore, moneyAspectj, moneyHttpClient, moneyJavaServlet, moneyWire, moneyKafka, moneySpring, moneySpring3)
 
 lazy val moneyApi =
   Project("money-api", file("./money-api"))

--- a/money-aspectj/src/test/scala/com/comcast/money/aspectj/TraceAspectSpec.scala
+++ b/money-aspectj/src/test/scala/com/comcast/money/aspectj/TraceAspectSpec.scala
@@ -23,7 +23,7 @@ import org.aspectj.lang.ProceedingJoinPoint
 import org.mockito.Mockito._
 import org.scalatest._
 import org.scalatest.concurrent.Eventually
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.slf4j.MDC
 
 import scala.concurrent.{ Await, Future, Promise }

--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpan.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpan.scala
@@ -20,7 +20,7 @@ import java.lang.Long
 
 import com.comcast.money.api._
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.collection.concurrent.TrieMap
 
 /**
@@ -84,7 +84,7 @@ case class CoreSpan(
       endTimeMicros,
       calculateDuration,
       success,
-      noted.toMap[String, Note[_]])
+      noted.toMap[String, Note[_]].asJava)
 
   private def calculateDuration: Long =
     if (endTimeMicros <= 0L && startTimeMicros <= 0L)

--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpanFactory.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpanFactory.scala
@@ -19,7 +19,7 @@ package com.comcast.money.core
 import com.comcast.money.api.{ Span, SpanFactory, SpanHandler, SpanId }
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class CoreSpanFactory(handler: SpanHandler) extends SpanFactory {
 
@@ -52,7 +52,7 @@ class CoreSpanFactory(handler: SpanHandler) extends SpanFactory {
     val child = newSpan(info.id.newChildId, childName)
 
     if (sticky) {
-      info.notes.values
+      info.notes.values.asScala
         .filter(_.isSticky)
         .foreach(child.record)
     }
@@ -61,7 +61,7 @@ class CoreSpanFactory(handler: SpanHandler) extends SpanFactory {
   }
 
   def newSpan(spanId: SpanId, spanName: String): Span =
-    new CoreSpan(
+    CoreSpan(
       id = spanId,
       name = spanName,
       handler = handler)

--- a/money-core/src/main/scala/com/comcast/money/core/async/AsyncNotifier.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/async/AsyncNotifier.scala
@@ -18,7 +18,7 @@ package com.comcast.money.core.async
 
 import com.typesafe.config.Config
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 case class AsyncNotifier(handlers: Seq[AsyncNotificationHandler]) {
   def resolveHandler(future: AnyRef): Option[AsyncNotificationHandler] =
@@ -29,7 +29,7 @@ object AsyncNotifier {
   import AsyncNotificationHandlerFactory.create
 
   def apply(config: Config): AsyncNotifier = {
-    val handlers = config.getConfigList("handlers").map(create)
-    new AsyncNotifier(handlers)
+    val handlers = config.getConfigList("handlers").asScala.map(create)
+    AsyncNotifier(handlers)
   }
 }

--- a/money-core/src/main/scala/com/comcast/money/core/handlers/HandlerChain.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/handlers/HandlerChain.scala
@@ -20,7 +20,7 @@ import com.comcast.money.api.{ SpanHandler, SpanInfo }
 import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 case class HandlerChain(handlers: Seq[SpanHandler]) extends SpanHandler {
 
@@ -42,7 +42,7 @@ object HandlerChain {
   import HandlerFactory.create
 
   def apply(config: Config): SpanHandler = {
-    val handlers = config.getConfigList("handlers").map(create)
+    val handlers = config.getConfigList("handlers").asScala.map(create)
 
     if (config.getBoolean("async")) {
       new AsyncSpanHandler(scala.concurrent.ExecutionContext.global, HandlerChain(handlers))

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
@@ -18,7 +18,7 @@ package com.comcast.money.core
 
 import com.comcast.money.api.{ Note, SpanHandler, SpanId }
 import com.comcast.money.core.handlers.TestData
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ Matchers, WordSpec }
 
 class CoreSpanFactorySpec extends WordSpec with Matchers with MockitoSugar with TestData {

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanSpec.scala
@@ -16,11 +16,11 @@
 
 package com.comcast.money.core
 
-import com.comcast.money.api.{ SpanInfo, SpanHandler, Note, SpanId }
+import com.comcast.money.api.{ SpanInfo, SpanHandler, SpanId }
 import com.comcast.money.core.handlers.TestData
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ Matchers, WordSpec }
 
 class CoreSpanSpec extends WordSpec with Matchers with TestData with MockitoSugar {

--- a/money-core/src/test/scala/com/comcast/money/core/TracerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/TracerSpec.scala
@@ -22,7 +22,7 @@ import com.comcast.money.core.internal.SpanLocal
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ OneInstancePerTest, BeforeAndAfterEach, Matchers, WordSpec }
 
 class TracerSpec extends WordSpec

--- a/money-core/src/test/scala/com/comcast/money/core/async/AsyncNotifierSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/async/AsyncNotifierSpec.scala
@@ -22,7 +22,7 @@ import com.typesafe.config.ConfigFactory
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.{ Matchers, OneInstancePerTest, WordSpecLike }
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 import scala.concurrent.Future
 

--- a/money-core/src/test/scala/com/comcast/money/core/async/DirectExecutionContextSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/async/DirectExecutionContextSpec.scala
@@ -19,7 +19,7 @@ package com.comcast.money.core.async
 import com.comcast.money.core.SpecHelpers
 import com.comcast.money.core.concurrent.ConcurrentSupport
 import org.scalatest.{ Matchers, OneInstancePerTest, WordSpecLike }
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 class DirectExecutionContextSpec
   extends WordSpecLike

--- a/money-core/src/test/scala/com/comcast/money/core/async/ScalaFutureNotificationHandlerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/async/ScalaFutureNotificationHandlerSpec.scala
@@ -19,7 +19,7 @@ package com.comcast.money.core.async
 import com.comcast.money.core.SpecHelpers
 import com.comcast.money.core.concurrent.ConcurrentSupport
 import org.scalatest.{ Matchers, OneInstancePerTest, WordSpecLike }
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 import org.mockito.Matchers.{ any, eq => argEq }
 

--- a/money-core/src/test/scala/com/comcast/money/core/concurrent/TraceFriendlyExecutionContextExecutorSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/concurrent/TraceFriendlyExecutionContextExecutorSpec.scala
@@ -20,7 +20,7 @@ import com.comcast.money.api.SpanId
 import com.comcast.money.core.SpecHelpers
 import com.comcast.money.core.internal.SpanLocal
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ BeforeAndAfterEach, Matchers, OneInstancePerTest, WordSpec }
 import org.slf4j.MDC
 

--- a/money-core/src/test/scala/com/comcast/money/core/concurrent/TraceFriendlyThreadPoolExecutorSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/concurrent/TraceFriendlyThreadPoolExecutorSpec.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.{ Callable, ExecutorService }
 import com.comcast.money.api.SpanId
 import com.comcast.money.core.SpecHelpers
 import com.comcast.money.core.internal.SpanLocal
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ Matchers, OneInstancePerTest, WordSpecLike }
 import org.slf4j.MDC
 

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/AsyncSpanHandlerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/AsyncSpanHandlerSpec.scala
@@ -18,7 +18,7 @@ package com.comcast.money.core.handlers
 
 import com.comcast.money.api.{ SpanHandler, SpanInfo }
 import com.comcast.money.core.SpecHelpers
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ Matchers, WordSpec }
 
 class AsyncSpanHandlerSpec extends WordSpec with Matchers with MockitoSugar with TestData with SpecHelpers {

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/HandlerChainSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/HandlerChainSpec.scala
@@ -20,7 +20,7 @@ import com.comcast.money.api.SpanHandler
 import com.typesafe.config.ConfigFactory
 import org.mockito.Mockito
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ Matchers, WordSpec }
 
 class HandlerChainSpec extends WordSpec with Matchers with MockitoSugar with TestData {

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/LoggingSpanHandlerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/LoggingSpanHandlerSpec.scala
@@ -21,7 +21,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ Matchers, OneInstancePerTest, WordSpec }
 import org.slf4j.Logger
 

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/MetricsHandlerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/MetricsHandlerSpec.scala
@@ -20,7 +20,7 @@ import com.codahale.metrics.{ Meter, Histogram, MetricRegistry }
 import com.typesafe.config.Config
 import org.mockito.Mockito._
 import org.mockito.Matchers._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ OneInstancePerTest, Matchers, WordSpec }
 
 class MetricsHandlerSpec extends WordSpec with Matchers with MockitoSugar with TestData with OneInstancePerTest {

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/SpanLogFormatterSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/SpanLogFormatterSpec.scala
@@ -21,7 +21,7 @@ import com.comcast.money.core.CoreSpanInfo
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{ Matchers, WordSpec }
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.collection._
 
 class SpanLogFormatterSpec extends WordSpec with Matchers {
@@ -45,7 +45,7 @@ class SpanLogFormatterSpec extends WordSpec with Matchers {
     name = "key",
     appName = "unknown",
     host = "host",
-    notes = Map("bob" -> Note.of("bob", "craig"), "what" -> Note.of("what", 1L), "when" -> Note.of("when", 2L)),
+    notes = Map[String, Note[_]]("bob" -> Note.of("bob", "craig"), "what" -> Note.of("what", 1L), "when" -> Note.of("when", 2L)).asJava,
     success = true)
 
   val withNull = CoreSpanInfo(
@@ -58,7 +58,7 @@ class SpanLogFormatterSpec extends WordSpec with Matchers {
     name = "key",
     appName = "unknown",
     host = "host",
-    notes = Map("empty" -> Note.of("empty", null)),
+    notes = Map[String, Note[_]]("empty" -> Note.of("empty", null)).asJava,
     success = true)
 
   "A LogEmitter must" must {

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/StructuredLogSpanHandlerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/StructuredLogSpanHandlerSpec.scala
@@ -19,7 +19,7 @@ package com.comcast.money.core.handlers
 import com.typesafe.config.ConfigFactory
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ Matchers, OneInstancePerTest, WordSpec }
 import org.slf4j.Logger
 

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/TestData.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/TestData.scala
@@ -34,7 +34,7 @@ class NonConfiguredHandler extends SpanHandler {
 
 trait TestData {
 
-  import scala.collection.JavaConversions._
+  import scala.collection.JavaConverters._
 
   val testStringNote = Note.of("str", "bar")
   val testLongNote = Note.of("lng", 200L)
@@ -51,7 +51,7 @@ trait TestData {
     name = "test-span",
     appName = "test",
     host = "localhost",
-    notes = Map("str" -> testStringNote, "lng" -> testLongNote, "dbl" -> testDoubleNote, "bool" -> testBooleanNote))
+    notes = Map[String, Note[_]]("str" -> testStringNote, "lng" -> testLongNote, "dbl" -> testDoubleNote, "bool" -> testBooleanNote).asJava)
 
   val testSpan = CoreSpan(new SpanId(), "test-span", null)
 
@@ -65,5 +65,5 @@ trait TestData {
     name = "test-span",
     appName = "test",
     host = "localhost",
-    notes = Map("str" -> testStringNote, "lng" -> testLongNote, "dbl" -> testDoubleNote, "bool" -> testBooleanNote))
+    notes = Map[String, Note[_]]("str" -> testStringNote, "lng" -> testLongNote, "dbl" -> testDoubleNote, "bool" -> testBooleanNote).asJava)
 }

--- a/money-core/src/test/scala/com/comcast/money/core/internal/MDCSupportSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/internal/MDCSupportSpec.scala
@@ -20,6 +20,7 @@ import com.comcast.money.api.SpanId
 import org.scalatest.{ BeforeAndAfterEach, Matchers, OneInstancePerTest, WordSpec }
 import org.slf4j.MDC
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 class MDCSupportSpec extends WordSpec with Matchers with BeforeAndAfterEach with OneInstancePerTest {
@@ -49,19 +50,15 @@ class MDCSupportSpec extends WordSpec with Matchers with BeforeAndAfterEach with
       MDC.get("moneyTrace") shouldBe null
     }
     "not propogate MDC if disabled" in {
-      import scala.collection.JavaConversions._
-
       val mdcContext: mutable.Map[_, _] = mutable.HashMap("FINGERPRINT" -> "print")
       val disabled = new MDCSupport(false)
-      disabled.propogateMDC(Some(mdcContext))
+      disabled.propogateMDC(Some(mdcContext.asJava))
       MDC.get("FINGERPRINT") shouldBe null
     }
     "propogate MDC if not disabled" in {
-      import scala.collection.JavaConversions._
-
       val mdcContext: mutable.Map[_, _] = mutable.HashMap("FINGERPRINT" -> "print")
 
-      testMDCSupport.propogateMDC(Some(mdcContext))
+      testMDCSupport.propogateMDC(Some(mdcContext.asJava))
       MDC.get("FINGERPRINT") shouldBe "print"
     }
     "clear MDC if given an empty context" in {

--- a/money-core/src/test/scala/com/comcast/money/core/internal/SpanLocalSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/internal/SpanLocalSpec.scala
@@ -18,7 +18,7 @@ package com.comcast.money.core.internal
 
 import com.comcast.money.api.SpanId
 import com.comcast.money.core.handlers.TestData
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ OneInstancePerTest, BeforeAndAfterEach, Matchers, WordSpec }
 import org.slf4j.MDC
 

--- a/money-core/src/test/scala/com/comcast/money/core/logging/TraceLoggingSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/logging/TraceLoggingSpec.scala
@@ -17,7 +17,7 @@
 package com.comcast.money.core.logging
 
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ Matchers, OneInstancePerTest, WordSpec }
 import org.slf4j.Logger
 

--- a/money-core/src/test/scala/com/comcast/money/core/metrics/MetricRegistryFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/metrics/MetricRegistryFactorySpec.scala
@@ -21,7 +21,7 @@ import com.typesafe.config.Config
 import org.mockito.Mockito._
 import org.scalatest.Matchers._
 import org.scalatest._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 object MockMetricRegistryFactory extends MetricRegistryFactory with MockitoSugar {
   lazy val mockRegistry = mock[MetricRegistry]

--- a/money-core/src/test/scala/com/comcast/money/core/reflect/ReflectionsSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/reflect/ReflectionsSpec.scala
@@ -22,7 +22,7 @@ import com.comcast.money.core._
 import com.sun.istack.internal.NotNull
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ Matchers, OneInstancePerTest, WordSpec }
 
 class ReflectionsSpec extends WordSpec with Matchers with MockitoSugar with OneInstancePerTest {
@@ -100,25 +100,21 @@ class ReflectionsSpec extends WordSpec with Matchers with MockitoSugar with OneI
       tds.size shouldBe 5
 
       val strNote = tds(0).get
-      strNote shouldBe a[Note[String]]
       strNote.value shouldBe "str"
       strNote.name shouldBe "STRING"
       strNote.isSticky shouldBe false
 
       val lngNote = tds(1).get
-      lngNote shouldBe a[Note[Long]]
       lngNote.value shouldBe 100L
       lngNote.name shouldBe "LONG"
       lngNote.isSticky shouldBe false
 
       val dblNote = tds(2).get
-      dblNote shouldBe a[Note[Double]]
       dblNote.value shouldBe 3.14
       dblNote.name shouldBe "DOUBLE"
       dblNote.isSticky shouldBe false
 
       val boolNote = tds(3).get
-      boolNote shouldBe a[Note[java.lang.Boolean]]
       boolNote.value shouldBe true
       boolNote.name shouldBe "BOOLEAN"
       boolNote.isSticky shouldBe false

--- a/money-http-client/src/test/scala/com/comcast/money/http/client/HttpTraceAspectSpec.scala
+++ b/money-http-client/src/test/scala/com/comcast/money/http/client/HttpTraceAspectSpec.scala
@@ -29,7 +29,7 @@ import org.apache.http.util.EntityUtils
 import org.aspectj.lang.ProceedingJoinPoint
 import org.mockito.Mockito._
 import org.scalatest._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 import scala.concurrent.duration._
 

--- a/money-http-client/src/test/scala/com/comcast/money/http/client/TraceFriendlyHttpClientSpec.scala
+++ b/money-http-client/src/test/scala/com/comcast/money/http/client/TraceFriendlyHttpClientSpec.scala
@@ -28,7 +28,7 @@ import org.apache.http.protocol.HttpContext
 import org.apache.http.{ HttpHost, HttpResponse, StatusLine }
 import org.mockito.Mockito._
 import org.scalatest._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 class TraceFriendlyHttpClientSpec extends WordSpec with SpecHelpers
   with Matchers with MockitoSugar with OneInstancePerTest with BeforeAndAfterEach {

--- a/money-java-servlet/src/test/scala/com/comcast/money/java/servlet/TraceFilterSpec.scala
+++ b/money-java-servlet/src/test/scala/com/comcast/money/java/servlet/TraceFilterSpec.scala
@@ -24,7 +24,7 @@ import com.comcast.money.core.internal.SpanLocal
 import com.comcast.money.core.Formatters.StringWithB3HeaderConversion
 import org.mockito.Mockito._
 import org.scalatest.OptionValues._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ BeforeAndAfter, Matchers, OneInstancePerTest, WordSpec }
 
 class TraceFilterSpec extends WordSpec with Matchers with OneInstancePerTest with BeforeAndAfter with MockitoSugar {

--- a/money-kafka/src/test/scala/com/comcast/money/kafka/KafkaSpanHandlerSpec.scala
+++ b/money-kafka/src/test/scala/com/comcast/money/kafka/KafkaSpanHandlerSpec.scala
@@ -16,16 +16,17 @@
 
 package com.comcast.money.kafka
 
+import com.comcast.money.api.Note
 import com.comcast.money.{ api, core }
-import com.typesafe.config.{ ConfigFactory, Config }
-import kafka.message.{ GZIPCompressionCodec, CompressionCodec }
+import com.typesafe.config.{ Config, ConfigFactory }
+import kafka.message.{ CompressionCodec, GZIPCompressionCodec }
 import kafka.producer.{ KeyedMessage, Producer }
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 trait MockProducerMaker extends ProducerMaker {
 
@@ -66,7 +67,7 @@ class KafkaSpanHandlerSpec extends WordSpec
       startTimeMillis = 1L,
       success = true,
       durationMicros = 35L,
-      notes = Map("what" -> api.Note.of("what", 1L), "when" -> api.Note.of("when", 2L), "bob" -> api.Note.of("bob", "craig")))
+      notes = Map[String, Note[_]]("what" -> api.Note.of("what", 1L), "when" -> api.Note.of("when", 2L), "bob" -> api.Note.of("bob", "craig")).asJava)
   }
 
   "A KafkaEmitter" should {

--- a/money-spring3/src/test/scala/com/comcast/money/spring3/TracedMethodAdvisorSpec.scala
+++ b/money-spring3/src/test/scala/com/comcast/money/spring3/TracedMethodAdvisorSpec.scala
@@ -16,7 +16,7 @@
 
 package com.comcast.money.spring3
 
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ Matchers, WordSpec }
 import org.springframework.aop.support.StaticMethodMatcherPointcut
 

--- a/money-spring3/src/test/scala/com/comcast/money/spring3/TracedMethodInterceptorScalaSpec.scala
+++ b/money-spring3/src/test/scala/com/comcast/money/spring3/TracedMethodInterceptorScalaSpec.scala
@@ -23,7 +23,7 @@ import com.sun.istack.internal.NotNull
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ BeforeAndAfterEach, Matchers, WordSpec }
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component

--- a/money-wire/src/test/scala/com/comcast/money/wire/AvroConversionSpec.scala
+++ b/money-wire/src/test/scala/com/comcast/money/wire/AvroConversionSpec.scala
@@ -24,7 +24,7 @@ class AvroConversionSpec extends WordSpec with Matchers with Inspectors {
 
   import AvroConversions._
 
-  import scala.collection.JavaConversions._
+  import scala.collection.JavaConverters._
 
   "Avro Conversion" should {
     "roundtrip" in {
@@ -36,13 +36,13 @@ class AvroConversionSpec extends WordSpec with Matchers with Inspectors {
         startTimeMillis = 1L,
         success = true,
         durationMicros = 35L,
-        notes = Map(
+        notes = Map[String, Note[_]](
           "what" -> Note.of("what", 1L),
           "when" -> Note.of("when", 2L),
           "bob" -> Note.of("bob", "craig"),
           "none" -> Note.of("none", null),
           "bool" -> Note.of("bool", true),
-          "dbl" -> Note.of("dbl", 1.0))).asInstanceOf[SpanInfo]
+          "dbl" -> Note.of("dbl", 1.0)).asJava).asInstanceOf[SpanInfo]
 
       val bytes = orig.convertTo[Array[Byte]]
       val roundtrip = bytes.convertTo[SpanInfo]

--- a/money-wire/src/test/scala/com/comcast/money/wire/JsonConversionSpec.scala
+++ b/money-wire/src/test/scala/com/comcast/money/wire/JsonConversionSpec.scala
@@ -24,7 +24,7 @@ class JsonConversionSpec extends WordSpec with Matchers with Inspectors {
 
   import JsonConversions._
 
-  import scala.collection.JavaConversions._
+  import scala.collection.JavaConverters._
 
   val orig = CoreSpanInfo(
     id = new SpanId("foo", 1L),
@@ -34,13 +34,13 @@ class JsonConversionSpec extends WordSpec with Matchers with Inspectors {
     startTimeMillis = 1L,
     success = true,
     durationMicros = 35L,
-    notes = Map(
+    notes = Map[String, Note[_]](
       "what" -> Note.of("what", 1L),
       "when" -> Note.of("when", 2L),
       "bob" -> Note.of("bob", "craig"),
       "none" -> Note.of("none", null),
       "bool" -> Note.of("bool", true),
-      "dbl" -> Note.of("dbl", 1.0))).asInstanceOf[SpanInfo]
+      "dbl" -> Note.of("dbl", 1.0)).asJava).asInstanceOf[SpanInfo]
 
   "Json Conversion" should {
     "roundtrip" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
   .exclude("commons-logging", "commons-logging")
 
   val springAop3 = "org.springframework" % "spring-aop" % "3.2.18.RELEASE"
-  val springContext = "org.springframework" % "spring-context" % "4.1.9.RELEASE"
+  val springContext = "org.springframework" % "spring-context" % "4.3.17.RELEASE"
 
   // Test
   val mockito = "org.mockito" % "mockito-core" % "1.9.5" % "test"


### PR DESCRIPTION
Removed many deprecation warnings, especially around `JavaConversions`

Some warnings remain.  For example, where we override http client things, the interface we are implemented is marked as `@deprecated`, so we in essence cannot do anything until that is removed.

Also, updated to spring 4.3.17 to remove security warning.

**Note: we will need to remove spring 3 support to eliminate all spring related security warnings.  Will have to do that in a future PR.**