### PR TITLE
Add TracerProvider and TracerProviderFactory implementations for OTel SPI

### DIFF
--- a/money-core/src/main/resources/META-INF/services/io.opentelemetry.trace.spi.TracerProviderFactory
+++ b/money-core/src/main/resources/META-INF/services/io.opentelemetry.trace.spi.TracerProviderFactory
@@ -1,0 +1,1 @@
+com.comcast.money.core.spi.MoneyTracerProviderFactory

--- a/money-core/src/main/scala/com/comcast/money/core/MoneyTracerProvider.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/MoneyTracerProvider.scala
@@ -19,7 +19,7 @@ package com.comcast.money.core
 import io.opentelemetry.trace
 import io.opentelemetry.trace.TracerProvider
 
-case class MoneyTracerProvider(tracer: Tracer) extends TracerProvider {
+final case class MoneyTracerProvider(tracer: Tracer) extends TracerProvider {
   override def get(instrumentationName: String): trace.Tracer = tracer
   override def get(instrumentationName: String, instrumentationVersion: String): trace.Tracer = tracer
 }

--- a/money-core/src/main/scala/com/comcast/money/core/MoneyTracerProvider.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/MoneyTracerProvider.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core
+
+import io.opentelemetry.trace
+import io.opentelemetry.trace.TracerProvider
+
+case class MoneyTracerProvider(tracer: Tracer) extends TracerProvider {
+  override def get(instrumentationName: String): trace.Tracer = tracer
+  override def get(instrumentationName: String, instrumentationVersion: String): trace.Tracer = tracer
+}

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/FormatterPropagator.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/FormatterPropagator.scala
@@ -25,7 +25,7 @@ import io.opentelemetry.trace.{ DefaultSpan, TracingContextUtils }
 
 import scala.collection.JavaConverters._
 
-case class FormatterPropagator(formatter: Formatter) extends TextMapPropagator {
+final case class FormatterPropagator(formatter: Formatter) extends TextMapPropagator {
 
   override def inject[C](context: Context, carrier: C, setter: TextMapPropagator.Setter[C]): Unit =
     Option(TracingContextUtils.getSpanWithoutDefault(context))

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/FormatterPropagator.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/FormatterPropagator.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.formatters
+
+import java.util
+
+import com.comcast.money.api.SpanId
+import io.grpc.Context
+import io.opentelemetry.context.propagation.TextMapPropagator
+import io.opentelemetry.trace.{ DefaultSpan, TracingContextUtils }
+
+import scala.collection.JavaConverters._
+
+case class FormatterPropagator(formatter: Formatter) extends TextMapPropagator {
+
+  override def inject[C](context: Context, carrier: C, setter: TextMapPropagator.Setter[C]): Unit =
+    Option(TracingContextUtils.getSpanWithoutDefault(context))
+      .map { _.getContext }
+      .map { SpanId.fromSpanContext }
+      .filter { _.isValid }
+      .foreach {
+        spanId => formatter.toHttpHeaders(spanId, (key, value) => setter.set(carrier, key, value))
+      }
+
+  override def extract[C](context: Context, carrier: C, getter: TextMapPropagator.Getter[C]): Context =
+    formatter.fromHttpHeaders(key => getter.get(carrier, key))
+      .filter { _.isValid }
+      .map { _.toSpanContext() }
+      .map { DefaultSpan.create }
+      .map { TracingContextUtils.withSpan(_, context) }
+      .getOrElse(context)
+
+  override def fields(): util.List[String] = formatter.fields.asJava
+}

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/FormatterPropagators.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/FormatterPropagators.scala
@@ -18,6 +18,6 @@ package com.comcast.money.core.formatters
 
 import io.opentelemetry.context.propagation.{ ContextPropagators, TextMapPropagator }
 
-case class FormatterPropagators(formatter: Formatter) extends ContextPropagators {
+final case class FormatterPropagators(formatter: Formatter) extends ContextPropagators {
   override def getTextMapPropagator: TextMapPropagator = FormatterPropagator(formatter)
 }

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/FormatterPropagators.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/FormatterPropagators.scala
@@ -14,24 +14,10 @@
  * limitations under the License.
  */
 
-package com.comcast.money.core
+package com.comcast.money.core.formatters
 
-import java.util.UUID
+import io.opentelemetry.context.propagation.{ ContextPropagators, TextMapPropagator }
 
-import com.comcast.money.api.SpanId
-import Formatters._
-import io.opentelemetry.trace.{ TraceFlags, TraceState }
-import org.scalacheck.Arbitrary
-import org.scalacheck.Test.Failed
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-
-class FormattersSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks with TraceGenerators {
-
-  implicit val arbitraryUUID: Arbitrary[UUID] = Arbitrary(genUUID)
-
-  "Http Formatting" should {
-
-  }
+case class FormatterPropagators(formatter: Formatter) extends ContextPropagators {
+  override def getTextMapPropagator: TextMapPropagator = FormatterPropagator(formatter)
 }

--- a/money-core/src/main/scala/com/comcast/money/core/spi/MoneyTracerProviderFactory.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/spi/MoneyTracerProviderFactory.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core.spi
+
+import com.comcast.money.core.{ Money, MoneyTracerProvider, Tracer }
+import io.opentelemetry.trace.TracerProvider
+import io.opentelemetry.trace.spi.TracerProviderFactory
+
+class MoneyTracerProviderFactory(tracer: Tracer) extends TracerProviderFactory {
+  def this() = this(Money.Environment.tracer)
+
+  override def create(): TracerProvider = {
+    MoneyTracerProvider(tracer)
+  }
+}

--- a/money-core/src/test/scala/com/comcast/money/core/MoneyTraceProviderSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/MoneyTraceProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core
 
 import org.scalatest.matchers.should.Matchers

--- a/money-core/src/test/scala/com/comcast/money/core/MoneyTraceProviderSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/MoneyTraceProviderSpec.scala
@@ -1,0 +1,19 @@
+package com.comcast.money.core
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+
+class MoneyTraceProviderSpec extends AnyWordSpec with MockitoSugar with Matchers {
+
+  "MoneyTraceProvider" should {
+    "wrap an existing tracer" in {
+      val tracer = mock[Tracer]
+
+      val underTest = MoneyTracerProvider(tracer)
+
+      underTest.get("test") shouldBe tracer
+      underTest.get("test", "1.0") shouldBe tracer
+    }
+  }
+}

--- a/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterPropagatorSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterPropagatorSpec.scala
@@ -1,12 +1,28 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core.formatters
 
 import com.comcast.money.api.SpanId
 import io.grpc.Context
 import io.opentelemetry.context.propagation.TextMapPropagator
-import io.opentelemetry.trace.{DefaultSpan, TraceFlags, TraceState, TracingContextUtils}
+import io.opentelemetry.trace.{ DefaultSpan, TraceFlags, TraceState, TracingContextUtils }
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.any
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito.{ verify, when }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar

--- a/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterPropagatorsSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterPropagatorsSpec.scala
@@ -1,0 +1,20 @@
+package com.comcast.money.core.formatters
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+
+class FormatterPropagatorsSpec extends AnyWordSpec with MockitoSugar with Matchers {
+  "FormatterPropagators" should {
+    "wraps the Formatter in a FormatterProvider" in {
+      val formatter = mock[Formatter]
+
+      val underTest = FormatterPropagators(formatter)
+      val propagator = underTest.getTextMapPropagator
+
+      propagator shouldBe a[FormatterPropagator]
+      val formatterPropagator = propagator.asInstanceOf[FormatterPropagator]
+      formatterPropagator.formatter shouldBe formatter
+    }
+  }
+}

--- a/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterPropagatorsSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterPropagatorsSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core.formatters
 
 import org.scalatest.matchers.should.Matchers

--- a/money-core/src/test/scala/com/comcast/money/core/spi/MoneyTracerProviderFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/spi/MoneyTracerProviderFactorySpec.scala
@@ -1,0 +1,19 @@
+package com.comcast.money.core.spi
+
+import com.comcast.money.core.Tracer
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+
+class MoneyTracerProviderFactorySpec extends AnyWordSpec with MockitoSugar with Matchers {
+  "MoneyTracerProviderFactory" should {
+    "wrap an existing tracer in a TracerProvider" in {
+      val tracer = mock[Tracer]
+      val underTest = new MoneyTracerProviderFactory(tracer)
+
+      val provider = underTest.create()
+      provider.get("test") shouldBe tracer
+      provider.get("test", "1.0") shouldBe tracer
+    }
+  }
+}

--- a/money-core/src/test/scala/com/comcast/money/core/spi/MoneyTracerProviderFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/spi/MoneyTracerProviderFactorySpec.scala
@@ -1,15 +1,34 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core.spi
 
 import java.util.ServiceLoader
 
-import com.comcast.money.core.Tracer
+import com.comcast.money.core.{ Money, Tracer }
+import io.opentelemetry.OpenTelemetry
 import io.opentelemetry.trace.spi.TracerProviderFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
+
 import scala.collection.JavaConverters._
 
 class MoneyTracerProviderFactorySpec extends AnyWordSpec with MockitoSugar with Matchers {
+
   "MoneyTracerProviderFactory" should {
     "wrap an existing tracer in a TracerProvider" in {
       val tracer = mock[Tracer]
@@ -27,6 +46,11 @@ class MoneyTracerProviderFactorySpec extends AnyWordSpec with MockitoSugar with 
       result.isDefined shouldBe true
       val factory = result.get
       factory shouldBe a[MoneyTracerProviderFactory]
+    }
+
+    "integrates with OpenTelemetry.getTracer" in {
+      val tracer = OpenTelemetry.getTracer("test")
+      tracer shouldBe Money.Environment.tracer
     }
   }
 }

--- a/money-core/src/test/scala/com/comcast/money/core/spi/MoneyTracerProviderFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/spi/MoneyTracerProviderFactorySpec.scala
@@ -1,9 +1,13 @@
 package com.comcast.money.core.spi
 
+import java.util.ServiceLoader
+
 import com.comcast.money.core.Tracer
+import io.opentelemetry.trace.spi.TracerProviderFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
+import scala.collection.JavaConverters._
 
 class MoneyTracerProviderFactorySpec extends AnyWordSpec with MockitoSugar with Matchers {
   "MoneyTracerProviderFactory" should {
@@ -14,6 +18,15 @@ class MoneyTracerProviderFactorySpec extends AnyWordSpec with MockitoSugar with 
       val provider = underTest.create()
       provider.get("test") shouldBe tracer
       provider.get("test", "1.0") shouldBe tracer
+    }
+
+    "integrates with Java SPI" in {
+      val services = ServiceLoader.load(classOf[TracerProviderFactory])
+      val result = services.asScala.headOption
+
+      result.isDefined shouldBe true
+      val factory = result.get
+      factory shouldBe a[MoneyTracerProviderFactory]
     }
   }
 }


### PR DESCRIPTION
Adds an implementation of `TracerProvider` and `TracerProviderFactory` that can be used with Java SPI service registration and automatically loaded by `OpenTelemetry.getTracer()`.