### PR TITLE
Refactor method interception into a shared trait for AspectJ and Spring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: false
 language: scala
 jdk: oraclejdk8
 

--- a/money-core/src/main/scala/com/comcast/money/core/logging/MethodTracer.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/logging/MethodTracer.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.logging
+
+import java.lang.reflect.Method
+
+import com.comcast.money.annotations.{ Timed, Traced }
+import com.comcast.money.core.{ Money, Tracer }
+import com.comcast.money.core.async.AsyncNotifier
+import com.comcast.money.core.internal.{ MDCSupport, SpanLocal }
+import com.comcast.money.core.reflect.Reflections
+import org.slf4j.MDC
+
+import scala.util.{ Failure, Success, Try }
+
+trait MethodTracer extends Reflections with TraceLogging {
+  val tracer: Tracer = Money.Environment.tracer
+  val asyncNotifier: AsyncNotifier = Money.Environment.asyncNotifier
+  val mdcSupport: MDCSupport = new MDCSupport()
+
+  def traceMethod(method: Method, annotation: Traced, args: Array[AnyRef], proceed: () => AnyRef): AnyRef = {
+    val key = annotation.value()
+
+    tracer.startSpan(key)
+    recordTracedParameters(method, args, tracer)
+
+    Try { proceed() } match {
+      case Success(result) if annotation.async() =>
+        traceAsyncResult(method, annotation, result) match {
+          case Some(future) =>
+            future
+          case None =>
+            tracer.stopSpan(true)
+            result
+        }
+      case Success(result) =>
+        tracer.stopSpan(true)
+        result
+      case Failure(exception) =>
+        logException(exception)
+        tracer.stopSpan(exceptionMatches(exception, annotation.ignoredExceptions()))
+        throw exception
+    }
+  }
+
+  def timeMethod(method: Method, annotation: Timed, proceed: () => AnyRef): AnyRef = {
+    val key = annotation.value()
+    try {
+      tracer.startTimer(key)
+      proceed()
+    } finally {
+      tracer.startTimer(key)
+    }
+  }
+
+  def traceAsyncResult(
+    method: Method,
+    annotation: Traced,
+    returnValue: AnyRef): Option[AnyRef] = for {
+
+    // resolve an async notification handler that supports the result
+    handler <- asyncNotifier.resolveHandler(method.getReturnType, returnValue)
+
+    // pop the current span from the stack as it will not be stopped by the tracer
+    span <- SpanLocal.pop()
+    // capture the current MDC context to be applied on the callback thread
+    mdc = Option(MDC.getCopyOfContextMap)
+
+    result = handler.whenComplete(method.getReturnType, returnValue) { completed =>
+      // reapply the MDC onto the callback thread
+      mdcSupport.propogateMDC(mdc)
+
+      // determine if the future completed successfully or exceptionally
+      val result = completed match {
+        case Success(_) => true
+        case Failure(exception) =>
+          logException(exception)
+          exceptionMatches(exception, annotation.ignoredExceptions())
+      }
+
+      // stop the captured span with the success/failure flag
+      span.stop(result)
+      // clear the MDC from the callback thread
+      MDC.clear()
+    }
+  } yield result
+}

--- a/money-core/src/main/scala/com/comcast/money/core/logging/MethodTracer.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/logging/MethodTracer.scala
@@ -63,7 +63,7 @@ trait MethodTracer extends Reflections with TraceLogging {
       tracer.startTimer(key)
       proceed()
     } finally {
-      tracer.startTimer(key)
+      tracer.stopTimer(key)
     }
   }
 

--- a/money-core/src/test/scala/com/comcast/money/core/logging/MethodTracerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/logging/MethodTracerSpec.scala
@@ -1,0 +1,264 @@
+package com.comcast.money.core.logging
+
+import java.lang.reflect.Method
+
+import com.comcast.money.annotations.{Timed, Traced, TracedData}
+import com.comcast.money.api.Span
+import com.comcast.money.core.Tracer
+import com.comcast.money.core.async.{AsyncNotificationHandler, AsyncNotifier}
+import com.comcast.money.core.internal.{MDCSupport, SpanContext}
+import org.mockito.Matchers.{any => argAny}
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
+
+import scala.util.{Failure, Success, Try}
+
+class MethodTracerSpec extends WordSpec with Matchers with MockitoSugar with OneInstancePerTest {
+
+  val mockTracer: Tracer = mock[Tracer]
+  val mockAsyncNotifier: AsyncNotifier = mock[AsyncNotifier]
+  val mockMdcSupport: MDCSupport = mock[MDCSupport]
+  val mockSpanContext: SpanContext = mock[SpanContext]
+
+  val tracedMethod: Method = classOf[Samples].getMethod("tracedMethod")
+  val tracedMethodWithParameters: Method = classOf[Samples].getMethod("tracedMethod")
+  val tracedMethodWithIgnoredExceptions: Method = classOf[Samples].getMethod("tracedMethodWithIgnoredExceptions")
+  val tracedAsyncMethod: Method = classOf[Samples].getMethod("tracedAsyncMethod")
+  val tracedAsyncMethodWithIgnoredExceptions: Method = classOf[Samples].getMethod("tracedAsyncMethodWithIgnoredExceptions")
+  val timedMethod: Method = classOf[Samples].getMethod("timedMethod")
+
+  val methodTracer: MethodTracer = new MethodTracer {
+    override val tracer: Tracer = mockTracer
+    override val asyncNotifier: AsyncNotifier = mockAsyncNotifier
+    override val mdcSupport: MDCSupport = mockMdcSupport
+    override val spanContext: SpanContext = mockSpanContext
+  }
+
+  "MethodTracer" should {
+    "trace methods" should {
+      "that return successfully" in {
+
+        val method = tracedMethod
+        val traced = method.getDeclaredAnnotation(classOf[Traced])
+
+        val empty = Array.empty[AnyRef]
+        val proceed = mock[() => String]
+
+        when(proceed.apply()).thenReturn("result")
+
+        val result = methodTracer.traceMethod(method, traced, empty, proceed)
+
+        verify(mockTracer).startSpan(traced.value())
+        verify(mockTracer).stopSpan(true)
+
+        result shouldBe "result"
+      }
+      "that throws" in {
+
+        val method = tracedMethod
+        val traced = method.getDeclaredAnnotation(classOf[Traced])
+
+        val empty = Array.empty[AnyRef]
+        val proceed = mock[() => String]
+
+        when(proceed.apply()).thenThrow(new IllegalArgumentException())
+
+        assertThrows[IllegalArgumentException] {
+          methodTracer.traceMethod(method, traced, empty, proceed)
+        }
+
+        verify(mockTracer).startSpan(traced.value())
+        verify(mockTracer).stopSpan(false)
+      }
+      "that throws an ignored exception" in {
+        val method = tracedMethodWithIgnoredExceptions
+        val traced = method.getDeclaredAnnotation(classOf[Traced])
+
+        val empty = Array.empty[AnyRef]
+        val proceed = mock[() => String]
+
+        when(proceed.apply()).thenThrow(new IllegalArgumentException())
+
+        assertThrows[IllegalArgumentException] {
+          methodTracer.traceMethod(method, traced, empty, proceed)
+        }
+
+        verify(mockTracer).startSpan(traced.value())
+        verify(mockTracer).stopSpan(true)
+      }
+    }
+    "traces async methods" should {
+      "that complete successfully" in {
+        val method = tracedAsyncMethod
+        val traced = method.getDeclaredAnnotation(classOf[Traced])
+
+        val empty = Array.empty[AnyRef]
+        val proceed = mock[() => String]
+        val handler = new TestAsyncHandler("result2")
+
+        when(proceed.apply()).thenReturn("result")
+        when(mockAsyncNotifier.resolveHandler(classOf[String], "result")).thenReturn(Some(handler))
+
+        val span = mock[Span]
+        when(mockSpanContext.pop).thenReturn(Some(span))
+        val result = methodTracer.traceMethod(method, traced, empty, proceed)
+
+        verify(mockTracer).startSpan(traced.value())
+        verify(mockSpanContext).pop
+        verify(mockTracer, never()).stopSpan(argAny())
+
+        result shouldBe "result2"
+
+        handler.callback(Success("result3"))
+
+        verify(span).stop(true)
+      }
+      "that complete exceptionally" in {
+        val method = tracedAsyncMethod
+        val traced = method.getDeclaredAnnotation(classOf[Traced])
+
+        val empty = Array.empty[AnyRef]
+        val proceed = mock[() => String]
+        val handler = new TestAsyncHandler("result2")
+
+        when(proceed.apply()).thenReturn("result")
+        when(mockAsyncNotifier.resolveHandler(classOf[String], "result")).thenReturn(Some(handler))
+
+        val span = mock[Span]
+        when(mockSpanContext.pop).thenReturn(Some(span))
+        val result = methodTracer.traceMethod(method, traced, empty, proceed)
+
+        verify(mockTracer).startSpan(traced.value())
+        verify(mockSpanContext).pop
+        verify(mockTracer, never()).stopSpan(argAny())
+
+        result shouldBe "result2"
+
+        handler.callback(Failure(new Exception))
+
+        verify(span).stop(false)
+      }
+      "that complete exceptionally with ignored exception" in {
+        val method = tracedAsyncMethodWithIgnoredExceptions
+        val traced = method.getDeclaredAnnotation(classOf[Traced])
+
+        val empty = Array.empty[AnyRef]
+        val proceed = mock[() => String]
+        val handler = new TestAsyncHandler("result2")
+
+        when(proceed.apply()).thenReturn("result")
+        when(mockAsyncNotifier.resolveHandler(classOf[String], "result")).thenReturn(Some(handler))
+
+        val span = mock[Span]
+        when(mockSpanContext.pop).thenReturn(Some(span))
+        val result = methodTracer.traceMethod(method, traced, empty, proceed)
+
+        verify(mockTracer).startSpan(traced.value())
+        verify(mockSpanContext).pop
+        verify(mockTracer, never()).stopSpan(argAny())
+
+        result shouldBe "result2"
+
+        handler.callback(Failure(new IllegalArgumentException()))
+
+        verify(span).stop(true)
+      }
+      "with unhandled return value" in {
+        val method = tracedAsyncMethod
+        val traced = method.getDeclaredAnnotation(classOf[Traced])
+
+        val empty = Array.empty[AnyRef]
+        val proceed = mock[() => String]
+        val handler = new TestAsyncHandler("result2")
+
+        when(proceed.apply()).thenReturn("result")
+        when(mockAsyncNotifier.resolveHandler(classOf[String], "result")).thenReturn(None)
+
+        val result = methodTracer.traceMethod(method, traced, empty, proceed)
+
+        verify(mockTracer).startSpan(traced.value())
+        verify(mockTracer).stopSpan(true)
+
+        result shouldBe "result"
+      }
+      "that throws" in {
+        val method = tracedAsyncMethod
+        val traced = method.getDeclaredAnnotation(classOf[Traced])
+
+        val empty = Array.empty[AnyRef]
+        val proceed = mock[() => String]
+        val handler = new TestAsyncHandler("result2")
+
+        when(proceed.apply()).thenThrow(new IllegalArgumentException())
+
+        assertThrows[IllegalArgumentException] {
+          methodTracer.traceMethod(method, traced, empty, proceed)
+        }
+
+        verify(mockTracer).startSpan(traced.value())
+        verify(mockTracer).stopSpan(false)
+      }
+    }
+    "time method" should {
+      "that return successfully" in {
+
+        val method = timedMethod
+        val timed = method.getDeclaredAnnotation(classOf[Timed])
+
+        val proceed = mock[() => String]
+
+        when(proceed.apply()).thenReturn("result")
+
+        val result = methodTracer.timeMethod(method, timed, proceed)
+
+        verify(mockTracer).startTimer(timed.value())
+        verify(mockTracer).stopTimer(timed.value())
+
+        result shouldBe "result"
+      }
+      "that throws" in {
+
+        val method = timedMethod
+        val timed = method.getDeclaredAnnotation(classOf[Timed])
+
+        val proceed = mock[() => String]
+
+        when(proceed.apply()).thenThrow(new IllegalArgumentException())
+
+        assertThrows[IllegalArgumentException] {
+          methodTracer.timeMethod(method, timed, proceed)
+        }
+
+        verify(mockTracer).startTimer(timed.value())
+        verify(mockTracer).stopTimer(timed.value())
+      }
+    }
+  }
+
+  class TestAsyncHandler(result: String, supports: Boolean = true) extends AsyncNotificationHandler {
+    var callback: Try[_] => Unit = _
+
+    override def supports(futureClass: Class[_], future: AnyRef): Boolean = supports
+    override def whenComplete(futureClass: Class[_], future: AnyRef)(f: Try[_] => Unit): AnyRef = {
+      callback = f
+      result
+    }
+  }
+
+  class Samples {
+    @Traced(value = "tracedMethod")
+    def tracedMethod(): String = "tracedMethod"
+    @Traced(value = "tracedMethodWithParameters")
+    def tracedMethodWithParameters(@TracedData("foo") foo: String, @TracedData("foo") bar: String): String = "tracedMethodWithParameters"
+    @Traced(value = "tracedMethodWithIgnoredExceptions", ignoredExceptions = Array(classOf[IllegalArgumentException]))
+    def tracedMethodWithIgnoredExceptions(): String = "tracedMethodWithIgnoredExceptions"
+    @Traced(value = "tracedAsyncMethod", async = true)
+    def tracedAsyncMethod(): String = "tracedAsyncMethod"
+    @Traced(value = "tracedAsyncMethodWithIgnoredExceptions", async = true, ignoredExceptions = Array(classOf[IllegalArgumentException]))
+    def tracedAsyncMethodWithIgnoredExceptions(): String = "tracedAsyncMethodWithIgnoredExceptions"
+
+    @Timed(value = "timedMethod")
+    def timedMethod(): String = "timedMethod"
+  }
+}

--- a/money-spring/src/main/scala/com/comcast/money/spring/TracedMethodInterceptor.scala
+++ b/money-spring/src/main/scala/com/comcast/money/spring/TracedMethodInterceptor.scala
@@ -19,9 +19,7 @@ package com.comcast.money.spring
 import java.lang.reflect.Method
 
 import com.comcast.money.annotations.Traced
-import com.comcast.money.core.internal.MDCSupport
-import com.comcast.money.core.logging.TraceLogging
-import com.comcast.money.core.reflect.Reflections
+import com.comcast.money.core.logging.MethodTracer
 import org.aopalliance.aop.Advice
 import org.aopalliance.intercept.{ MethodInterceptor, MethodInvocation }
 import org.springframework.aop.Pointcut
@@ -33,31 +31,14 @@ import org.springframework.stereotype.Component
  * Intercepts methods to start and stop a trace span around the method invocation
  */
 @Component
-class TracedMethodInterceptor @Autowired() (@Qualifier("springTracer") val tracer: SpringTracer)
+class TracedMethodInterceptor @Autowired() (@Qualifier("springTracer") override val tracer: SpringTracer)
   extends MethodInterceptor
-  with Reflections with TraceLogging {
-
-  val mdcSupport = new MDCSupport()
+  with MethodTracer {
 
   override def invoke(invocation: MethodInvocation): AnyRef = {
 
     Option(invocation.getStaticPart.getAnnotation(classOf[Traced])) map { annotation =>
-      var result = true
-      val oldSpanName = mdcSupport.getSpanNameMDC
-      try {
-        tracer.startSpan(annotation.value())
-        mdcSupport.setSpanNameMDC(Some(annotation.value()))
-        recordTracedParameters(invocation.getStaticPart.asInstanceOf[Method], invocation.getArguments, tracer)
-        invocation.proceed()
-      } catch {
-        case t: Throwable =>
-          logException(t)
-          result = if (exceptionMatches(t, annotation.ignoredExceptions())) true else false
-          throw t
-      } finally {
-        mdcSupport.setSpanNameMDC(oldSpanName)
-        tracer.stopSpan(result)
-      }
+      traceMethod(invocation.getMethod, annotation, invocation.getArguments, invocation.proceed)
     } getOrElse {
       invocation.proceed()
     }

--- a/money-spring/src/test/scala/com/comcast/money/spring/TracedMethodInterceptorScalaSpec.scala
+++ b/money-spring/src/test/scala/com/comcast/money/spring/TracedMethodInterceptorScalaSpec.scala
@@ -16,9 +16,13 @@
 
 package com.comcast.money.spring
 
+import java.lang.reflect.AccessibleObject
+
 import com.comcast.money.annotations.{ Traced, TracedData }
 import com.comcast.money.api.Note
 import com.sun.istack.internal.NotNull
+import org.aopalliance.intercept.MethodInvocation
+import org.aspectj.lang.JoinPoint
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
@@ -122,6 +126,20 @@ class TracedMethodInterceptorScalaSpec extends WordSpec with Matchers with Mocki
       noteCaptor.getValue.name shouldBe "STRING"
       noteCaptor.getValue.value shouldBe "prop"
       noteCaptor.getValue.isSticky shouldBe true
+    }
+    "should invoke joinpoint directly without Traced annotation" in {
+      val tracer = new SpringTracer()
+      val interceptor = new TracedMethodInterceptor(tracer)
+      val invocation = mock[MethodInvocation]
+      val accessibleObject = mock[AccessibleObject]
+      doReturn(accessibleObject).when(invocation).getStaticPart
+      doReturn(null).when(accessibleObject).getAnnotation(classOf[Traced])
+
+      interceptor.invoke(invocation)
+
+      verify(invocation, never()).getMethod
+      verify(invocation, never()).getArguments
+      verify(invocation).proceed()
     }
   }
 }


### PR DESCRIPTION
Refactors the method interception for the `@Traced` and `@Timed` annotations into a trait that can be shared by `TraceAspect` for AspectJ and `TracedMethodInterceptor` for Spring.