### PR TITLE
Refactor AsyncNotificationHandler to accept return type of traced method

### DIFF
--- a/money-core/src/main/scala/com/comcast/money/core/async/AbstractAsyncNotificationHandler.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/async/AbstractAsyncNotificationHandler.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.async
+
+import scala.reflect.ClassTag
+import scala.util.Try
+
+/**
+ * Provides a simple implementation of `AsyncNotificationHandler` where the future type matches the
+ * generic type argument
+ *
+ * @param ev the generic future type class tag
+ * @tparam T the generic future type
+ */
+abstract class AbstractAsyncNotificationHandler[T <: AnyRef](implicit ev: ClassTag[T]) extends AsyncNotificationHandler {
+
+  /**
+   * Determines if this handler can support the type and instance of the given future
+   * returned by the method bring traced
+   *
+   * @param futureClass the type of the future as declared on the method being traced
+   * @param future the future instance returned by the method being traced
+   * @return `true` if this handler can register completion for the future instance
+   */
+  override def supports(futureClass: Class[_], future: AnyRef): Boolean =
+    futureClass == ev.runtimeClass && futureClass.isInstance(future)
+
+  /**
+   * Registers a callback function to be invoked when the future has completed
+   *
+   * @param futureClass the type of the future as declared on the method being traced
+   * @param future the future instance for which the callback is to be registered
+   * @param f the callback function
+   * @return the future instance with the completion callback registered
+   */
+  override def whenComplete(futureClass: Class[_], future: AnyRef)(f: Try[_] => Unit): AnyRef =
+    future match {
+      case matched: T if supports(futureClass, future) => whenComplete(matched, f)
+      case _ => future
+    }
+
+  /**
+   * Implemented by derived type to register the callback function to be invoked when the future
+   * has completed
+   *
+   * @param future the future instance for which the callback is to be registered
+   * @param f the callback function
+   * @return the future instance with the completion callback registered
+   */
+  def whenComplete(future: T, f: Try[_] => Unit): T
+}

--- a/money-core/src/main/scala/com/comcast/money/core/async/AsyncNotificationHandler.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/async/AsyncNotificationHandler.scala
@@ -19,6 +19,6 @@ package com.comcast.money.core.async
 import scala.util.Try
 
 trait AsyncNotificationHandler {
-  def supports(future: AnyRef): Boolean
-  def whenComplete(future: AnyRef, f: Try[_] => Unit): AnyRef
+  def supports(futureClass: Class[_], future: AnyRef): Boolean
+  def whenComplete(futureClass: Class[_], future: AnyRef)(f: Try[_] => Unit): AnyRef
 }

--- a/money-core/src/main/scala/com/comcast/money/core/async/AsyncNotifier.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/async/AsyncNotifier.scala
@@ -22,9 +22,10 @@ import scala.collection.JavaConverters._
 
 case class AsyncNotifier(handlers: Seq[AsyncNotificationHandler]) {
   def resolveHandler(futureClass: Class[_], future: AnyRef): Option[AsyncNotificationHandler] =
-    if (futureClass != null && future != null)
-      handlers.find(_.supports(futureClass, future))
-    else None
+    (futureClass, future) match {
+      case (_: Class[_], _: AnyRef) => handlers.find(_.supports(futureClass, future))
+      case _ => None
+    }
 }
 
 object AsyncNotifier {

--- a/money-core/src/main/scala/com/comcast/money/core/async/AsyncNotifier.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/async/AsyncNotifier.scala
@@ -21,11 +21,12 @@ import com.typesafe.config.Config
 import scala.collection.JavaConverters._
 
 case class AsyncNotifier(handlers: Seq[AsyncNotificationHandler]) {
-  def resolveHandler(futureClass: Class[_], future: AnyRef): Option[AsyncNotificationHandler] =
-    (futureClass, future) match {
-      case (_: Class[_], _: AnyRef) => handlers.find(_.supports(futureClass, future))
-      case _ => None
-    }
+  def resolveHandler(futureClass: Class[_], future: AnyRef): Option[AsyncNotificationHandler] = for {
+    fc <- Option(futureClass)
+    f <- Option(future)
+
+    handler <- handlers.find(_.supports(fc, f))
+  } yield handler
 }
 
 object AsyncNotifier {

--- a/money-core/src/main/scala/com/comcast/money/core/async/AsyncNotifier.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/async/AsyncNotifier.scala
@@ -21,8 +21,10 @@ import com.typesafe.config.Config
 import scala.collection.JavaConverters._
 
 case class AsyncNotifier(handlers: Seq[AsyncNotificationHandler]) {
-  def resolveHandler(future: AnyRef): Option[AsyncNotificationHandler] =
-    Option(future).flatMap(f => handlers.find(_.supports(f)))
+  def resolveHandler(futureClass: Class[_], future: AnyRef): Option[AsyncNotificationHandler] =
+    if (futureClass != null && future != null)
+      handlers.find(_.supports(futureClass, future))
+    else None
 }
 
 object AsyncNotifier {

--- a/money-core/src/main/scala/com/comcast/money/core/async/ScalaFutureNotificationHandler.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/async/ScalaFutureNotificationHandler.scala
@@ -19,13 +19,10 @@ package com.comcast.money.core.async
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Try }
 
-class ScalaFutureNotificationHandler extends AsyncNotificationHandler {
+class ScalaFutureNotificationHandler extends AbstractAsyncNotificationHandler[Future[_]] {
   implicit val executionContext: ExecutionContext = new DirectExecutionContext
 
-  override def supports(future: AnyRef): Boolean =
-    future != null && future.isInstanceOf[Future[_]]
-
-  override def whenComplete(future: AnyRef, f: Try[_] => Unit): Future[_] = {
+  override def whenComplete(future: Future[_], f: Try[_] => Unit): Future[_] =
     future.asInstanceOf[Future[_]].transform(result => {
       f(Try(result))
       result
@@ -33,5 +30,4 @@ class ScalaFutureNotificationHandler extends AsyncNotificationHandler {
       f(Failure(throwable))
       throwable
     })
-  }
 }

--- a/money-core/src/test/scala/com/comcast/money/core/async/AsyncNotifierSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/async/AsyncNotifierSpec.scala
@@ -76,39 +76,52 @@ class AsyncNotifierSpec
     }
     "find AsyncNotificationHandler that supports Future" in {
       val mockHandler = mock[AsyncNotificationHandler]
+      val futureClass = classOf[Future[_]]
       val future = mock[Future[String]]
 
       val asyncNotifier = AsyncNotifier(Seq(mockHandler))
-      doReturn(true).when(mockHandler).supports(future)
+      doReturn(true).when(mockHandler).supports(futureClass, future)
 
-      val result = asyncNotifier.resolveHandler(future)
+      val result = asyncNotifier.resolveHandler(futureClass, future)
 
-      verify(mockHandler, times(1)).supports(future)
+      verify(mockHandler, times(1)).supports(futureClass, future)
 
       result.isDefined shouldEqual true
       result.get shouldEqual mockHandler
     }
-    "not find any AsyncNotificationHandler for null" in {
+    "not find any AsyncNotificationHandler for null futureClass" in {
+      val mockHandler = mock[AsyncNotificationHandler]
+      val future = mock[Future[String]]
+
+      val asyncNotifier = AsyncNotifier(Seq(mockHandler))
+      doReturn(true).when(mockHandler).supports(any[Class[_]], any)
+
+      val result = asyncNotifier.resolveHandler(null, future)
+
+      result.isEmpty shouldEqual true
+      verify(mockHandler, never).supports(any[Class[_]], any)
+    }
+    "not find any AsyncNotificationHandler for null future" in {
       val mockHandler = mock[AsyncNotificationHandler]
 
       val asyncNotifier = AsyncNotifier(Seq(mockHandler))
-      doReturn(true).when(mockHandler).supports(any)
+      doReturn(true).when(mockHandler).supports(any[Class[_]], any)
 
-      val result = asyncNotifier.resolveHandler(null)
+      val result = asyncNotifier.resolveHandler(classOf[Future[_]], null)
 
       result.isEmpty shouldEqual true
-      verify(mockHandler, never).supports(any)
+      verify(mockHandler, never).supports(any[Class[_]], any)
     }
     "not find AsyncNotificationHandler when not supported" in {
       val mockHandler = mock[AsyncNotificationHandler]
 
       val asyncNotifier = AsyncNotifier(Seq(mockHandler))
-      doReturn(false).when(mockHandler).supports(any)
+      doReturn(false).when(mockHandler).supports(any[Class[_]], any)
 
-      val result = asyncNotifier.resolveHandler(new Object)
+      val result = asyncNotifier.resolveHandler(classOf[Future[_]], new Object)
 
       result.isEmpty shouldEqual true
-      verify(mockHandler, times(1)).supports(any)
+      verify(mockHandler, times(1)).supports(any[Class[_]], any)
     }
   }
 }

--- a/money-core/src/test/scala/com/comcast/money/core/async/TestData.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/async/TestData.scala
@@ -23,11 +23,11 @@ class ConfiguredNotificationHandler extends ConfigurableNotificationHandler {
   var calledConfigure: Boolean = false
 
   override def configure(config: Config): Unit = calledConfigure = true
-  override def supports(future: AnyRef): Boolean = false
-  override def whenComplete(future: AnyRef, f: Try[_] => Unit): AnyRef = null
+  override def supports(futureClass: Class[_], future: AnyRef): Boolean = false
+  override def whenComplete(futureClass: Class[_], future: AnyRef)(f: Try[_] => Unit): AnyRef = null
 }
 
 class NonConfiguredNotificationHandler extends AsyncNotificationHandler {
-  override def supports(future: AnyRef): Boolean = false
-  override def whenComplete(future: AnyRef, f: Try[_] => Unit): AnyRef = null
+  override def supports(futureClass: Class[_], future: AnyRef): Boolean = false
+  override def whenComplete(futureClass: Class[_], future: AnyRef)(f: Try[_] => Unit): AnyRef = null
 }


### PR DESCRIPTION
Refactors `AsyncNotificationHandler` to accept the `Class[_]` of the return type of the `@Traced` annotated method.

This was an oversight on my part.  The declared return type of the annotated method is important to know that the return value can be safely replaced.  For example, if a method was declared that returned a type that extends from `Future[T]`:

```scala
@Traced(value = "my-method", async = true)
def myMethod(): MyFuture[String] = ???
```

The aspect would capture the return value and try to look up a compatible handler.  The `ScalaFutureNotificationHandler` would be passed the `AnyRef` return value instance which does implement `Future[_]` so it would try to handle it, but in calling `Future#transform` would end up returning a different instance that isn't compatible with `MyFuture[String]`.  This will certainly end up with an exception at runtime.

Also added an abstract class to simplify implementation of `AsyncNotificationHandler` by capturing the reified class tag of the implementing class and using that to determine whether or not that handler supports a particular `Class[_]` and `AnyRef` out of the box.