### PR TITLE
Add W3C Trace Context headers and OpenTelemetry-compat ID formatting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,7 @@ def aspectjProjectSettings = projectSettings ++ Seq(
 
 def basicSettings =  Defaults.itSettings ++ SbtScalariform.scalariformSettings ++ Seq(
   organization := "com.comcast.money",
-  version := "0.9.1-SNAPSHOT",
+  version := "0.9.2-SNAPSHOT",
   scalaVersion := "2.12.6",
   resolvers ++= Seq(
     "spray repo" at "http://repo.spray.io/",

--- a/money-core/src/main/scala/com/comcast/money/core/Money.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Money.scala
@@ -31,6 +31,7 @@ case class Money(
   factory: SpanFactory,
   tracer: Tracer,
   logExceptions: Boolean = false,
+  formatIdsAsHex: Boolean = false,
   asyncNotifier: AsyncNotifier = new AsyncNotifier(Seq()))
 
 object Money {
@@ -50,7 +51,8 @@ object Money {
       }
       val logExceptions = conf.getBoolean("log-exceptions")
       val asyncNotificationHandlerChain = AsyncNotifier(conf.getConfig("async-notifier"))
-      Money(enabled, handler, applicationName, hostName, factory, tracer, logExceptions, asyncNotificationHandlerChain)
+      val formatIdsAsHex = conf.hasPath("format-ids-as-hex") && conf.getBoolean("format-ids-as-hex")
+      Money(enabled, handler, applicationName, hostName, factory, tracer, logExceptions, formatIdsAsHex, asyncNotificationHandlerChain)
     } else {
       disabled(applicationName, hostName)
     }

--- a/money-core/src/test/scala/com/comcast/money/core/FormattersSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/FormattersSpec.scala
@@ -104,24 +104,42 @@ class FormattersSpec extends WordSpec with Matchers with GeneratorDrivenProperty
           case B3TraceIdHeader if traceIdValue.getLeastSignificantBits == 0 => v shouldBe traceIdValue.toString.fromGuid.substring(0, 16)
           case B3TraceIdHeader => v shouldBe traceIdValue.toString.fromGuid
           case B3ParentSpanIdHeader if expectedSpanId.isRoot => Failed
-          case B3ParentSpanIdHeader => parentSpanIdValue.toHexString
-          case B3SpanIdHeader => v shouldBe spanIdValue.toHexString
+          case B3ParentSpanIdHeader => v shouldBe f"${parentSpanIdValue}%016x"
+          case B3SpanIdHeader => v shouldBe f"${spanIdValue}%016x"
         })
       }
     }
 
-    "convert a string from hexadecimal to long" in {
-      forAll(genHexStrFromLong) { hexStr: String =>
-        {
-          val actualLong = hexStr.fromHexStringToLong
-          actualLong.toHexString shouldBe hexStr
-        }
+    "read a traceparent http header" in {
+      forAll { (traceIdValue: UUID, spanIdValue: Long) =>
+        val expectedSpanId = new SpanId(traceIdValue.toString, spanIdValue, spanIdValue)
+        val spanId = fromTraceParentHeader(
+          getHeader = {
+            case TraceParentHeader => TraceParentHeaderFormat.format(expectedSpanId.traceId.fromGuid, expectedSpanId.selfId)
+          })
+        spanId should not be None
+        spanId.get.traceId shouldBe traceIdValue.toString
+        spanId.get.selfId shouldBe spanIdValue
       }
     }
 
-    "fail to convert a non-hex string from hexadecimal to long" in {
-      intercept[NumberFormatException] { "".fromHexStringToLong }
-      intercept[NumberFormatException] { "z".fromHexStringToLong }
+    "fail to read traceparent headers correctly for invalid headers" in {
+      forAll { (traceIdValue: String, parentSpanIdValue: String, spanIdValue: String) =>
+        val spanId = fromTraceParentHeader(
+          getHeader = {
+            case TraceParentHeader => "garbage"
+          })
+        spanId shouldBe None
+      }
+    }
+
+    "create traceparent headers correctly given any valid character UUID for trace-Id and any valid long integers for parent and span ID" in {
+      forAll { (traceIdValue: UUID, spanIdValue: Long) =>
+        val expectedSpanId = new SpanId(traceIdValue.toString, spanIdValue, spanIdValue)
+        Formatters.toTraceParentHeader(expectedSpanId, (k, v) => k match {
+          case TraceParentHeader => v shouldBe f"00-${traceIdValue.toString.fromGuid}%s-${spanIdValue}%016x-00"
+        })
+      }
     }
 
     "convert a string to guid format" in {

--- a/money-core/src/test/scala/com/comcast/money/core/internal/MDCSupportSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/internal/MDCSupportSpec.scala
@@ -30,12 +30,18 @@ class MDCSupportSpec extends WordSpec with Matchers with BeforeAndAfterEach with
 
   override def beforeEach() = {
     SpanLocal.clear()
+    MDC.clear()
   }
 
   "MDCSupport" should {
     "set the span in MDC when provide" in {
       testMDCSupport.setSpanMDC(Some(spanId))
       MDC.get("moneyTrace") shouldEqual MDCSupport.format(spanId)
+    }
+    "set the span in MDC in hex format" in {
+      val mdcSupportFormatAsHex = new MDCSupport(true, true)
+      mdcSupportFormatAsHex.setSpanMDC(Some(spanId))
+      MDC.get("moneyTrace") shouldEqual MDCSupport.format(spanId, formatIdsAsHex = true)
     }
     "clear the MDC value when set to None" in {
       testMDCSupport.setSpanMDC(Some(spanId))
@@ -45,13 +51,13 @@ class MDCSupportSpec extends WordSpec with Matchers with BeforeAndAfterEach with
       MDC.get("moneyTrace") shouldBe null
     }
     "not be run if tracing is disabled" in {
-      val disabled = new MDCSupport(false)
+      val disabled = new MDCSupport(false, false)
       disabled.setSpanMDC(Some(spanId))
       MDC.get("moneyTrace") shouldBe null
     }
     "not propogate MDC if disabled" in {
       val mdcContext: mutable.Map[_, _] = mutable.HashMap("FINGERPRINT" -> "print")
-      val disabled = new MDCSupport(false)
+      val disabled = new MDCSupport(false, false)
       disabled.propogateMDC(Some(mdcContext.asJava))
       MDC.get("FINGERPRINT") shouldBe null
     }

--- a/money-http-client/src/test/scala/com/comcast/money/http/client/TraceFriendlyHttpClientSpec.scala
+++ b/money-http-client/src/test/scala/com/comcast/money/http/client/TraceFriendlyHttpClientSpec.scala
@@ -69,7 +69,8 @@ class TraceFriendlyHttpClientSpec extends WordSpec with SpecHelpers
     verify(underTest.tracer).record("http-response-code", 200L)
     verify(httpUriRequest).setHeader("X-MoneyTrace", s"trace-id=${spanId.traceId};parent-id=${spanId.parentId};span-id=${spanId.selfId}")
     verify(httpUriRequest).setHeader("X-B3-TraceId", spanId.traceId.replace("-", ""))
-    verify(httpUriRequest).setHeader("X-B3-SpanId", spanId.selfId().toHexString)
+    verify(httpUriRequest).setHeader("X-B3-SpanId", f"${spanId.selfId}%016x")
+    verify(httpUriRequest).setHeader("traceparent", f"00-${spanId.traceId.replace("-", "")}%s-${spanId.selfId}%016x-00")
   }
 
   "TraceFriendlyHttpClient" should {


### PR DESCRIPTION
Adds reading/writing of W3C Trace Context `traceparent` header. Also adds configuration option to format trace ID and span ID in MDC as hex in the same format as OpenTelemetry IDs. Fixes formatting of ZipKin B3 headers which need to be padded to 16 characters.