### PR TITLE
Add aspect-based async tracing support for Java 8 CompletionStage and CompletableFuture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: false
+
 language: scala
 jdk: oraclejdk8
 

--- a/money-aspectj/src/test/scala/com/comcast/money/aspectj/TraceAspectSpec.scala
+++ b/money-aspectj/src/test/scala/com/comcast/money/aspectj/TraceAspectSpec.scala
@@ -16,6 +16,8 @@
 
 package com.comcast.money.aspectj
 
+import java.util.concurrent.{ CompletableFuture, CompletionStage, TimeUnit }
+
 import com.comcast.money.annotations.{ Timed, Traced, TracedData }
 import com.comcast.money.core.internal.MDCSupport
 import com.comcast.money.core.{ LogRecord, Money, SpecHelpers }
@@ -24,7 +26,6 @@ import org.mockito.Mockito._
 import org.scalatest._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
-import org.slf4j.MDC
 
 import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
@@ -84,6 +85,16 @@ class TraceAspectSpec extends WordSpec
   def asyncMethodReturnsFuture(future: Future[String]): Future[String] = future
 
   @Traced(
+    value = "asyncMethodReturnsCompletableFuture",
+    async = true)
+  def asyncMethodReturnsCompletableFuture(future: CompletableFuture[String]): CompletableFuture[String] = future
+
+  @Traced(
+    value = "asyncMethodReturnsCompletionStage",
+    async = true)
+  def asyncMethodReturnsCompletionStage(future: CompletionStage[String]): CompletionStage[String] = future
+
+  @Traced(
     value = "asyncMethodReturnsNull",
     async = true)
   def asyncMethodReturnsNull(): Future[String] = null
@@ -91,12 +102,12 @@ class TraceAspectSpec extends WordSpec
   @Traced(
     value = "asyncMethodReturnsNonFuture",
     async = true)
-  def asyncMethodReturnsNonFuture(): AnyRef = new Object
+  def asyncMethodReturnsNonFuture(): Object = new Object
 
   @Traced(
     value = "asyncMethodThrowingException",
     async = true)
-  def asyncMethodThrowingException(): AnyRef = {
+  def asyncMethodThrowingException(): Future[String] = {
     Thread.sleep(50)
     throw new RuntimeException()
   }
@@ -105,7 +116,7 @@ class TraceAspectSpec extends WordSpec
     value = "asyncMethodWithIgnoredException",
     async = true,
     ignoredExceptions = Array(classOf[IllegalArgumentException]))
-  def asyncMethodWithIgnoredException(): AnyRef = {
+  def asyncMethodWithIgnoredException(): Future[String] = {
     throw new IllegalArgumentException("ignored")
   }
 
@@ -113,7 +124,7 @@ class TraceAspectSpec extends WordSpec
     value = "asyncMethodWithNonMatchingIgnoredException",
     async = true,
     ignoredExceptions = Array(classOf[IllegalArgumentException]))
-  def asyncMethodWithNonMatchingIgnoredException(): AnyRef = {
+  def asyncMethodWithNonMatchingIgnoredException(): Future[String] = {
     throw new RuntimeException("not-ignored")
   }
 
@@ -122,6 +133,18 @@ class TraceAspectSpec extends WordSpec
     async = true,
     ignoredExceptions = Array(classOf[IllegalArgumentException]))
   def asyncMethodWithIgnoredException(future: Future[String]): Future[String] = future
+
+  @Traced(
+    value = "asyncMethodWithIgnoredException",
+    async = true,
+    ignoredExceptions = Array(classOf[IllegalArgumentException]))
+  def asyncMethodWithIgnoredException(future: CompletableFuture[String]): CompletableFuture[String] = future
+
+  @Traced(
+    value = "asyncMethodWithIgnoredException",
+    async = true,
+    ignoredExceptions = Array(classOf[IllegalArgumentException]))
+  def asyncMethodWithIgnoredException(future: CompletionStage[String]): CompletionStage[String] = future
 
   @Timed("methodWithTiming")
   def methodWithTiming() = {
@@ -195,138 +218,278 @@ class TraceAspectSpec extends WordSpec
       }
     }
     "advising methods by tracing them with async flag" should {
-      "handle async methods that return a future" in {
-        Given("a method that returns a future")
+      "for Scala Future[T]" should {
+        "handle async methods that return a future" in {
+          Given("a method that returns a future")
 
-        When("the method is invoked")
-        val promise = Promise[String]()
-        val future = asyncMethodReturnsFuture(promise.future)
+          When("the method is invoked")
+          val promise = Promise[String]()
+          val future = asyncMethodReturnsFuture(promise.future)
 
-        Then("the method execution is logged")
-        dontExpectSpanInfoThat("is named asyncMethodReturnsFuture", _.name == "asyncMethodReturnsFuture")
+          Then("the method execution is logged")
+          dontExpectSpanInfoThat("is named asyncMethodReturnsFuture", _.name == "asyncMethodReturnsFuture")
 
-        When("the future completes")
-        promise.complete(Try("Success"))
-        Await.ready(future, 500 millis)
+          When("the future completes")
+          promise.complete(Try("Success"))
+          Await.ready(future, 500 millis)
 
-        Then("the async execution is logged")
-        expectSpanInfoThat("is named asyncMethodReturnsFuture", _.name == "asyncMethodReturnsFuture")
-      }
-      "handle async methods that return a failed future" in {
-        Given("a method that returns a future")
+          Then("the async execution is logged")
+          expectSpanInfoThat("is named asyncMethodReturnsFuture", _.name == "asyncMethodReturnsFuture")
+        }
+        "handle async methods that return a failed future" in {
+          Given("a method that returns a future")
 
-        When("the method is invoked")
-        val promise = Promise[String]()
-        val future = asyncMethodReturnsFuture(promise.future)
+          When("the method is invoked")
+          val promise = Promise[String]()
+          val future = asyncMethodReturnsFuture(promise.future)
 
-        Then("the method execution is logged")
-        dontExpectSpanInfoThat("is named asyncMethodReturnsFuture", _.name == "asyncMethodReturnsFuture")
+          Then("the method execution is logged")
+          dontExpectSpanInfoThat("is named asyncMethodReturnsFuture", _.name == "asyncMethodReturnsFuture")
 
-        When("the future fails")
-        promise.complete(Failure(new RuntimeException()))
-        Await.ready(future, 500 millis)
+          When("the future fails")
+          promise.complete(Failure(new RuntimeException()))
+          Await.ready(future, 500 millis)
 
-        Then("the async execution is logged")
-        expectSpanInfoThat("is named asyncMethodReturnsFuture and is not successful", span =>
-          span.name == "asyncMethodReturnsFuture" && !span.success())
-      }
-      "handle async methods that return a failed future with ignored exception" in {
-        Given("a method that returns a future")
+          Then("the async execution is logged")
+          expectSpanInfoThat("is named asyncMethodReturnsFuture and is not successful", span =>
+            span.name == "asyncMethodReturnsFuture" && !span.success())
+        }
+        "handle async methods that return a failed future with ignored exception" in {
+          Given("a method that returns a future")
 
-        When("the method is invoked")
-        val promise = Promise[String]()
-        val future = asyncMethodWithIgnoredException(promise.future)
+          When("the method is invoked")
+          val promise = Promise[String]()
+          val future = asyncMethodWithIgnoredException(promise.future)
 
-        Then("the method execution is logged")
-        dontExpectSpanInfoThat("is named asyncMethodWithIgnoredException", _.name == "asyncMethodWithIgnoredException")
+          Then("the method execution is logged")
+          dontExpectSpanInfoThat("is named asyncMethodWithIgnoredException", _.name == "asyncMethodWithIgnoredException")
 
-        When("the future fails")
-        promise.complete(Failure(new IllegalArgumentException()))
-        Await.ready(future, 500 millis)
+          When("the future fails")
+          promise.complete(Failure(new IllegalArgumentException()))
+          Await.ready(future, 500 millis)
 
-        Then("the async execution is logged")
-        expectSpanInfoThat("is named asyncMethodWithIgnoredException and is successful", span =>
-          span.name == "asyncMethodWithIgnoredException" && span.success())
-      }
-      "handle async methods that return a failed future with exception not in ignored list" in {
-        Given("a method that returns a future")
+          Then("the async execution is logged")
+          expectSpanInfoThat("is named asyncMethodWithIgnoredException and is successful", span =>
+            span.name == "asyncMethodWithIgnoredException" && span.success())
+        }
+        "handle async methods that return a failed future with exception not in ignored list" in {
+          Given("a method that returns a future")
 
-        When("the method is invoked")
-        val promise = Promise[String]()
-        val future = asyncMethodWithIgnoredException(promise.future)
+          When("the method is invoked")
+          val promise = Promise[String]()
+          val future = asyncMethodWithIgnoredException(promise.future)
 
-        Then("the method execution is logged")
-        dontExpectSpanInfoThat("is named asyncMethodWithIgnoredException", _.name == "asyncMethodWithIgnoredException")
+          Then("the method execution is logged")
+          dontExpectSpanInfoThat("is named asyncMethodWithIgnoredException", _.name == "asyncMethodWithIgnoredException")
 
-        When("the future fails")
-        promise.complete(Failure(new RuntimeException()))
-        Await.ready(future, 500 millis)
+          When("the future fails")
+          promise.complete(Failure(new RuntimeException()))
+          Await.ready(future, 500 millis)
 
-        Then("the async execution is logged")
-        expectSpanInfoThat("is named asyncMethodWithIgnoredException and is not successful", span =>
-          span.name == "asyncMethodWithIgnoredException" && !span.success())
-      }
-      "handle async methods that return a null future" in {
-        Given("a method that returns null")
+          Then("the async execution is logged")
+          expectSpanInfoThat("is named asyncMethodWithIgnoredException and is not successful", span =>
+            span.name == "asyncMethodWithIgnoredException" && !span.success())
+        }
+        "handle async methods that return a null future" in {
+          Given("a method that returns null")
 
-        When("the method is invoked")
-        val _ = asyncMethodReturnsNull()
+          When("the method is invoked")
+          val _ = asyncMethodReturnsNull()
 
-        Then("the method and future execution is logged")
-        expectSpanInfoThat("is named asyncMethodReturnsNull", _.name == "asyncMethodReturnsNull")
-      }
-      "handle async methods that return a non-future" in {
-        Given("a method that returns a non-future")
+          Then("the method and future execution is logged")
+          expectSpanInfoThat("is named asyncMethodReturnsNull", _.name == "asyncMethodReturnsNull")
+        }
+        "handle async methods that return a non-future" in {
+          Given("a method that returns a non-future")
 
-        When("the method is invoked")
-        val _ = asyncMethodReturnsNonFuture()
+          When("the method is invoked")
+          val _ = asyncMethodReturnsNonFuture()
 
-        Then("the method and future execution is logged")
-        expectSpanInfoThat("is named asyncMethodReturnsNonFuture", _.name == "asyncMethodReturnsNonFuture")
-      }
-      "complete the trace for methods that throw exceptions" in {
-        Given("a method that throws an exception")
+          Then("the method and future execution is logged")
+          expectSpanInfoThat("is named asyncMethodReturnsNonFuture", _.name == "asyncMethodReturnsNonFuture")
+        }
+        "complete the trace for methods that throw exceptions" in {
+          Given("a method that throws an exception")
 
-        When("the method is invoked")
-        a[RuntimeException] should be thrownBy {
-          asyncMethodThrowingException()
+          When("the method is invoked")
+          a[RuntimeException] should be thrownBy {
+            asyncMethodThrowingException()
+          }
+
+          Then("the method execution is logged")
+          expectSpanInfoThat("is named asyncMethodThrowingException", _.name == "asyncMethodThrowingException")
+
+          And("a span-success is logged with a value of false")
+          expectLogMessageContaining("span-success=false")
+        }
+        "complete the trace with success for methods that throw ignored exceptions" in {
+          Given("a method that throws an ignored exception")
+
+          When("the method is invoked")
+          an[IllegalArgumentException] should be thrownBy {
+            asyncMethodWithIgnoredException()
+          }
+
+          Then("the method execution is logged")
+          expectSpanInfoThat("is named asyncMethodWithIgnoredException", _.name == "asyncMethodWithIgnoredException")
+
+          And("a span-success is logged with a value of true")
+          expectLogMessageContaining("span-success=true")
+        }
+        "complete the trace with failure for methods that throw exceptions that are not in ignored list" in {
+          Given("a method that throws an ignored exception")
+
+          When("the method is invoked")
+          a[RuntimeException] should be thrownBy {
+            asyncMethodWithNonMatchingIgnoredException()
+          }
+
+          Then("the method execution is logged")
+          expectSpanInfoThat("is named asyncMethodWithNonMatchingIgnoredException", _.name == "asyncMethodWithNonMatchingIgnoredException")
+
+          And("a span-success is logged with a value of false")
+          expectLogMessageContaining("span-success=false")
         }
 
-        Then("the method execution is logged")
-        expectSpanInfoThat("is named asyncMethodThrowingException", _.name == "asyncMethodThrowingException")
-
-        And("a span-success is logged with a value of false")
-        expectLogMessageContaining("span-success=false")
       }
-      "complete the trace with success for methods that throw ignored exceptions" in {
-        Given("a method that throws an ignored exception")
+      "for Java CompletableFuture[T]" should {
+        "handle async methods that return a future" in {
+          Given("a method that returns a future")
 
-        When("the method is invoked")
-        an[IllegalArgumentException] should be thrownBy {
-          asyncMethodWithIgnoredException()
+          When("the method is invoked")
+          val completableFuture = new CompletableFuture[String]()
+          val future = asyncMethodReturnsCompletableFuture(completableFuture)
+
+          Then("the method execution is logged")
+          dontExpectSpanInfoThat("is named asyncMethodReturnsCompletableFuture", _.name == "asyncMethodReturnsCompletableFuture")
+
+          When("the future completes")
+          completableFuture.complete("Success")
+
+          Then("the async execution is logged")
+          expectSpanInfoThat("is named asyncMethodReturnsCompletableFuture", _.name == "asyncMethodReturnsCompletableFuture")
         }
+        "handle async methods that return a failed future" in {
+          Given("a method that returns a future")
 
-        Then("the method execution is logged")
-        expectSpanInfoThat("is named asyncMethodWithIgnoredException", _.name == "asyncMethodWithIgnoredException")
+          When("the method is invoked")
+          val completableFuture = new CompletableFuture[String]()
+          val future = asyncMethodReturnsCompletableFuture(completableFuture)
 
-        And("a span-success is logged with a value of true")
-        expectLogMessageContaining("span-success=true")
-      }
-      "complete the trace with failure for methods that throw exceptions that are not in ignored list" in {
-        Given("a method that throws an ignored exception")
+          Then("the method execution is logged")
+          dontExpectSpanInfoThat("is named asyncMethodReturnsCompletableFuture", _.name == "asyncMethodReturnsCompletableFuture")
 
-        When("the method is invoked")
-        a[RuntimeException] should be thrownBy {
-          asyncMethodWithNonMatchingIgnoredException()
+          When("the future fails")
+          completableFuture.completeExceptionally(new RuntimeException())
+
+          Then("the async execution is logged")
+          expectSpanInfoThat("is named asyncMethodReturnsCompletableFuture and is not successful", span =>
+            span.name == "asyncMethodReturnsCompletableFuture" && !span.success())
         }
+        "handle async methods that return a failed future with ignored exception" in {
+          Given("a method that returns a future")
 
-        Then("the method execution is logged")
-        expectSpanInfoThat("is named asyncMethodWithNonMatchingIgnoredException", _.name == "asyncMethodWithNonMatchingIgnoredException")
+          When("the method is invoked")
+          val completableFuture = new CompletableFuture[String]()
+          val future = asyncMethodWithIgnoredException(completableFuture)
 
-        And("a span-success is logged with a value of false")
-        expectLogMessageContaining("span-success=false")
+          Then("the method execution is logged")
+          dontExpectSpanInfoThat("is named asyncMethodWithIgnoredException", _.name == "asyncMethodWithIgnoredException")
+
+          When("the future fails")
+          completableFuture.completeExceptionally(new IllegalArgumentException())
+
+          Then("the async execution is logged")
+          expectSpanInfoThat("is named asyncMethodWithIgnoredException and is successful", span =>
+            span.name == "asyncMethodWithIgnoredException" && span.success())
+        }
+        "handle async methods that return a failed future with exception not in ignored list" in {
+          Given("a method that returns a future")
+
+          When("the method is invoked")
+          val completableFuture = new CompletableFuture[String]()
+          val future = asyncMethodWithIgnoredException(completableFuture)
+
+          Then("the method execution is logged")
+          dontExpectSpanInfoThat("is named asyncMethodWithIgnoredException", _.name == "asyncMethodWithIgnoredException")
+
+          When("the future fails")
+          completableFuture.completeExceptionally(new RuntimeException())
+
+          Then("the async execution is logged")
+          expectSpanInfoThat("is named asyncMethodWithIgnoredException and is not successful", span =>
+            span.name == "asyncMethodWithIgnoredException" && !span.success())
+        }
       }
+      "for Java CompletionStage[T]" should {
+        "handle async methods that return a future" in {
+          Given("a method that returns a future")
 
+          When("the method is invoked")
+          val completableFuture = new CompletableFuture[String]()
+          val future = asyncMethodReturnsCompletionStage(completableFuture)
+
+          Then("the method execution is logged")
+          dontExpectSpanInfoThat("is named asyncMethodReturnsCompletionStage", _.name == "asyncMethodReturnsCompletionStage")
+
+          When("the future completes")
+          completableFuture.complete("Success")
+
+          Then("the async execution is logged")
+          expectSpanInfoThat("is named asyncMethodReturnsCompletionStage", _.name == "asyncMethodReturnsCompletionStage")
+        }
+        "handle async methods that return a failed future" in {
+          Given("a method that returns a future")
+
+          When("the method is invoked")
+          val completableFuture = new CompletableFuture[String]()
+          val future = asyncMethodReturnsCompletionStage(completableFuture)
+
+          Then("the method execution is logged")
+          dontExpectSpanInfoThat("is named asyncMethodReturnsCompletionStage", _.name == "asyncMethodReturnsCompletionStage")
+
+          When("the future fails")
+          completableFuture.completeExceptionally(new RuntimeException())
+
+          Then("the async execution is logged")
+          expectSpanInfoThat("is named asyncMethodReturnsCompletionStage and is not successful", span =>
+            span.name == "asyncMethodReturnsCompletionStage" && !span.success())
+        }
+        "handle async methods that return a failed future with ignored exception" in {
+          Given("a method that returns a future")
+
+          When("the method is invoked")
+          val completableFuture = new CompletableFuture[String]()
+          val future = asyncMethodWithIgnoredException(completableFuture.asInstanceOf[CompletionStage[String]])
+
+          Then("the method execution is logged")
+          dontExpectSpanInfoThat("is named asyncMethodWithIgnoredException", _.name == "asyncMethodWithIgnoredException")
+
+          When("the future fails")
+          completableFuture.completeExceptionally(new IllegalArgumentException())
+
+          Then("the async execution is logged")
+          expectSpanInfoThat("is named asyncMethodWithIgnoredException and is successful", span =>
+            span.name == "asyncMethodWithIgnoredException" && span.success())
+        }
+        "handle async methods that return a failed future with exception not in ignored list" in {
+          Given("a method that returns a future")
+
+          When("the method is invoked")
+          val completableFuture = new CompletableFuture[String]()
+          val future = asyncMethodWithIgnoredException(completableFuture.asInstanceOf[CompletionStage[String]])
+
+          Then("the method execution is logged")
+          dontExpectSpanInfoThat("is named asyncMethodWithIgnoredException", _.name == "asyncMethodWithIgnoredException")
+
+          When("the future fails")
+          completableFuture.completeExceptionally(new RuntimeException())
+
+          Then("the async execution is logged")
+          expectSpanInfoThat("is named asyncMethodWithIgnoredException and is not successful", span =>
+            span.name == "asyncMethodWithIgnoredException" && !span.success())
+        }
+      }
     }
     "advising methods that have parameters with the TracedData annotation" should {
       "record the value of the parameter in the trace" in {
@@ -394,28 +557,6 @@ class TraceAspectSpec extends WordSpec
         val traceAspect = new TraceAspect()
         traceAspect.traced(null)
         traceAspect.timed(null)
-      }
-    }
-    "advising methods" should {
-      "set span name in MDC" in {
-        val jp = mock[ProceedingJoinPoint]
-        val ann = mock[Traced]
-        doReturn("testSpanName").when(ann).value()
-        doReturn(None).when(mockMdcSupport).getSpanNameMDC
-        testTraceAspect.adviseMethodsWithTracing(jp, ann)
-
-        verify(mockMdcSupport).setSpanNameMDC(Some("testSpanName"))
-        verify(mockMdcSupport).setSpanNameMDC(None)
-      }
-      "save the current span name and reset after the child span is complete" in {
-        val jp = mock[ProceedingJoinPoint]
-        val ann = mock[Traced]
-        doReturn("testSpanName").when(ann).value()
-        doReturn(Some("parentSpan")).when(mockMdcSupport).getSpanNameMDC
-
-        testTraceAspect.adviseMethodsWithTracing(jp, ann)
-
-        verify(mockMdcSupport).setSpanNameMDC(Some("parentSpan"))
       }
     }
   }

--- a/money-core/src/main/resources/reference.conf
+++ b/money-core/src/main/resources/reference.conf
@@ -49,6 +49,12 @@ money {
     handlers = [
       {
         class = "com.comcast.money.core.async.ScalaFutureNotificationHandler"
+      },
+      {
+        class = "com.comcast.money.core.async.CompletionStageNotificationHandler"
+      },
+      {
+        class = "com.comcast.money.core.async.CompletableFutureNotificationHandler"
       }
     ]
   }

--- a/money-core/src/main/scala/com/comcast/money/core/async/CompletableFutureNotificationHandler.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/async/CompletableFutureNotificationHandler.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.async
+
+import java.util.concurrent.{ CompletableFuture, Future }
+
+import scala.util.{ Failure, Success, Try }
+
+class CompletableFutureNotificationHandler extends AbstractAsyncNotificationHandler[CompletableFuture[_]] {
+
+  /**
+   * Determines if this handler can support the type and instance of the given future
+   * returned by the method bring traced
+   *
+   * @param futureClass the type of the future as declared on the method being traced
+   * @param future      the future instance returned by the method being traced
+   * @return `true` if this handler can register completion for the future instance
+   */
+  override def supports(futureClass: Class[_], future: AnyRef): Boolean =
+    (futureClass == classOf[CompletableFuture[_]] || futureClass == classOf[Future[_]]) && future.isInstanceOf[CompletableFuture[_]]
+
+  /**
+   * Implemented by derived type to register the callback function to be invoked when the future
+   * has completed
+   *
+   * @param future the future instance for which the callback is to be registered
+   * @param f      the callback function
+   * @return the future instance with the completion callback registered
+   */
+  override def whenComplete(future: CompletableFuture[_], f: Try[_] => Unit): CompletableFuture[_] =
+    future.whenComplete((result, exception) =>
+      f(
+        Option(exception)
+          .map(Failure(_))
+          .getOrElse(Success(result))))
+}

--- a/money-core/src/main/scala/com/comcast/money/core/async/CompletionStageNotificationHandler.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/async/CompletionStageNotificationHandler.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.async
+
+import java.util.concurrent.CompletionStage
+
+import scala.util.{ Failure, Success, Try }
+
+class CompletionStageNotificationHandler extends AbstractAsyncNotificationHandler[CompletionStage[_]] {
+  /**
+   * Implemented by derived type to register the callback function to be invoked when the future
+   * has completed
+   *
+   * @param future the future instance for which the callback is to be registered
+   * @param f      the callback function
+   * @return the future instance with the completion callback registered
+   */
+  override def whenComplete(future: CompletionStage[_], f: Try[_] => Unit): CompletionStage[_] =
+    future.whenComplete((result, exception) =>
+      f(
+        Option(exception)
+          .map(Failure(_)).
+          getOrElse(Success(result))))
+}

--- a/money-core/src/test/scala/com/comcast/money/core/async/CompletableFutureNotificationHandlerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/async/CompletableFutureNotificationHandlerSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.async
+
+import java.util.concurrent.{ CompletableFuture, Future }
+
+import com.comcast.money.core.SpecHelpers
+import com.comcast.money.core.concurrent.ConcurrentSupport
+import org.mockito.Matchers.{ any, eq => argEq }
+import org.mockito.Mockito.{ doReturn, never, times, verify }
+import org.scalatest.{ Matchers, OneInstancePerTest, WordSpecLike }
+import org.scalatest.mockito.MockitoSugar
+
+import scala.util.{ Failure, Try }
+
+class CompletableFutureNotificationHandlerSpec
+  extends WordSpecLike
+  with MockitoSugar with Matchers with ConcurrentSupport with OneInstancePerTest with SpecHelpers {
+
+  val underTest = new CompletableFutureNotificationHandler()
+  val futureClass: Class[_] = classOf[CompletableFuture[_]]
+  val success: CompletableFuture[String] = CompletableFuture.completedFuture("success")
+
+  "CompletableFutureNotificationHandler" should {
+    "support java.util.concurrent.CompletableFuture" in {
+      val result = underTest.supports(futureClass, success)
+
+      result shouldEqual true
+    }
+    "support java.util.concurrent.Future with a value of CompletableFuture" in {
+      val result = underTest.supports(classOf[Future[_]], success)
+
+      result shouldEqual true
+    }
+    "support descendents of java.util.concurrent.CompletableFuture" in {
+      val future = mock[MyCompletableFuture[String]]
+      val result = underTest.supports(futureClass, future)
+
+      result shouldEqual true
+    }
+    "does not support descendent classes of java.util.concurrent.CompletableFuture" in {
+      val result = underTest.supports(classOf[MyCompletableFuture[_]], success)
+
+      result shouldEqual false
+    }
+    "does not support non-CompletableFutures" in {
+      val nonFuture = new Object()
+      val result = underTest.supports(classOf[Object], nonFuture)
+
+      result shouldEqual false
+    }
+    "does not support null class" in {
+      val result = underTest.supports(null, success)
+
+      result shouldEqual false
+    }
+    "does not support null" in {
+      val result = underTest.supports(futureClass, null)
+
+      result shouldEqual false
+    }
+    "calls whenComplete method on the future" in {
+      val future = mock[CompletableFuture[String]]
+      doReturn(future).when(future).whenComplete(any())
+
+      val result = underTest.whenComplete(futureClass, future) { _ => {} }
+
+      verify(future, times(1)).whenComplete(any())
+      result shouldEqual future
+    }
+    "calls registered completion function for already completed future" in {
+      val future = success
+      val func = mock[Try[_] => Unit]
+
+      underTest.whenComplete(futureClass, future)(func)
+
+      verify(func, times(1)).apply(argEq(Try("success")))
+    }
+    "calls registered completion function for already exceptionally completed future" in {
+      val ex = new RuntimeException
+      val future = new CompletableFuture[String]()
+      future.completeExceptionally(ex)
+      val func = mock[Try[_] => Unit]
+
+      underTest.whenComplete(futureClass, future)(func)
+
+      verify(func, times(1)).apply(argEq(Failure(ex)))
+    }
+    "calls registered completion function when the future completes successfully" in {
+      val future = new CompletableFuture[String]()
+
+      val func = mock[Try[_] => Unit]
+
+      underTest.whenComplete(futureClass, future)(func)
+      verify(func, never()).apply(any())
+
+      future.complete("success")
+
+      verify(func, times(1)).apply(argEq(Try("success")))
+    }
+    "calls registered completion function when the future completes exceptionally" in {
+      val future = new CompletableFuture[String]()
+
+      val func = mock[Try[_] => Unit]
+
+      underTest.whenComplete(futureClass, future)(func)
+      verify(func, never()).apply(any())
+
+      val exception = new RuntimeException()
+      future.completeExceptionally(exception)
+
+      verify(func, times(1)).apply(argEq(Failure(exception)))
+    }
+  }
+
+  private abstract class MyCompletableFuture[T] extends CompletableFuture[T] {}
+}

--- a/money-core/src/test/scala/com/comcast/money/core/async/CompletionStageNotificationHandlerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/async/CompletionStageNotificationHandlerSpec.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.async
+
+import java.util.concurrent.{ CompletableFuture, CompletionStage }
+
+import com.comcast.money.core.SpecHelpers
+import com.comcast.money.core.concurrent.ConcurrentSupport
+import org.mockito.Matchers.{ any, eq => argEq }
+import org.mockito.Mockito.{ doReturn, never, times, verify }
+import org.scalatest.{ Matchers, OneInstancePerTest, WordSpecLike }
+import org.scalatest.mockito.MockitoSugar
+
+import scala.util.{ Failure, Try }
+
+class CompletionStageNotificationHandlerSpec
+  extends WordSpecLike
+  with MockitoSugar with Matchers with ConcurrentSupport with OneInstancePerTest with SpecHelpers {
+
+  val underTest = new CompletionStageNotificationHandler()
+  val futureClass: Class[_] = classOf[CompletionStage[_]]
+  val success: CompletionStage[String] = CompletableFuture.completedFuture("success")
+
+  "CompletionStageNotificationHandler" should {
+    "support java.util.concurrent.CompletionStage" in {
+      val result = underTest.supports(futureClass, success)
+
+      result shouldEqual true
+    }
+    "support descendents of java.util.concurrent.CompletionStage" in {
+      val stage = mock[MyCompletionStage[String]]
+      val result = underTest.supports(futureClass, stage)
+
+      result shouldEqual true
+    }
+    "does not support descendent classes of java.util.concurrent.CompletionStage" in {
+      val result = underTest.supports(classOf[MyCompletionStage[_]], success)
+
+      result shouldEqual false
+    }
+    "does not support non-CompletionStages" in {
+      val nonFuture = new Object()
+      val result = underTest.supports(classOf[Object], nonFuture)
+
+      result shouldEqual false
+    }
+    "does not support null class" in {
+      val result = underTest.supports(null, success)
+
+      result shouldEqual false
+    }
+    "does not support null" in {
+      val result = underTest.supports(futureClass, null)
+
+      result shouldEqual false
+    }
+    "calls whenComplete method on the completion stage" in {
+      val stage = mock[CompletionStage[String]]
+      doReturn(stage).when(stage).whenComplete(any())
+
+      val result = underTest.whenComplete(futureClass, stage) { _ => {} }
+
+      verify(stage, times(1)).whenComplete(any())
+      result shouldEqual stage
+    }
+    "calls registered completion function for already completed stage" in {
+      val stage = success
+      val func = mock[Try[_] => Unit]
+
+      underTest.whenComplete(futureClass, stage)(func)
+
+      verify(func, times(1)).apply(argEq(Try("success")))
+    }
+    "calls registered completion function for already exceptionally completed stage" in {
+      val ex = new RuntimeException
+      val stage = new CompletableFuture[String]()
+      stage.completeExceptionally(ex)
+      val func = mock[Try[_] => Unit]
+
+      underTest.whenComplete(futureClass, stage)(func)
+
+      verify(func, times(1)).apply(argEq(Failure(ex)))
+    }
+    "calls registered completion function when the stage completes successfully" in {
+      val stage = new CompletableFuture[String]()
+
+      val func = mock[Try[_] => Unit]
+
+      underTest.whenComplete(futureClass, stage)(func)
+      verify(func, never()).apply(any())
+
+      stage.complete("success")
+
+      verify(func, times(1)).apply(argEq(Try("success")))
+    }
+    "calls registered completion function when the stage completes exceptionally" in {
+      val stage = new CompletableFuture[String]()
+
+      val func = mock[Try[_] => Unit]
+
+      underTest.whenComplete(futureClass, stage)(func)
+      verify(func, never()).apply(any())
+
+      val exception = new RuntimeException()
+      stage.completeExceptionally(exception)
+
+      verify(func, times(1)).apply(argEq(Failure(exception)))
+    }
+  }
+
+  private abstract class MyCompletionStage[T] extends CompletionStage[T] {}
+}


### PR DESCRIPTION
Adds AsyncNotificationHandlers to support Java 8 `CompletionStage<T>` and `CompletableFuture<T>` for asynchronous tracing using `@Traced` annotation and AspectJ/Spring.