### PR TITLE
Add config to format span IDs as hex in logging span handlers

### DIFF
--- a/money-core/src/main/scala/com/comcast/money/core/handlers/SpanLogFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/handlers/SpanLogFormatter.scala
@@ -27,6 +27,7 @@ object SpanLogFormatter {
       nullValue = configValue("formatting.null-value", "NULL"),
       logTemplate = configValue("formatting.log-template", "[ %s=%s ]"),
       spanDurationMsEnabled = configEnabled("formatting.span-duration-ms-enabled"),
+      formatIdsAsHex = configEnabled("formatting.format-ids-as-hex"),
       spanIdKey = configValue("formatting.keys.span-id", "span-id"),
       traceIdKey = configValue("formatting.keys.trace-id", "trace-id"),
       parentIdKey = configValue("formatting.keys.parent-id", "parent-id"),
@@ -56,6 +57,7 @@ class SpanLogFormatter(
   val nullValue: String,
   val logTemplate: String,
   val spanDurationMsEnabled: Boolean,
+  val formatIdsAsHex: Boolean,
   val spanIdKey: String,
   val traceIdKey: String,
   val parentIdKey: String,
@@ -69,9 +71,9 @@ class SpanLogFormatter(
   def buildMessage(spanInfo: SpanInfo): String = {
     implicit val builder = new StringBuilder()
     builder.append(spanStart)
-    append(spanIdKey, spanInfo.id.selfId)
-    append(traceIdKey, spanInfo.id.traceId)
-    append(parentIdKey, spanInfo.id.parentId)
+    append(spanIdKey, if (formatIdsAsHex) spanInfo.id.selfIdAsHex else spanInfo.id.selfId)
+    append(traceIdKey, if (formatIdsAsHex) spanInfo.id.traceIdAsHex else spanInfo.id.traceId)
+    append(parentIdKey, if (formatIdsAsHex) spanInfo.id.parentIdAsHex else spanInfo.id.parentId)
     append(spanNameKey, spanInfo.name)
     append(appNameKey, spanInfo.appName)
     append(startTimeKey, spanInfo.startTimeMillis)

--- a/money-core/src/main/scala/com/comcast/money/core/handlers/StructuredLogSpanHandler.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/handlers/StructuredLogSpanHandler.scala
@@ -45,6 +45,7 @@ class StructuredLogSpanHandler(
   import com.comcast.money.core.handlers.LoggingSpanHandler._
 
   protected var logFunction: LogFunction = logger.info
+  protected var formatIdsAsHex: Boolean = false
 
   def configure(config: Config): Unit = {
 
@@ -60,15 +61,18 @@ class StructuredLogSpanHandler(
         case "TRACE" => logFunction = logger.trace
       }
     }
+    if (config.hasPath("formatting.format-ids-as-hex")) {
+      formatIdsAsHex = config.getBoolean("formatting.format-ids-as-hex")
+    }
   }
 
   def handle(spanInfo: SpanInfo): Unit = {
     import scala.collection.JavaConverters._
     val baseFields = Seq(
       // The field names below are the same as cedi-dtrace. This makes it easier to query a transaction in elastic search.
-      ("trace-id", spanInfo.id.traceId()),
-      ("parent-id", spanInfo.id.parentId()),
-      ("span-id", spanInfo.id.selfId()),
+      ("trace-id", if (formatIdsAsHex) spanInfo.id.traceIdAsHex() else spanInfo.id.traceId()),
+      ("parent-id", if (formatIdsAsHex) spanInfo.id.parentIdAsHex() else spanInfo.id.parentId()),
+      ("span-id", if (formatIdsAsHex) spanInfo.id.selfIdAsHex() else spanInfo.id.selfId()),
       ("span-name", spanInfo.name()),
       ("app", spanInfo.appName()),
       ("host", spanInfo.host()),

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/SpanLogFormatterSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/SpanLogFormatterSpec.scala
@@ -37,8 +37,9 @@ class SpanLogFormatterSpec extends AnyWordSpec with Matchers {
     """)
   val spanLogFormatter = SpanLogFormatter(emitterConf)
 
+  val spanId = new SpanId("01234567-890A-BCDE-F012-34567890ABCD", 81985529216486895L, 81985529216486895L)
   val sampleData = CoreSpanInfo(
-    id = SpanId.fromString("SpanId~1~1~1"),
+    id = spanId,
     startTimeNanos = 1000000L,
     endTimeNanos = 26000000L,
     durationNanos = 35000000L,
@@ -49,7 +50,7 @@ class SpanLogFormatterSpec extends AnyWordSpec with Matchers {
     status = StatusCanonicalCode.OK)
 
   val withNull = CoreSpanInfo(
-    id = SpanId.fromString("SpanId~1~1~1"),
+    id = spanId,
     startTimeNanos = 1000000L,
     endTimeNanos = 26000000L,
     durationNanos = 35000000L,
@@ -64,8 +65,8 @@ class SpanLogFormatterSpec extends AnyWordSpec with Matchers {
       val actualMessage = spanLogFormatter.buildMessage(sampleData)
 
       assert(
-        actualMessage === ("Span: [ span-id=1 ][ trace-id=1 ][ parent-id=1 ][ span-name=key ][ app-name=unknown ][ " +
-          "start-time=1 ][ span-duration=35000 ][ span-success=true ][ bob=craig ][ what=1 ][ when=2 ]"))
+        actualMessage === ("Span: [ span-id=81985529216486895 ][ trace-id=01234567-890A-BCDE-F012-34567890ABCD ][ parent-id=81985529216486895 ]" +
+          "[ span-name=key ][ app-name=unknown ][ start-time=1 ][ span-duration=35000 ][ span-success=true ][ bob=craig ][ what=1 ][ when=2 ]"))
     }
     "honor key names from the config" in {
       val conf = ConfigFactory.parseString(
@@ -90,8 +91,8 @@ class SpanLogFormatterSpec extends AnyWordSpec with Matchers {
 
       val actualMessage = spanLogFormatter.buildMessage(sampleData)
       assert(
-        actualMessage === ("Span: [ spanId=1 ][ traceId=1 ][ parentId=1 ][ spanName=key ][ appName=unknown ][ " +
-          "startTime=1 ][ spanDuration=35000 ][ spanSuccess=true ][ bob=craig ][ what=1 ][ when=2 ]"))
+        actualMessage === ("Span: [ spanId=81985529216486895 ][ traceId=01234567-890A-BCDE-F012-34567890ABCD ][ parentId=81985529216486895 ]" +
+          "[ spanName=key ][ appName=unknown ][ startTime=1 ][ spanDuration=35000 ][ spanSuccess=true ][ bob=craig ][ what=1 ][ when=2 ]"))
     }
     "honor the span-start from the config" in {
       val conf = ConfigFactory.parseString(
@@ -106,8 +107,8 @@ class SpanLogFormatterSpec extends AnyWordSpec with Matchers {
       val spanLogFormatter = SpanLogFormatter(conf)
       val actualMessage = spanLogFormatter.buildMessage(sampleData)
       assert(
-        actualMessage === ("Start :|: [ span-id=1 ][ trace-id=1 ][ parent-id=1 ][ span-name=key ][ app-name=unknown ][ " +
-          "start-time=1 ][ span-duration=35000 ][ span-success=true ][ bob=craig ][ what=1 ][ when=2 ]"))
+        actualMessage === ("Start :|: [ span-id=81985529216486895 ][ trace-id=01234567-890A-BCDE-F012-34567890ABCD ][ parent-id=81985529216486895 ]" +
+          "[ span-name=key ][ app-name=unknown ][ start-time=1 ][ span-duration=35000 ][ span-success=true ][ bob=craig ][ what=1 ][ when=2 ]"))
     }
     "honor the log-template from the config" in {
       val conf = ConfigFactory.parseString(
@@ -122,8 +123,8 @@ class SpanLogFormatterSpec extends AnyWordSpec with Matchers {
       val spanLogFormatter = SpanLogFormatter(conf)
       val actualMessage = spanLogFormatter.buildMessage(sampleData)
       assert(
-        actualMessage === ("""Span: span-id="1" trace-id="1" parent-id="1" span-name="key" """ +
-          """app-name="unknown" start-time="1" span-duration="35000" span-success="true" """ +
+        actualMessage === ("""Span: span-id="81985529216486895" trace-id="01234567-890A-BCDE-F012-34567890ABCD" parent-id="81985529216486895" """ +
+          """span-name="key" app-name="unknown" start-time="1" span-duration="35000" span-success="true" """ +
           """bob="craig" what="1" when="2" """))
     }
     "honor the span-duration-ms settings in the config" in {
@@ -164,6 +165,21 @@ class SpanLogFormatterSpec extends AnyWordSpec with Matchers {
       val expectedLogMessage = spanLogFormatter.buildMessage(withNull)
 
       expectedLogMessage should include("[ empty=null_value ]")
+    }
+    "honor formatting span IDs as hex" in {
+      val conf = ConfigFactory.parseString(
+        """
+              {
+                emitter="com.comcast.money.emitters.LogRecorder"
+                formatting {
+                  format-ids-as-hex = true
+                }
+              }
+        """)
+      val spanLogFormatter = SpanLogFormatter(conf)
+      val expectedLogMessage = spanLogFormatter.buildMessage(sampleData)
+
+      expectedLogMessage should include("[ span-id=0123456789abcdef ][ trace-id=01234567890abcdef01234567890abcd ][ parent-id=0123456789abcdef ]")
     }
   }
 }


### PR DESCRIPTION
Adds the `formatting.format-ids-as-hex` option to both `LoggingSpanHandler` and `StructuredLogSpanHandler` which formats the span ID components as padded hex in the same format as OpenTelemetry IDs.