### PR TITLE
Bump sbt version to 1.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 target
 ajcore.*.txt
 .bloop/
+.bsp/
 .metals/
 .vscode/
 .metals/

--- a/build.sbt
+++ b/build.sbt
@@ -170,7 +170,7 @@ def basicSettings =  Defaults.itSettings ++ Seq(
   scalaVersion := "2.12.12",
   crossScalaVersions := List("2.13.3", "2.12.12"),
   resolvers ++= Seq(
-    "spray repo" at "http://repo.spray.io/",
+    ("spray repo" at "http://repo.spray.io/").withAllowInsecureProtocol(true),
     "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases/"
   ),
   scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -11,13 +11,14 @@ lazy val copyApiDocsTask = taskKey[Unit]("Copies the scala docs from each projec
 
 lazy val props = new SystemProperties()
 
-lazy val money = Project("money", file("."))
-.settings(projectSettings: _*)
-.settings(
-  publishLocal := {},
-  publish := {}
-)
-.aggregate(moneyApi, moneyAkka, moneyCore, moneyAspectj, moneyHttpClient, moneyJavaServlet, moneyWire, moneyKafka, moneySpring)
+lazy val money =
+  Project("money", file("."))
+    .settings(projectSettings: _*)
+    .settings(
+      publishLocal := {},
+      publish := {}
+    )
+    .aggregate(moneyApi, moneyAkka, moneyCore, moneyAspectj, moneyHttpClient, moneyJavaServlet, moneyWire, moneyKafka, moneySpring)
 
 lazy val moneyApi =
   Project("money-api", file("./money-api"))
@@ -60,15 +61,15 @@ lazy val moneyAkka =
 
 lazy val moneyAspectj =
   Project("money-aspectj", file("./money-aspectj"))
-  .enablePlugins(SbtAspectj, AutomateHeaderPlugin)
-  .settings(aspectjProjectSettings: _*)
-  .settings(
-    libraryDependencies ++=
-      Seq(
-        typesafeConfig,
-      ) ++ commonTestDependencies
-  )
-  .dependsOn(moneyCore % "test->test;compile->compile")
+    .enablePlugins(SbtAspectj, AutomateHeaderPlugin)
+    .settings(aspectjProjectSettings: _*)
+    .settings(
+      libraryDependencies ++=
+        Seq(
+          typesafeConfig,
+        ) ++ commonTestDependencies
+    )
+    .dependsOn(moneyCore % "test->test;compile->compile")
 
 lazy val moneyHttpClient =
   Project("money-http-client", file("./money-http-client"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.4.0


### PR DESCRIPTION
Bumps the build to using the latest release of sbt.  Requires specifying that spray.io repository can be used without SSL.