### PR TITLE
Fix resolver URIs to https

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -189,7 +189,7 @@ def basicSettings =  Defaults.itSettings ++ SbtScalariform.scalariformSettings +
   scalaVersion := "2.12.6",
   resolvers ++= Seq(
     "spray repo" at "http://repo.spray.io/",
-    "Sonatype OSS Releases" at "http://oss.sonatype.org/content/repositories/releases/"
+    "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases/"
   ),
   scalacOptions ++= Seq(
     "-unchecked",
@@ -237,8 +237,8 @@ def basicSettings =  Defaults.itSettings ++ SbtScalariform.scalariformSettings +
       } yield entry.data).headOption
     }
     val links: Seq[Option[(File, URL)]] = Seq(
-      findManagedDependency("org.scala-lang", "scala-library").map(d => d -> url(s"http://www.scala-lang.org/api/2.10.4/")),
-      findManagedDependency("com.typesafe", "config").map(d => d -> url("http://typesafehub.github.io/config/latest/api/"))
+      findManagedDependency("org.scala-lang", "scala-library").map(d => d -> url(s"https://www.scala-lang.org/api/2.12.6/")),
+      findManagedDependency("com.typesafe", "config").map(d => d -> url("https://typesafehub.github.io/config/latest/api/"))
     )
     val x = links.collect { case Some(d) => d }.toMap
     println("links: " + x)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 logLevel := Level.Warn
 
 // The Typesafe repository
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.5.1")
 


### PR DESCRIPTION
Updates the resolver URIs to https for repositories that require secure connections.  Keep spray.io repository over http as it gets an SSL handshake error over https.