### PR TITLE
Refactor SpanId API to force trace ID format to be consistent

### DIFF
--- a/money-akka/src/test/scala/com/comcast/money/akka/acceptance/http/MoneyTraceSpec.scala
+++ b/money-akka/src/test/scala/com/comcast/money/akka/acceptance/http/MoneyTraceSpec.scala
@@ -70,7 +70,7 @@ class MoneyTraceSpec extends AnyWordSpec with ScalatestRouteTest with BeforeAndA
 
     "continue a span for a request with a span" in {
       import scala.collection.immutable.Seq
-      val parentSpanId: SpanId = new SpanId()
+      val parentSpanId: SpanId = SpanId.createNew()
 
       Formatters.toHttpHeaders(parentSpanId, (name, value) => {
         val parentSpanIdHeader = HttpHeader.parse(name, value) match {

--- a/money-api/src/main/java/com/comcast/money/api/SpanId.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanId.java
@@ -85,6 +85,9 @@ public final class SpanId {
         if (!matcher.matches()) {
             throw new IllegalArgumentException("traceId is not in the required format: '" + traceId + "'");
         }
+        if (parentId == 0) {
+            parentId = selfId;
+        }
         return new SpanId(traceId, parentId, selfId, true, flags, state);
     }
 
@@ -245,6 +248,7 @@ public final class SpanId {
 
         SpanId spanId = (SpanId) o;
 
+        if (parentId != spanId.parentId) return false;
         if (selfId != spanId.selfId) return false;
         return traceId.equals(spanId.traceId);
     }
@@ -252,6 +256,7 @@ public final class SpanId {
     @Override
     public int hashCode() {
         int result = traceId.hashCode();
+        result = 31 * result + (int) (parentId ^ (parentId >>> 32));
         result = 31 * result + (int) (selfId ^ (selfId >>> 32));
         return result;
     }

--- a/money-api/src/main/java/com/comcast/money/api/SpanId.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanId.java
@@ -295,10 +295,7 @@ public final class SpanId {
 
         if (parentId != spanId.parentId) return false;
         if (selfId != spanId.selfId) return false;
-        if (remote != spanId.remote) return false;
-        if (flags != spanId.flags) return false;
-        if (!traceId.equals(spanId.traceId)) return false;
-        return state.equals(spanId.state);
+        return traceId.equals(spanId.traceId);
     }
 
     @Override
@@ -306,9 +303,6 @@ public final class SpanId {
         int result = traceId.hashCode();
         result = 31 * result + (int) (parentId ^ (parentId >>> 32));
         result = 31 * result + (int) (selfId ^ (selfId >>> 32));
-        result = 31 * result + (remote ? 1 : 0);
-        result = 31 * result + (int) flags;
-        result = 31 * result + state.hashCode();
         return result;
     }
 

--- a/money-api/src/main/java/com/comcast/money/api/SpanId.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanId.java
@@ -142,7 +142,7 @@ public final class SpanId {
     }
 
     private SpanId(String traceId, long parentId, long selfId, boolean remote, byte flags, TraceState traceState) {
-        this.traceId = traceId;
+        this.traceId = traceId.toLowerCase(Locale.US);
         this.parentId = parentId;
         this.selfId = selfId;
         this.remote = remote;
@@ -161,7 +161,7 @@ public final class SpanId {
      * @return the trace ID formatted as 32 lowercase hexadecimal characters
      */
     public String traceIdAsHex() {
-        return traceId.replace("-", "").toLowerCase(Locale.US);
+        return traceId.replace("-", "");
     }
 
     /**

--- a/money-api/src/main/java/com/comcast/money/api/SpanId.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanId.java
@@ -18,6 +18,7 @@ package com.comcast.money.api;
 
 import java.nio.ByteBuffer;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -30,58 +31,120 @@ import io.opentelemetry.trace.TraceState;
 /**
  * A unique identifier for a Span.
  */
-public class SpanId {
+public final class SpanId {
 
     private static final Random rand = new Random();
-    private static final String STRING_FORMAT = "SpanId~%s~%s~%s";
     private static final String INVALID_TRACE_ID = "00000000-0000-0000-0000-000000000000";
-    private static final SpanId INVALID_SPAN_ID = new SpanId(INVALID_TRACE_ID, 0, 0);
-    private static final Pattern TRACE_ID_PATTERN = Pattern.compile("^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$", Pattern.CASE_INSENSITIVE);
+    private static final SpanId INVALID_SPAN_ID = new SpanId(INVALID_TRACE_ID, 0L, 0L, false, (byte) 0, TraceState.getDefault());
+    private static final Pattern TRACE_ID_PATTERN = Pattern.compile("^([0-9a-f]{8})-?([0-9a-f]{4})-([0-9a-f]{4})-?([0-9a-f]{4})-?([0-9a-f]{12})$", Pattern.CASE_INSENSITIVE);
+    private static final byte SAMPLED = TraceFlags.getSampled();
 
     private final String traceId;
     private final long parentId;
     private final long selfId;
+    private final boolean remote;
+    private final byte flags;
+    private final TraceState state;
 
     /**
-     * Creates a new root span ID with a random trace ID and span ID.
+     * Creates a new root span ID
      */
-    public SpanId() {
-        this(UUID.randomUUID().toString());
+    public static SpanId createNew() {
+        return createNew(true);
     }
 
     /**
-     * Creates a new root span ID with the specified trace ID and random span ID.
+     * Creates a new root span ID
      */
-    public SpanId(String traceId) {
+    public static SpanId createNew(boolean sampled) {
+        String traceId = UUID.randomUUID().toString();
+        long selfId = randomNonZeroLong();
+        byte flags = sampled ? TraceFlags.getSampled() : TraceFlags.getDefault();
+        return new SpanId(traceId, selfId, selfId, false, flags, TraceState.getDefault());
+    }
 
-        if (traceId == null) {
-            this.traceId = UUID.randomUUID().toString();
+    /**
+     * Creates a new child span ID inheriting state from the parent span ID
+     */
+    public static SpanId createChild(SpanId parentSpanId) {
+
+        if (parentSpanId != null && parentSpanId.isValid()) {
+            return new SpanId(parentSpanId.traceId, parentSpanId.selfId, randomNonZeroLong(), false, parentSpanId.flags, parentSpanId.state);
         } else {
-            this.traceId = traceId;
+            return createNew();
         }
-        this.parentId = rand.nextLong();
-        this.selfId = this.parentId;
     }
 
     /**
-     * Creates a new child span ID with the specified trace ID and parent span ID and random span ID.
+     * @return a new remote span ID
      */
-    public SpanId(String traceId, long parentId) {
-        this(traceId, parentId, rand.nextLong());
+    public static SpanId createRemote(String traceId, long parentId, long selfId, byte flags, TraceState state) {
+
+        Objects.requireNonNull(traceId);
+        Matcher matcher = TRACE_ID_PATTERN.matcher(traceId);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("traceId is not in the required format: '" + traceId + "'");
+        }
+        return new SpanId(traceId, parentId, selfId, true, flags, state);
     }
 
     /**
-     * Creates a span ID with the specified trace ID, parent span ID and span ID.
+     * Creates a span ID from the OpenTelemetry {@link SpanContext}
      */
-    public SpanId(String traceId, long parentId, long selfId) {
-
-        if (traceId == null) {
-            this.traceId = UUID.randomUUID().toString();
+    public static SpanId fromSpanContext(SpanContext spanContext) {
+        if (spanContext.isValid()) {
+            ByteBuffer buffer = ByteBuffer.wrap(spanContext.getTraceIdBytes());
+            long traceIdHi = buffer.getLong();
+            long traceIdLo = buffer.getLong();
+            String traceId = new UUID(traceIdHi, traceIdLo).toString();
+            buffer = ByteBuffer.wrap(spanContext.getSpanIdBytes());
+            long spanId = buffer.getLong();
+            return new SpanId(traceId, spanId, spanId,
+                    spanContext.isRemote(),
+                    spanContext.getTraceFlags(),
+                    spanContext.getTraceState());
         } else {
-            this.traceId = traceId;
+            return INVALID_SPAN_ID;
         }
+    }
+
+    /**
+     * Gets an invalid span ID.
+     */
+    public static SpanId getInvalid() {
+        return INVALID_SPAN_ID;
+    }
+
+    /**
+     * Generates a random non-zero 64-bit ID that can be used as span ID
+     */
+    public static long randomNonZeroLong() {
+        long id;
+        do {
+            id = rand.nextLong();
+        } while (id == 0L);
+        return id;
+    }
+
+    /**
+     * Generates a random trace ID.
+     */
+    public static String randomTraceId() {
+        return UUID.randomUUID().toString();
+    }
+
+    // for testing purposes
+    SpanId(String traceId, long parentId, long selfId) {
+        this(traceId, parentId, selfId, false, (byte) 0, TraceState.getDefault());
+    }
+
+    private SpanId(String traceId, long parentId, long selfId, boolean remote, byte flags, TraceState traceState) {
+        this.traceId = traceId;
         this.parentId = parentId;
         this.selfId = selfId;
+        this.remote = remote;
+        this.flags = flags;
+        this.state = traceState;
     }
 
     /**
@@ -91,22 +154,23 @@ public class SpanId {
         return traceId;
     }
 
+    /**
+     * @return the trace ID formatted as 32 lowercase hexadecimal characters
+     */
     public String traceIdAsHex() {
-        Matcher matcher = TRACE_ID_PATTERN.matcher(traceId);
-        if (matcher.matches()) {
-            return matcher.replaceFirst("$1$2$3$4$5")
-                    .toLowerCase(Locale.US);
-        }
-        return traceId;
+        return traceId.replace("-", "").toLowerCase(Locale.US);
     }
 
     /**
      * @return the parent span ID, which will be the same as the span ID in the case of a root span
      */
     public long parentId() {
-        return parentId;
+        return parentId != 0 ? parentId : selfId;
     }
 
+    /**
+     * @return the parent span ID, formatted as 16 lowercase hexadecimal characters
+     */
     public String parentIdAsHex() {
         return io.opentelemetry.trace.SpanId.fromLong(parentId);
     }
@@ -118,35 +182,46 @@ public class SpanId {
         return selfId;
     }
 
+    /**
+     * @return the span ID formatted as 16 lowercase hexadecimal characters
+     */
     public String selfIdAsHex() {
         return io.opentelemetry.trace.SpanId.fromLong(selfId);
     }
 
     /**
-     * Creates a new child span ID from the current span ID.
-     */
-    public SpanId newChildId() {
-        return new SpanId(traceId, selfId);
-    }
-
-    /**
      * @return {@code true} if the span ID is a root span; otherwise, {@code false}
      */
-    public boolean isRoot() { return parentId == selfId; }
+    public boolean isRoot() {
+        return parentId == 0 || parentId == selfId;
+    }
 
     /**
      * @return {@code true} if the trace ID and span ID are valid.
      */
     public boolean isValid() {
-        return selfId != 0L
-                && traceId != null
-                && !traceId.isEmpty()
-                && !INVALID_TRACE_ID.equals(traceId);
+        return selfId != 0L && !INVALID_TRACE_ID.equals(traceId);
     }
 
-    @Override
-    public String toString() {
-        return String.format(STRING_FORMAT, traceId, parentId, selfId);
+    /**
+     * @return {@code true} if the span ID represents a remote span
+     */
+    public boolean isRemote() {
+        return remote;
+    }
+
+    /**
+     * @return {@code true} if the span ID is sampled
+     */
+    public boolean isSampled() {
+        return (flags & SAMPLED) == SAMPLED;
+    }
+
+    /**
+     * Creates a new child span ID from the current span ID
+     */
+    public SpanId createChild() {
+        return createChild(this);
     }
 
     /**
@@ -163,46 +238,6 @@ public class SpanId {
         return SpanContext.create(traceIdAsHex(), selfIdAsHex(), traceFlags, traceState);
     }
 
-    /**
-     * Creates a span ID from the String format.
-     */
-    public static SpanId fromString(String spanIdString) {
-
-        String[] parts = spanIdString.split("~");
-        if (parts.length < 4) {
-            return null;
-        }
-
-        String traceId = parts[1].trim();
-        long parentId = Long.parseLong(parts[2].trim());
-        long selfId = Long.parseLong(parts[3].trim());
-        return new SpanId(traceId, parentId, selfId);
-    }
-
-    /**
-     * Creates a span ID from the OpenTelemetry {@link SpanContext}
-     */
-    public static SpanId fromSpanContext(SpanContext spanContext) {
-        if (spanContext.isValid()) {
-            ByteBuffer buffer = ByteBuffer.wrap(spanContext.getTraceIdBytes());
-            long traceIdHi = buffer.getLong();
-            long traceIdLo = buffer.getLong();
-            String traceId = new UUID(traceIdHi, traceIdLo).toString();
-            buffer = ByteBuffer.wrap(spanContext.getSpanIdBytes());
-            long spanId = buffer.getLong();
-            return new SpanId(traceId, spanId, spanId);
-        } else {
-            return INVALID_SPAN_ID;
-        }
-    }
-
-    /**
-     * Gets an invalid span ID.
-     */
-    public static SpanId getInvalid() {
-        return INVALID_SPAN_ID;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -210,17 +245,26 @@ public class SpanId {
 
         SpanId spanId = (SpanId) o;
 
-        if (parentId != spanId.parentId) return false;
         if (selfId != spanId.selfId) return false;
         return traceId.equals(spanId.traceId);
-
     }
 
     @Override
     public int hashCode() {
         int result = traceId.hashCode();
-        result = 31 * result + (int) (parentId ^ (parentId >>> 32));
         result = 31 * result + (int) (selfId ^ (selfId >>> 32));
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return "SpanId{" +
+                "traceId='" + traceId + '\'' +
+                ", parentId=" + parentId +
+                ", selfId=" + selfId +
+                ", remote=" + remote +
+                ", flags=" + flags +
+                ", state=" + state +
+                '}';
     }
 }

--- a/money-api/src/test/scala/com/comcast/money/api/SpanIdSpec.scala
+++ b/money-api/src/test/scala/com/comcast/money/api/SpanIdSpec.scala
@@ -127,6 +127,54 @@ class SpanIdSpec extends AnyWordSpec with Matchers {
       spanId.isValid shouldBe false
     }
 
+    "parses a 128-bit hexadecimal string into a trace id" in {
+      val hex = "01234567890abcdef01234567890abcd"
+
+      val traceId = SpanId.parseTraceIdFromHex(hex)
+
+      traceId shouldBe "01234567-890a-bcde-f012-34567890abcd"
+    }
+
+    "parses a 64-bit hexadecimal string into a trace id" in {
+      val hex = "01234567890abcde"
+
+      val traceId = SpanId.parseTraceIdFromHex(hex)
+
+      traceId shouldBe "00000000-0000-0000-0123-4567890abcde"
+    }
+
+    "fails to parse a null hexadecimal string into a trace id" in {
+      assertThrows[NullPointerException] {
+        SpanId.parseTraceIdFromHex(null)
+      }
+    }
+
+    "fails to parse garbage string into a trace id" in {
+      assertThrows[IllegalArgumentException] {
+        SpanId.parseTraceIdFromHex("foo")
+      }
+    }
+
+    "parses a 64-bit hexadecimal string into a long id" in {
+      val hex = "0123456789abcdef"
+
+      val id = SpanId.parseIdFromHex(hex)
+
+      id shouldBe 81985529216486895L
+    }
+
+    "fails to parse a null hexadecimal string into a long id" in {
+      assertThrows[NullPointerException] {
+        SpanId.parseIdFromHex(null)
+      }
+    }
+
+    "fails to parse garbage hexadecimal string into a long id" in {
+      assertThrows[IllegalArgumentException] {
+        SpanId.parseIdFromHex("foo")
+      }
+    }
+
     "isValid returns false for an invalid span id" in {
       val invalidSpanId = SpanId.getInvalid
       invalidSpanId.isValid shouldBe false

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
@@ -36,7 +36,7 @@ class CoreSpanFactorySpec extends AnyWordSpec with Matchers with MockitoSugar wi
     }
 
     "create a new span given an existing span id" in {
-      val existingId = new SpanId()
+      val existingId = SpanId.createNew()
       val result = underTest.newSpan(existingId, "foo").asInstanceOf[CoreSpan]
 
       result.id shouldBe existingId

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanInfoSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanInfoSpec.scala
@@ -24,7 +24,7 @@ class CoreSpanInfoSpec extends AnyWordSpec with Matchers {
 
   "CoreSpanInfo" should {
     "have acceptable default values" in {
-      val spanId = new SpanId()
+      val spanId = SpanId.createNew()
       val underTest = CoreSpanInfo(spanId, "test")
 
       underTest.id shouldBe spanId

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanSpec.scala
@@ -24,7 +24,7 @@ import com.comcast.money.core.handlers.TestData
 import io.opentelemetry.common.{ AttributeKey, Attributes }
 import io.opentelemetry.context.Scope
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.{ EndSpanOptions, StatusCanonicalCode, Span => OtelSpan }
+import io.opentelemetry.trace.{ EndSpanOptions, StatusCanonicalCode, TraceFlags, TraceState, Span => OtelSpan }
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
 import org.scalatest.matchers.should.Matchers
@@ -35,7 +35,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
   "CoreSpan" should {
     "set the startTimeMillis and startTimeMicros when started" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
       underTest.start()
 
       val state = underTest.info
@@ -45,7 +45,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set the startTimeMillis and startTimeMicros when started with time stamps" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
       val instant = Instant.now
       underTest.start(instant.getEpochSecond, instant.getNano)
 
@@ -56,7 +56,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "record a timer" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       underTest.startTimer("foo")
       underTest.stopTimer("foo")
@@ -65,7 +65,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "record a note" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       underTest.record(testLongNote)
 
@@ -73,7 +73,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a String attribute" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       underTest.setAttribute("foo", "bar")
 
@@ -84,7 +84,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a long attribute" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       underTest.setAttribute("foo", 200L)
 
@@ -95,7 +95,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a double attribute" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       underTest.setAttribute("foo", 2.2)
 
@@ -106,7 +106,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a boolean attribute" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       underTest.setAttribute("foo", true)
 
@@ -117,7 +117,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a attribute with an attribute key" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       underTest.setAttribute(AttributeKey.stringKey("foo"), "bar")
 
@@ -128,7 +128,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "add an event with name" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       underTest.addEvent("event")
 
@@ -141,7 +141,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "add an event with name and timestamp" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       underTest.addEvent("event", 100L)
 
@@ -154,7 +154,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "add an event with name and attributes" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       underTest.addEvent("event", Attributes.of(AttributeKey.stringKey("foo"), "bar"))
 
@@ -167,7 +167,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "add an event with name, attributes and timestamp" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       underTest.addEvent("event", Attributes.of(AttributeKey.stringKey("foo"), "bar"), 100L)
 
@@ -181,7 +181,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "record an exception" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       val exception = new RuntimeException("BOOM")
       underTest.recordException(exception)
@@ -198,7 +198,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "record an exception with attributes" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       val exception = new RuntimeException("BOOM")
       underTest.recordException(exception, Attributes.of(AttributeKey.stringKey("foo"), "bar"))
@@ -217,7 +217,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "set the status to OK" in {
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
 
       underTest.setStatus(StatusCanonicalCode.OK)
 
@@ -230,7 +230,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "set the status to ERROR" in {
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
 
       underTest.setStatus(StatusCanonicalCode.ERROR)
 
@@ -243,7 +243,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "set the status to OK and stop with false result" in {
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
 
       underTest.setStatus(StatusCanonicalCode.OK)
 
@@ -256,7 +256,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "set the status to ERROR and stop with true result" in {
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
 
       underTest.setStatus(StatusCanonicalCode.ERROR)
 
@@ -269,7 +269,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "set the status with description" in {
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
 
       underTest.setStatus(StatusCanonicalCode.OK, "description")
 
@@ -277,7 +277,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "update the span name" in {
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       underTest.name shouldBe "test"
       underTest.info.name shouldBe "test"
@@ -291,7 +291,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "gets isRecording" in {
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
 
       underTest.isRecording shouldBe false
 
@@ -305,7 +305,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "gets SpanContext" in {
-      val spanId = new SpanId("01234567-890A-BCDE-F012-34567890ABCD", 81985529216486895L, 81985529216486895L)
+      val spanId = SpanId.createRemote("01234567-890A-BCDE-F012-34567890ABCD", 81985529216486895L, 81985529216486895L, TraceFlags.getSampled, TraceState.getDefault)
       val underTest = CoreSpan(spanId, "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
       val context = underTest.getContext
@@ -316,7 +316,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "set the endTimeMillis and endTimeMicros when stopped" in {
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
 
       underTest.stop(true)
 
@@ -329,7 +329,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     "invoke the span handler when stopped" in {
       val handler = mock[SpanHandler]
       val handleCaptor = ArgumentCaptor.forClass(classOf[SpanInfo])
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
 
       underTest.start()
       underTest.record(testLongNote)
@@ -350,7 +350,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     "invoke the span handler when closed" in {
       val handler = mock[SpanHandler]
       val handleCaptor = ArgumentCaptor.forClass(classOf[SpanInfo])
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
 
       underTest.start()
       underTest.record(testLongNote)
@@ -373,7 +373,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
       val scope2 = mock[Scope]
 
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
 
       underTest.attachScope(scope1)
       underTest.attachScope(scope2)
@@ -387,7 +387,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     "invoke the span handler when ended" in {
       val handler = mock[SpanHandler]
       val handleCaptor = ArgumentCaptor.forClass(classOf[SpanInfo])
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
 
       underTest.start()
       underTest.record(testLongNote)
@@ -408,7 +408,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     "invoke the span handler when ended with options" in {
       val handler = mock[SpanHandler]
       val handleCaptor = ArgumentCaptor.forClass(classOf[SpanInfo])
-      val underTest = CoreSpan(new SpanId(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
 
       underTest.start()
       underTest.record(testLongNote)

--- a/money-core/src/test/scala/com/comcast/money/core/FormattersSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/FormattersSpec.scala
@@ -58,7 +58,7 @@ class FormattersSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProp
         val spanId = SpanId.createRemote(traceIdValue.toString, parentSpanIdValue, spanIdValue, TraceFlags.getSampled, TraceState.getDefault)
         toMoneyHeader(spanId, (header, value) => {
           header shouldBe Formatters.MoneyTraceHeader
-          value shouldBe MoneyHeaderFormat.format(traceIdValue, parentSpanIdValue, spanIdValue)
+          value shouldBe MoneyHeaderFormat.format(spanId.traceId, spanId.parentId, spanId.selfId)
         })
       }
     }

--- a/money-core/src/test/scala/com/comcast/money/core/TraceGenerators.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/TraceGenerators.scala
@@ -25,6 +25,7 @@ import scala.concurrent.duration._
 import scala.language.higherKinds
 import Arbitrary.arbitrary
 import com.comcast.money.api.{ Note, Span, SpanId }
+import io.opentelemetry.trace.{ TraceFlags, TraceState }
 import org.scalacheck.Gen.{ alphaLowerChar, alphaUpperChar, choose, frequency }
 
 trait TraceGenerators {
@@ -55,7 +56,9 @@ trait TraceGenerators {
     traceId <- genUUID
     parentId <- arbitrary[Long]
     childId <- arbitrary[Long]
-  } yield new SpanId(traceId.toString, parentId, childId)
+    remoteId = SpanId.createRemote(traceId.toString, parentId, childId, TraceFlags.getSampled, TraceState.getDefault)
+    spanId = remoteId.createChild()
+  } yield spanId
 
 }
 

--- a/money-core/src/test/scala/com/comcast/money/core/concurrent/TraceFriendlyExecutionContextExecutorSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/concurrent/TraceFriendlyExecutionContextExecutorSpec.scala
@@ -48,7 +48,7 @@ class TraceFriendlyExecutionContextExecutorSpec extends AnyWordSpec
 
   "TraceFriendlyExecutionContext" should {
     "propagate the current trace local value" in {
-      val originalSpanId = new SpanId("1", 2L, 3L)
+      val originalSpanId = SpanId.createNew()
       val originalSpan = testSpan(originalSpanId)
       SpanLocal.push(originalSpan)
 
@@ -70,8 +70,8 @@ class TraceFriendlyExecutionContextExecutorSpec extends AnyWordSpec
       futureResult shouldEqual None
     }
     "propagate only the latest span id value" in {
-      val spanId1 = new SpanId()
-      val spanId2 = new SpanId()
+      val spanId1 = SpanId.createNew()
+      val spanId2 = SpanId.createNew()
       SpanLocal.push(testSpan(spanId1))
       SpanLocal.push(testSpan(spanId2))
 

--- a/money-core/src/test/scala/com/comcast/money/core/concurrent/TraceFriendlyThreadPoolExecutorSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/concurrent/TraceFriendlyThreadPoolExecutorSpec.scala
@@ -35,7 +35,7 @@ class TraceFriendlyThreadPoolExecutorSpec
 
   "TraceFriendlyThreadPoolExecutor cachedThreadPool" should {
     "propagate the current span local value" in {
-      val traceId = new SpanId("1", 2L, 3L)
+      val traceId = SpanId.createNew()
       SpanLocal.push(testSpan(traceId))
 
       val future = executor.submit(testCallable)
@@ -52,8 +52,8 @@ class TraceFriendlyThreadPoolExecutorSpec
       SpanLocal.current shouldEqual None
     }
     "propagate only the current span id value" in {
-      val traceId1 = new SpanId()
-      val traceId2 = new SpanId()
+      val traceId1 = SpanId.createNew()
+      val traceId2 = SpanId.createNew()
       SpanLocal.push(testSpan(traceId1))
       SpanLocal.push(testSpan(traceId2))
 
@@ -61,7 +61,7 @@ class TraceFriendlyThreadPoolExecutorSpec
       future.get shouldEqual Some(traceId2)
     }
     "propagate MDC" in {
-      val traceId = new SpanId("1", 2L, 3L)
+      val traceId = SpanId.createNew()
       SpanLocal.push(testSpan(traceId))
       MDC.put("foo", "bar")
 

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/SpanLogFormatterSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/SpanLogFormatterSpec.scala
@@ -37,8 +37,9 @@ class SpanLogFormatterSpec extends AnyWordSpec with Matchers {
     """)
   val spanLogFormatter = SpanLogFormatter(emitterConf)
 
+  val spanId = SpanId.createNew()
   val sampleData = CoreSpanInfo(
-    id = SpanId.fromString("SpanId~1~1~1"),
+    id = spanId,
     startTimeNanos = 1000000L,
     endTimeNanos = 26000000L,
     durationNanos = 35000000L,
@@ -49,7 +50,7 @@ class SpanLogFormatterSpec extends AnyWordSpec with Matchers {
     status = StatusCanonicalCode.OK)
 
   val withNull = CoreSpanInfo(
-    id = SpanId.fromString("SpanId~1~1~1"),
+    id = spanId,
     startTimeNanos = 1000000L,
     endTimeNanos = 26000000L,
     durationNanos = 35000000L,
@@ -64,7 +65,7 @@ class SpanLogFormatterSpec extends AnyWordSpec with Matchers {
       val actualMessage = spanLogFormatter.buildMessage(sampleData)
 
       assert(
-        actualMessage === ("Span: [ span-id=1 ][ trace-id=1 ][ parent-id=1 ][ span-name=key ][ app-name=unknown ][ " +
+        actualMessage === (s"Span: [ span-id=${spanId.selfId} ][ trace-id=${spanId.traceId} ][ parent-id=${spanId.parentId} ][ span-name=key ][ app-name=unknown ][ " +
           "start-time=1 ][ span-duration=35000 ][ span-success=true ][ bob=craig ][ what=1 ][ when=2 ]"))
     }
     "honor key names from the config" in {
@@ -90,7 +91,7 @@ class SpanLogFormatterSpec extends AnyWordSpec with Matchers {
 
       val actualMessage = spanLogFormatter.buildMessage(sampleData)
       assert(
-        actualMessage === ("Span: [ spanId=1 ][ traceId=1 ][ parentId=1 ][ spanName=key ][ appName=unknown ][ " +
+        actualMessage === (s"Span: [ spanId=${spanId.selfId} ][ traceId=${spanId.traceId} ][ parentId=${spanId.parentId} ][ spanName=key ][ appName=unknown ][ " +
           "startTime=1 ][ spanDuration=35000 ][ spanSuccess=true ][ bob=craig ][ what=1 ][ when=2 ]"))
     }
     "honor the span-start from the config" in {
@@ -106,7 +107,7 @@ class SpanLogFormatterSpec extends AnyWordSpec with Matchers {
       val spanLogFormatter = SpanLogFormatter(conf)
       val actualMessage = spanLogFormatter.buildMessage(sampleData)
       assert(
-        actualMessage === ("Start :|: [ span-id=1 ][ trace-id=1 ][ parent-id=1 ][ span-name=key ][ app-name=unknown ][ " +
+        actualMessage === (s"Start :|: [ span-id=${spanId.selfId} ][ trace-id=${spanId.traceId} ][ parent-id=${spanId.parentId} ][ span-name=key ][ app-name=unknown ][ " +
           "start-time=1 ][ span-duration=35000 ][ span-success=true ][ bob=craig ][ what=1 ][ when=2 ]"))
     }
     "honor the log-template from the config" in {
@@ -122,7 +123,7 @@ class SpanLogFormatterSpec extends AnyWordSpec with Matchers {
       val spanLogFormatter = SpanLogFormatter(conf)
       val actualMessage = spanLogFormatter.buildMessage(sampleData)
       assert(
-        actualMessage === ("""Span: span-id="1" trace-id="1" parent-id="1" span-name="key" """ +
+        actualMessage === (s"""Span: span-id="${spanId.selfId}" trace-id="${spanId.traceId}" parent-id="${spanId.parentId}" span-name="key" """ +
           """app-name="unknown" start-time="1" span-duration="35000" span-success="true" """ +
           """bob="craig" what="1" when="2" """))
     }

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/TestData.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/TestData.scala
@@ -21,7 +21,7 @@ import java.util.Collections
 import com.comcast.money.api.{ Note, SpanHandler, SpanId, SpanInfo }
 import com.comcast.money.core.{ Clock, CoreSpan, CoreSpanInfo, SystemClock }
 import com.typesafe.config.Config
-import io.opentelemetry.trace.{ StatusCanonicalCode, Span => OtelSpan }
+import io.opentelemetry.trace.{ StatusCanonicalCode, TraceFlags, TraceState, Span => OtelSpan }
 
 class ConfiguredHandler extends ConfigurableHandler {
 
@@ -47,7 +47,7 @@ trait TestData {
   val clock: Clock = SystemClock
 
   val testSpanInfo = CoreSpanInfo(
-    id = new SpanId(),
+    id = SpanId.createNew(),
     startTimeNanos = clock.now,
     endTimeNanos = clock.now,
     durationNanos = 123456000L,
@@ -58,11 +58,14 @@ trait TestData {
     notes = Map[String, Note[_]]("str" -> testStringNote, "lng" -> testLongNote, "dbl" -> testDoubleNote, "bool" -> testBooleanNote).asJava,
     events = Collections.emptyList())
 
-  val testSpan = CoreSpan(new SpanId(), "test-span", OtelSpan.Kind.INTERNAL, SystemClock, null)
-  val childSpan = CoreSpan(new SpanId(), "child-span", OtelSpan.Kind.INTERNAL, SystemClock, null)
+  val testSpanId = SpanId.createNew()
+  val testSpan = CoreSpan(testSpanId, "test-span", OtelSpan.Kind.INTERNAL, SystemClock, null)
+  val childSpanId = testSpanId.createChild()
+  val childSpan = CoreSpan(childSpanId, "child-span", OtelSpan.Kind.INTERNAL, SystemClock, null)
 
+  val fixedTestSpanId = SpanId.createRemote("5092ddfe-3701-4f84-b3d2-21f5501c0d28", 5176425846116696835L, 5176425846116696835L, TraceFlags.getSampled, TraceState.getDefault)
   val fixedTestSpanInfo = CoreSpanInfo(
-    id = new SpanId("5092ddfe-3701-4f84-b3d2-21f5501c0d28", 5176425846116696835L, 5176425846116696835L),
+    id = fixedTestSpanId,
     startTimeNanos = 100000000L,
     endTimeNanos = 300000000L,
     durationNanos = 200000L,

--- a/money-core/src/test/scala/com/comcast/money/core/internal/MDCSupportSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/internal/MDCSupportSpec.scala
@@ -32,7 +32,7 @@ import org.mockito.Mockito._
 class MDCSupportSpec extends AnyWordSpec with Matchers with MockitoSugar with BeforeAndAfterEach with OneInstancePerTest {
 
   val testMDCSupport = new MDCSupport
-  val spanId = new SpanId()
+  val spanId = SpanId.createNew()
   val span = mock[Span]
   val spanInfo = mock[SpanInfo]
 

--- a/money-core/src/test/scala/com/comcast/money/core/internal/SpanLocalSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/internal/SpanLocalSpec.scala
@@ -52,14 +52,14 @@ class SpanLocalSpec extends AnyWordSpec
         SpanLocal.current shouldEqual Some(testSpan)
       }
       "add to the existing call stack" in {
-        val nested = testSpan.copy(new SpanId())
+        val nested = testSpan.copy(SpanId.createNew())
 
         SpanLocal.push(testSpan)
         SpanLocal.push(nested)
         SpanLocal.current shouldEqual Some(nested)
       }
       "close the last added item from the call stack" in {
-        val nested = testSpan.copy(new SpanId())
+        val nested = testSpan.copy(SpanId.createNew())
         SpanLocal.push(testSpan)
         val scope = SpanLocal.push(nested)
 

--- a/money-http-client/src/test/scala/com/comcast/money/http/client/TraceFriendlyHttpClientSpec.scala
+++ b/money-http-client/src/test/scala/com/comcast/money/http/client/TraceFriendlyHttpClientSpec.scala
@@ -43,7 +43,7 @@ class TraceFriendlyHttpClientSpec extends AnyWordSpec with SpecHelpers
   val statusLine = mock[StatusLine]
   val httpHost = new HttpHost("localhost")
   val httpContext = mock[HttpContext]
-  val spanId = new SpanId()
+  val spanId = SpanId.createNew()
   val scope = mock[Scope]
 
   when(httpResponse.getStatusLine).thenReturn(statusLine)

--- a/money-java-servlet/src/test/scala/com/comcast/money/java/servlet/TraceFilterSpec.scala
+++ b/money-java-servlet/src/test/scala/com/comcast/money/java/servlet/TraceFilterSpec.scala
@@ -34,7 +34,7 @@ class TraceFilterSpec extends AnyWordSpec with Matchers with OneInstancePerTest 
   val mockRequest = mock[HttpServletRequest]
   val mockResponse = mock[HttpServletResponse]
   val mockFilterChain = mock[FilterChain]
-  val existingSpanId = new SpanId()
+  val existingSpanId = SpanId.createNew()
   val underTest = new TraceFilter()
   val MoneyTraceFormat = "trace-id=%s;parent-id=%s;span-id=%s"
   val filterChain: FilterChain = (_: ServletRequest, _: ServletResponse) => capturedSpan = SpanLocal.current
@@ -121,7 +121,7 @@ class TraceFilterSpec extends AnyWordSpec with Matchers with OneInstancePerTest 
       when(mockRequest.getHeader("X-MoneyTrace"))
         .thenReturn(MoneyTraceFormat.format(existingSpanId.traceId, existingSpanId.parentId, existingSpanId.selfId))
       when(mockRequest.getHeader("traceparent"))
-        .thenReturn(traceParentHeader(new SpanId()))
+        .thenReturn(traceParentHeader(SpanId.createNew()))
       underTest.doFilter(mockRequest, mockResponse, filterChain)
       capturedSpan.value.info.id shouldEqual existingSpanId
     }
@@ -134,7 +134,7 @@ class TraceFilterSpec extends AnyWordSpec with Matchers with OneInstancePerTest 
       when(mockRequest.getHeader("X-B3-SpanId"))
         .thenReturn(existingSpanId.selfId.toHexString)
       when(mockRequest.getHeader("traceparent"))
-        .thenReturn(traceParentHeader(new SpanId()))
+        .thenReturn(traceParentHeader(SpanId.createNew()))
       underTest.doFilter(mockRequest, mockResponse, filterChain)
       capturedSpan.value.info.id shouldEqual existingSpanId
     }

--- a/money-kafka/src/test/scala/com/comcast/money/kafka/KafkaSpanHandlerSpec.scala
+++ b/money-kafka/src/test/scala/com/comcast/money/kafka/KafkaSpanHandlerSpec.scala
@@ -66,7 +66,7 @@ class KafkaSpanHandlerSpec extends AnyWordSpec
 
     val testProducer = underTest.mockProducer
     val sampleData = TestSpanInfo(
-      id = new api.SpanId("foo", 1L),
+      id = api.SpanId.createNew(),
       name = "key",
       appName = "app",
       host = "host",

--- a/money-spring/src/test/java/com/comcast/money/spring/MoneyClientHttpInterceptorSpec.java
+++ b/money-spring/src/test/java/com/comcast/money/spring/MoneyClientHttpInterceptorSpec.java
@@ -24,7 +24,6 @@ import com.comcast.money.core.internal.SpanLocal;
 
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.trace.StatusCanonicalCode;
-import org.apache.commons.lang.math.RandomUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,15 +33,15 @@ import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 
 import java.util.Collections;
-import java.util.UUID;
 
 import static org.mockito.Mockito.*;
 
 public class MoneyClientHttpInterceptorSpec {
 
-    private final static String traceId = UUID.randomUUID().toString();
-    private final static long spanId = RandomUtils.nextLong();
-    private final static long parentSpanId = RandomUtils.nextLong();
+    private final static SpanId id = SpanId.createNew().createChild();
+    private final static String traceId = id.traceId();
+    private final static long spanId = id.selfId();
+    private final static long parentSpanId = id.parentId();
 
     private Scope spanScope;
 
@@ -50,7 +49,7 @@ public class MoneyClientHttpInterceptorSpec {
     public void setUp() {
         Span span = mock(Span.class);
         SpanInfo testSpanInfo = new CoreSpanInfo(
-                new SpanId(traceId, parentSpanId, spanId),
+                id,
                 "testName",
                 io.opentelemetry.trace.Span.Kind.INTERNAL,
                 0L,

--- a/money-wire/src/main/scala/com/comcast/money/wire/SpanConverters.scala
+++ b/money-wire/src/main/scala/com/comcast/money/wire/SpanConverters.scala
@@ -28,7 +28,7 @@ import com.comcast.money.wire.avro
 import com.comcast.money.wire.avro.NoteType
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.{ DeserializationFeature, ObjectMapper }
-import io.opentelemetry.trace.{ Span, StatusCanonicalCode }
+import io.opentelemetry.trace.{ Span, StatusCanonicalCode, TraceFlags, TraceState }
 import org.apache.avro.Schema
 import org.apache.avro.io.{ DecoderFactory, EncoderFactory }
 import org.apache.avro.specific.{ SpecificDatumReader, SpecificDatumWriter }
@@ -104,7 +104,7 @@ trait SpanWireConverters {
   }
 
   implicit val wireToSpanId: TypeConverter[avro.SpanId, api.SpanId] = TypeConverter.instance { spanId =>
-    new api.SpanId(spanId.getTraceId, spanId.getParentId, spanId.getSpanId)
+    api.SpanId.createRemote(spanId.getTraceId, spanId.getParentId, spanId.getSpanId, TraceFlags.getSampled, TraceState.getDefault)
   }
 
   implicit val spanToWire: TypeConverter[SpanInfo, avro.Span] = TypeConverter.instance { span: SpanInfo =>

--- a/money-wire/src/test/scala/com/comcast/money/wire/AvroConversionSpec.scala
+++ b/money-wire/src/test/scala/com/comcast/money/wire/AvroConversionSpec.scala
@@ -31,7 +31,7 @@ class AvroConversionSpec extends AnyWordSpec with Matchers with Inspectors {
   "Avro Conversion" should {
     "roundtrip" in {
       val orig = TestSpanInfo(
-        id = new SpanId("foo", 1L),
+        id = SpanId.createNew(),
         name = "key",
         appName = "app",
         host = "host",

--- a/money-wire/src/test/scala/com/comcast/money/wire/JsonConversionSpec.scala
+++ b/money-wire/src/test/scala/com/comcast/money/wire/JsonConversionSpec.scala
@@ -29,7 +29,7 @@ class JsonConversionSpec extends AnyWordSpec with Matchers with Inspectors {
   import scala.collection.JavaConverters._
 
   val orig = TestSpanInfo(
-    id = new SpanId("foo", 1L),
+    id = SpanId.createNew(),
     name = "key",
     appName = "app",
     host = "host",


### PR DESCRIPTION
Refactors `SpanId` so that all trace IDs are generated or validated so that the rest of Money can safely make the assumption that all trace IDs are in UUIDv4 format.  Also ensures that span flags (such as sampling and state) are propagated to child spans.

Rather than using a constructor you use one of several static methods to obtain a `SpanId` that will either generate new IDs or reuse IDs from a parent `SpanId`:

`SpanId.createNew()` - creates a new trace with a new root span id
`SpanId.createChild(SpanId)` - creates a child span for the specified parent span
`SpanId.createRemote(String, long, long, byte, TraceState)` - creates a span id from remote/propagated ids, e.g. HTTP headers
`SpanId.fromSpanContext(SpanContext)` - gets a span id for the OpenTelemetry SpanContext
`SpanId.getInvalid` - gets an invalid span id