### PR TITLE
Use List instead of Stack for thread local spans

### DIFF
--- a/money-core/src/main/scala/com/comcast/money/core/internal/SpanLocal.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/internal/SpanLocal.scala
@@ -23,11 +23,11 @@ import scala.collection.mutable.Stack
 trait SpanContext {
   def push(span: Span): Unit
 
-  def pop: Option[Span]
+  def pop(): Option[Span]
 
   def current: Option[Span]
 
-  def clear: Unit
+  def clear(): Unit
 }
 
 /**
@@ -37,7 +37,7 @@ trait SpanContext {
 object SpanLocal extends SpanContext {
 
   // A stack of span ids for the current thread
-  private[this] val threadLocalCtx = new ThreadLocal[Stack[Span]]
+  private[this] val threadLocalCtx = new ThreadLocal[List[Span]]
 
   private lazy val mdcSupport = new MDCSupport()
 
@@ -46,36 +46,33 @@ object SpanLocal extends SpanContext {
   override def current: Option[Span] = Option(threadLocalCtx.get).flatMap(_.headOption)
 
   override def push(span: Span): Unit =
-    if (span != null)
+    if (span != null) {
       Option(threadLocalCtx.get) match {
-        case Some(stack) =>
-          stack.push(span)
-          setSpanMDC(Some(span.info.id))
-          setSpanNameMDC(Some(span.info.name))
+        case Some(current) =>
+          threadLocalCtx.set(span :: current)
         case None =>
-          threadLocalCtx.set(new Stack[Span]())
-          push(span)
+          threadLocalCtx.set(List(span))
       }
+      setSpanMDC(Some(span.info.id))
+      setSpanNameMDC(Some(span.info.name))
+    }
 
   override def pop(): Option[Span] =
-    Option(threadLocalCtx.get).map {
-      stack =>
-        // remove the current span in scope for this thread
-        val spanId = stack.pop()
-
-        // rolls back the mdc span to the parent if present, if none then it will be cleared
-        val head = stack.headOption
+    threadLocalCtx.get match {
+      case span :: rest =>
+        threadLocalCtx.set(rest)
+        val head = rest.headOption
         setSpanMDC(head.map(_.info.id))
         setSpanNameMDC(head.map(_.info.name))
-
-        spanId
+        Some(span)
+      case _ => None
     }
 
   /**
    * Clears the entire call stack for the thread
    */
-  override def clear() = {
-    if (threadLocalCtx != null) threadLocalCtx.remove()
+  override def clear(): Unit = {
+    threadLocalCtx.remove()
 
     setSpanMDC(None)
     setSpanNameMDC(None)

--- a/money-core/src/main/scala/com/comcast/money/core/internal/SpanLocal.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/internal/SpanLocal.scala
@@ -72,7 +72,7 @@ object SpanLocal extends SpanContext {
    * Clears the entire call stack for the thread
    */
   override def clear(): Unit = {
-    threadLocalCtx.remove()
+    if (threadLocalCtx != null) threadLocalCtx.remove()
 
     setSpanMDC(None)
     setSpanNameMDC(None)

--- a/money-core/src/test/scala/com/comcast/money/core/internal/SpanLocalSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/internal/SpanLocalSpec.scala
@@ -62,6 +62,12 @@ class SpanLocalSpec extends WordSpec
         popped shouldEqual Some(nested)
         SpanLocal.current shouldEqual Some(testSpan)
       }
+      "pop with no current Span" in {
+        SpanLocal.clear()
+
+        val popped = SpanLocal.pop()
+        popped shouldEqual None
+      }
       "set the MDC value on push" in {
         SpanLocal.push(testSpan)
 


### PR DESCRIPTION
[`scala.collection.mutable.Stack`](https://www.scala-lang.org/api/2.12.0/scala/collection/mutable/Stack.html) is deprecated as of Scala 2.12 and the recommendation is to just use a [`scala.collection.immutable.List`](https://www.scala-lang.org/api/2.12.0/scala/collection/immutable/List.html) instead.