### PR TITLE
Explicitly declares checked exceptions in Scala decorator of HttpClient

### DIFF
--- a/money-http-client/src/main/scala/com/comcast/money/http/client/TraceFriendlyHttpClient.scala
+++ b/money-http-client/src/main/scala/com/comcast/money/http/client/TraceFriendlyHttpClient.scala
@@ -16,18 +16,18 @@
 
 package com.comcast.money.http.client
 
-import java.io.Closeable
+import java.io.{Closeable, IOException}
 
-import com.comcast.money.core.{ Formatters, Tracer, Money }
+import com.comcast.money.core.{Formatters, Money, Tracer}
 import com.comcast.money.core.Tracers._
 import com.comcast.money.core.internal.SpanLocal
 import org.apache.http.client.methods.HttpUriRequest
-import org.apache.http.client.{ HttpClient, ResponseHandler }
+import org.apache.http.client.{ClientProtocolException, HttpClient, ResponseHandler}
 import org.apache.http.conn.ClientConnectionManager
-import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.params.HttpParams
 import org.apache.http.protocol.HttpContext
-import org.apache.http.{ HttpHost, HttpRequest, HttpResponse }
+import org.apache.http.{HttpHost, HttpRequest, HttpResponse}
 
 import scala.util.Try
 
@@ -77,18 +77,26 @@ class TraceFriendlyHttpClient(wrapee: HttpClient) extends HttpClient with java.i
 
   override def getConnectionManager: ClientConnectionManager = wrapee.getConnectionManager
 
+  @throws(classOf[IOException])
+  @throws(classOf[ClientProtocolException])
   override def execute(request: HttpUriRequest): HttpResponse = wrapSimpleExecute(request, tracer) {
     wrapee.execute(request)
   }
 
+  @throws(classOf[IOException])
+  @throws(classOf[ClientProtocolException])
   override def execute(request: HttpUriRequest, context: HttpContext): HttpResponse = wrapSimpleExecute(request, tracer) {
     wrapee.execute(request, context)
   }
 
+  @throws(classOf[IOException])
+  @throws(classOf[ClientProtocolException])
   override def execute(target: HttpHost, request: HttpRequest): HttpResponse = wrapSimpleExecute(request, tracer) {
     wrapee.execute(target, request)
   }
 
+  @throws(classOf[IOException])
+  @throws(classOf[ClientProtocolException])
   override def execute(target: HttpHost, request: HttpRequest, context: HttpContext): HttpResponse = wrapSimpleExecute(
     request, tracer) {
     wrapee.execute(target, request, context)
@@ -101,24 +109,33 @@ class TraceFriendlyHttpClient(wrapee: HttpClient) extends HttpClient with java.i
    * then we are screwed
    */
 
+  @throws(classOf[IOException])
+  @throws(classOf[ClientProtocolException])
   override def execute[T](request: HttpUriRequest, responseHandler: ResponseHandler[_ <: T]): T = {
     wrapee.execute(request, responseHandler)
   }
 
+  @throws(classOf[IOException])
+  @throws(classOf[ClientProtocolException])
   override def execute[T](request: HttpUriRequest, responseHandler: ResponseHandler[_ <: T],
     context: HttpContext): T = {
     wrapee.execute(request, responseHandler, context)
   }
 
+  @throws(classOf[IOException])
+  @throws(classOf[ClientProtocolException])
   override def execute[T](target: HttpHost, request: HttpRequest, responseHandler: ResponseHandler[_ <: T]): T = {
     wrapee.execute(target, request, responseHandler)
   }
 
+  @throws(classOf[IOException])
+  @throws(classOf[ClientProtocolException])
   override def execute[T](target: HttpHost, request: HttpRequest, responseHandler: ResponseHandler[_ <: T],
     context: HttpContext): T = {
     wrapee.execute(target, request, responseHandler, context)
   }
 
+  @throws(classOf[IOException])
   override def close(): Unit = {
     if (wrapee.isInstanceOf[CloseableHttpClient])
       wrapee.asInstanceOf[CloseableHttpClient].close()


### PR DESCRIPTION
For Java consumers of `TraceFriendlyHttpClient` class the overridden `execute` methods appear to not throw any checked exceptions.  However, as simple wrappers around `HttpClient#execute` they can still throw `IOException` and `ClientProtocolException`.  Normally this is fine, the checked exception can still be intercepted by the caller.

However, if the `TraceFriendlyHttpClient` class is proxied, e.g. via an aspect, when one of those checked exceptions is thrown it is intercepted by the JRE that will then compare the type of the checked exception against the list of checked exceptions declared by the method.  If the type isn't in the list the exception is wrapped in the unchecked `java.lang.reflect.UndeclaredThrowableException`.  This can result in the weird case where the caller is trying to invoke `HttpClient#execute` and is correctly handling the possible `IOException` but the exception being thrown is `UndeclaredThrowableException`.