### PR TITLE
Clean up some warnings and a typo in a public method

### DIFF
--- a/money-akka/src/main/scala/com/comcast/money/akka/MoneyExtension.scala
+++ b/money-akka/src/main/scala/com/comcast/money/akka/MoneyExtension.scala
@@ -49,7 +49,7 @@ object MoneyExtension extends ExtensionId[MoneyExtension] with ExtensionIdProvid
    *
    * @return MoneyExtension
    */
-  override def lookup = MoneyExtension
+  override def lookup() = MoneyExtension
 
   /**
    * Creates an instance of the [[MoneyExtension]] from config

--- a/money-akka/src/main/scala/com/comcast/money/akka/SpanContextWithStack.scala
+++ b/money-akka/src/main/scala/com/comcast/money/akka/SpanContextWithStack.scala
@@ -93,7 +93,7 @@ class SpanContextWithStack() extends SpanContext {
    * @return Option[Span]
    */
 
-  override def pop: Option[Span] =
+  override def pop(): Option[Span] =
     stack.headOption match {
       case someSpan: Some[Span] =>
         stack = stack.tail
@@ -112,7 +112,7 @@ class SpanContextWithStack() extends SpanContext {
    * @return
    */
 
-  override def current: Option[Span] = stack.headOption
+  override def current(): Option[Span] = stack.headOption
 
   /**
    * CAUTION THIS WILL CAUSE ALL THE STARTED SPANS TO NOT BE STOPPED
@@ -122,5 +122,5 @@ class SpanContextWithStack() extends SpanContext {
    * empties the Stack of all spans
    */
 
-  override def clear: Unit = stack = List.empty[Span]
+  override def clear(): Unit = stack = List.empty[Span]
 }

--- a/money-akka/src/main/scala/com/comcast/money/akka/SpanContextWithStack.scala
+++ b/money-akka/src/main/scala/com/comcast/money/akka/SpanContextWithStack.scala
@@ -112,7 +112,7 @@ class SpanContextWithStack() extends SpanContext {
    * @return
    */
 
-  override def current(): Option[Span] = stack.headOption
+  override def current: Option[Span] = stack.headOption
 
   /**
    * CAUTION THIS WILL CAUSE ALL THE STARTED SPANS TO NOT BE STOPPED

--- a/money-core/src/main/scala/com/comcast/money/core/Formatters.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Formatters.scala
@@ -156,7 +156,7 @@ object Formatters {
   private[core] def toTraceParentHeader(spanId: SpanId, addHeader: (String, String) => Unit): Unit =
     addHeader(TraceParentHeader, TraceParentHeaderFormat.format(spanId.traceId.fromGuid, spanId.selfId))
 
-  def setResponseHeaders(getHeader: String => String, addHeader: (String, String) => Unit) {
+  def setResponseHeaders(getHeader: String => String, addHeader: (String, String) => Unit): Unit = {
     def setResponseHeader(headerName: String): Unit = Option(getHeader(headerName)).foreach(v => addHeader(headerName, v))
     Seq(MoneyTraceHeader, B3TraceIdHeader, B3ParentSpanIdHeader, B3SpanIdHeader, TraceParentHeader).foreach(setResponseHeader)
   }

--- a/money-core/src/main/scala/com/comcast/money/core/Tracer.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Tracer.scala
@@ -256,7 +256,7 @@ trait Tracer extends Closeable {
    * @param result The result of the span, this will be Result.success or Result.failed
    */
   def stopSpan(result: Boolean = true): Unit = {
-    spanContext.pop foreach {
+    spanContext.pop() foreach {
       span =>
         span.stop(result)
     }

--- a/money-core/src/main/scala/com/comcast/money/core/concurrent/TraceFriendlyExecutionContextExecutor.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/concurrent/TraceFriendlyExecutionContextExecutor.scala
@@ -34,7 +34,7 @@ class TraceFriendlyExecutionContextExecutor(wrapped: ExecutionContext)
     wrapped.execute(
       new Runnable {
         override def run = {
-          mdcSupport.propogateMDC(Option(submittingThreadsContext))
+          mdcSupport.propagateMDC(Option(submittingThreadsContext))
           SpanLocal.clear()
           inherited.foreach(SpanLocal.push)
           try {

--- a/money-core/src/main/scala/com/comcast/money/core/concurrent/TraceFriendlyThreadPoolExecutor.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/concurrent/TraceFriendlyThreadPoolExecutor.scala
@@ -70,7 +70,7 @@ class TraceFriendlyThreadPoolExecutor(corePoolSize: Int, maximumPoolSize: Int, k
     super.execute(
       new Runnable {
         override def run = {
-          mdcSupport.propogateMDC(Option(submittingThreadsContext))
+          mdcSupport.propagateMDC(Option(submittingThreadsContext))
           SpanLocal.clear()
           inherited.foreach(SpanLocal.push)
           try {

--- a/money-core/src/main/scala/com/comcast/money/core/internal/MDCSupport.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/internal/MDCSupport.scala
@@ -18,7 +18,7 @@ package com.comcast.money.core.internal
 
 import java.util.Map
 
-import com.comcast.money.api.SpanId
+import com.comcast.money.api.{ Span, SpanId }
 import com.comcast.money.core.Money
 import org.slf4j.MDC
 
@@ -50,27 +50,22 @@ class MDCSupport(
   private val MoneyTraceKey = "moneyTrace"
   private val SpanNameKey = "spanName"
 
-  def setSpanMDC(spanId: Option[SpanId]): Unit = if (enabled) {
-    spanId match {
-      case Some(id) => MDC.put(MoneyTraceKey, MDCSupport.format(id, formatIdsAsHex))
-      case None => MDC.remove(MoneyTraceKey)
+  def setSpanMDC(span: Option[Span]): Unit = if (enabled) {
+    span match {
+      case Some(s) =>
+        MDC.put(MoneyTraceKey, MDCSupport.format(s.info.id, formatIdsAsHex))
+        MDC.put(SpanNameKey, s.info.name)
+      case None =>
+        MDC.remove(MoneyTraceKey)
+        MDC.remove(MoneyTraceKey)
+        MDC.remove(SpanNameKey)
     }
   }
 
-  def propogateMDC(submittingThreadsContext: Option[Map[_, _]]): Unit = if (enabled) {
+  def propagateMDC(submittingThreadsContext: Option[Map[String, String]]): Unit = if (enabled) {
     submittingThreadsContext match {
       case Some(context: Map[String, String]) => MDC.setContextMap(context)
       case None => MDC.clear()
     }
   }
-
-  def setSpanNameMDC(spanName: Option[String]) =
-    if (enabled) {
-      spanName match {
-        case Some(name) => MDC.put(SpanNameKey, name)
-        case None => MDC.remove(SpanNameKey)
-      }
-    }
-
-  def getSpanNameMDC: Option[String] = Option(MDC.get(SpanNameKey))
 }

--- a/money-core/src/main/scala/com/comcast/money/core/internal/SpanLocal.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/internal/SpanLocal.scala
@@ -18,8 +18,6 @@ package com.comcast.money.core.internal
 
 import com.comcast.money.api.Span
 
-import scala.collection.mutable.Stack
-
 trait SpanContext {
   def push(span: Span): Unit
 
@@ -37,7 +35,7 @@ trait SpanContext {
 object SpanLocal extends SpanContext {
 
   // A stack of span ids for the current thread
-  private[this] val threadLocalCtx = new ThreadLocal[Stack[Span]]
+  private[this] val threadLocalCtx = new ThreadLocal[List[Span]]
 
   private lazy val mdcSupport = new MDCSupport()
 
@@ -46,38 +44,32 @@ object SpanLocal extends SpanContext {
   override def current: Option[Span] = Option(threadLocalCtx.get).flatMap(_.headOption)
 
   override def push(span: Span): Unit =
-    if (span != null)
-      Option(threadLocalCtx.get) match {
-        case Some(stack) =>
-          stack.push(span)
-          setSpanMDC(Some(span.info.id))
-          setSpanNameMDC(Some(span.info.name))
-        case None =>
-          threadLocalCtx.set(new Stack[Span]())
-          push(span)
+    if (span != null) {
+      val updatedContext = Option(threadLocalCtx.get) match {
+        case Some(existingContext) => span :: existingContext
+        case None => List(span)
       }
+      threadLocalCtx.set(updatedContext)
+      setSpanMDC(Some(span))
+    }
 
   override def pop(): Option[Span] =
-    Option(threadLocalCtx.get).map {
-      stack =>
-        // remove the current span in scope for this thread
-        val spanId = stack.pop()
-
-        // rolls back the mdc span to the parent if present, if none then it will be cleared
-        val head = stack.headOption
-        setSpanMDC(head.map(_.info.id))
-        setSpanNameMDC(head.map(_.info.name))
-
-        spanId
+    Option(threadLocalCtx.get) match {
+      case Some(span :: remaining) =>
+        threadLocalCtx.set(remaining)
+        setSpanMDC(remaining.headOption)
+        Some(span)
+      case _ =>
+        threadLocalCtx.remove()
+        setSpanMDC(None)
+        None
     }
 
   /**
    * Clears the entire call stack for the thread
    */
-  override def clear() = {
-    if (threadLocalCtx != null) threadLocalCtx.remove()
-
+  override def clear(): Unit = {
+    threadLocalCtx.remove()
     setSpanMDC(None)
-    setSpanNameMDC(None)
   }
 }

--- a/money-core/src/main/scala/com/comcast/money/core/internal/SpanLocal.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/internal/SpanLocal.scala
@@ -21,11 +21,11 @@ import com.comcast.money.api.Span
 trait SpanContext {
   def push(span: Span): Unit
 
-  def pop: Option[Span]
+  def pop(): Option[Span]
 
   def current: Option[Span]
 
-  def clear: Unit
+  def clear(): Unit
 }
 
 /**

--- a/money-core/src/main/scala/com/comcast/money/core/logging/MethodTracer.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/logging/MethodTracer.scala
@@ -77,7 +77,7 @@ trait MethodTracer extends Reflections with TraceLogging {
     handler <- asyncNotifier.resolveHandler(method.getReturnType, returnValue)
 
     // pop the current span from the stack as it will not be stopped by the tracer
-    span <- spanContext.pop
+    span <- spanContext.pop()
     // capture the current MDC context to be applied on the callback thread
     mdc = Option(MDC.getCopyOfContextMap)
 

--- a/money-core/src/main/scala/com/comcast/money/core/logging/MethodTracer.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/logging/MethodTracer.scala
@@ -83,7 +83,7 @@ trait MethodTracer extends Reflections with TraceLogging {
 
     result = handler.whenComplete(method.getReturnType, returnValue) { completed =>
       // reapply the MDC onto the callback thread
-      mdcSupport.propogateMDC(mdc)
+      mdcSupport.propagateMDC(mdc)
 
       // determine if the future completed successfully or exceptionally
       val result = completed match {

--- a/money-core/src/test/scala/com/comcast/money/core/SpecHelpers.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/SpecHelpers.scala
@@ -82,13 +82,13 @@ trait SpecHelpers extends Eventually { this: Matchers =>
       s"Not expected span info that $message found after $wait")
   }
 
-  def expectLogMessageContaining(contains: String, wait: FiniteDuration = 2.seconds) {
+  def expectLogMessageContaining(contains: String, wait: FiniteDuration = 2.seconds): Unit = {
     awaitCond(
       LogRecord.contains("log")(_.contains(contains)), wait, 100 milliseconds,
       s"Expected log message containing string $contains not found after $wait")
   }
 
-  def expectLogMessageContainingStrings(strings: Seq[String], wait: FiniteDuration = 2.seconds) {
+  def expectLogMessageContainingStrings(strings: Seq[String], wait: FiniteDuration = 2.seconds): Unit = {
     awaitCond(
       LogRecord.contains("log")(s => strings.forall(s.contains)), wait, 100 milliseconds,
       s"Expected log message containing $strings not found after $wait")

--- a/money-core/src/test/scala/com/comcast/money/core/internal/SpanLocalSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/internal/SpanLocalSpec.scala
@@ -37,6 +37,9 @@ class SpanLocalSpec extends AnyWordSpec
         SpanLocal.push(testSpan)
         SpanLocal.current shouldEqual Some(testSpan)
       }
+      "return None with no span local value" in {
+        SpanLocal.current shouldEqual None
+      }
       "clear the stored value" in {
         SpanLocal.push(testSpan)
 
@@ -63,6 +66,9 @@ class SpanLocalSpec extends AnyWordSpec
         val popped = SpanLocal.pop()
         popped shouldEqual Some(nested)
         SpanLocal.current shouldEqual Some(testSpan)
+      }
+      "pop None with no span local value" in {
+        SpanLocal.pop() shouldEqual None
       }
       "set the MDC value on push" in {
         SpanLocal.push(testSpan)

--- a/money-core/src/test/scala/com/comcast/money/core/logging/MethodTracerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/logging/MethodTracerSpec.scala
@@ -119,11 +119,11 @@ class MethodTracerSpec extends AnyWordSpec with Matchers with MockitoSugar with 
         when(mockAsyncNotifier.resolveHandler(classOf[String], "result")).thenReturn(Some(handler))
 
         val span = mock[Span]
-        when(mockSpanContext.pop).thenReturn(Some(span))
+        when(mockSpanContext.pop()).thenReturn(Some(span))
         val result = methodTracer.traceMethod(method, traced, empty, proceed)
 
         verify(mockTracer).startSpan(traced.value())
-        verify(mockSpanContext).pop
+        verify(mockSpanContext).pop()
         verify(mockTracer, never()).stopSpan(argAny())
 
         result shouldBe "result2"
@@ -144,11 +144,11 @@ class MethodTracerSpec extends AnyWordSpec with Matchers with MockitoSugar with 
         when(mockAsyncNotifier.resolveHandler(classOf[String], "result")).thenReturn(Some(handler))
 
         val span = mock[Span]
-        when(mockSpanContext.pop).thenReturn(Some(span))
+        when(mockSpanContext.pop()).thenReturn(Some(span))
         val result = methodTracer.traceMethod(method, traced, empty, proceed)
 
         verify(mockTracer).startSpan(traced.value())
-        verify(mockSpanContext).pop
+        verify(mockSpanContext).pop()
         verify(mockTracer, never()).stopSpan(argAny())
 
         result shouldBe "result2"
@@ -169,11 +169,11 @@ class MethodTracerSpec extends AnyWordSpec with Matchers with MockitoSugar with 
         when(mockAsyncNotifier.resolveHandler(classOf[String], "result")).thenReturn(Some(handler))
 
         val span = mock[Span]
-        when(mockSpanContext.pop).thenReturn(Some(span))
+        when(mockSpanContext.pop()).thenReturn(Some(span))
         val result = methodTracer.traceMethod(method, traced, empty, proceed)
 
         verify(mockTracer).startSpan(traced.value())
-        verify(mockSpanContext).pop
+        verify(mockSpanContext).pop()
         verify(mockTracer, never()).stopSpan(argAny())
 
         result shouldBe "result2"

--- a/samples/samples-springmvc/src/main/java/com/comcast/money/samples/springmvc/services/NestedService.java
+++ b/samples/samples-springmvc/src/main/java/com/comcast/money/samples/springmvc/services/NestedService.java
@@ -2,8 +2,8 @@ package com.comcast.money.samples.springmvc.services;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.client.HttpClient;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
 import org.springframework.stereotype.Component;
 
@@ -13,7 +13,7 @@ import com.comcast.money.http.client.TraceFriendlyHttpClient;
 @Component
 public class NestedService {
 
-    private HttpClient httpClient = new TraceFriendlyHttpClient(new DefaultHttpClient());
+    private HttpClient httpClient = new TraceFriendlyHttpClient(HttpClientBuilder.create().build());
 
     @Traced("NESTED_SERVICE")
     public String doSomethingElse(String message) throws Exception {
@@ -35,7 +35,7 @@ public class NestedService {
 
             // need to call EntityUtils in order to tie into the http trace aspect
             // if you sniff the request, you will also see the X-MoneyTrace request header in the HTTP request
-            String result = EntityUtils.toString(response.getEntity());
+            EntityUtils.consumeQuietly(response.getEntity());
             Thread.sleep(1);
         } catch(Exception ex) {
             // just eat it


### PR DESCRIPTION
Clean up most of the Scala 2.12 warnings.  Many of the Scala 2.13 warnings cannot currently be addressed with code that can cross-compile with Scala 2.12.

Replace use of deprecated `Stack[Span]` in `SpanLocal` with `List[Span]` treated as a stack.

Fix typo in name of `MDCSupport.propagateMDC` method.