### PR TITLE
Update spring, httpclient, databind versions

### DIFF
--- a/samples/samples-springmvc/pom.xml
+++ b/samples/samples-springmvc/pom.xml
@@ -9,8 +9,9 @@
     <version>0.0.1-SNAPSHOT</version>
     <packaging>war</packaging>
     <properties>
-        <spring.version>4.0.5.RELEASE</spring.version>
+        <spring.version>4.3.17.RELEASE</spring.version>
         <jackson.version>2.2.3</jackson.version>
+        <jackson.databind.version>2.8.11.1</jackson.databind.version>
         <jetty.version>8.1.5.v20120716</jetty.version>
         <jetty.jsp.version>8.1.4.v20120524</jetty.jsp.version>
         <money.version>0.9.0-RC2</money.version>
@@ -109,7 +110,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.2.1</version>
+            <version>4.5.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -126,7 +127,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Update Spring version to 4.3.17, Apache HTTP Client to 4.5.6
and Jackson databind to 2.8.11.1 in order to prevent any
potential security vulnerabilities