### PR TITLE
Refactor methods for generating/parsing/validating IDs to a helper class

### DIFF
--- a/money-api/src/main/java/com/comcast/money/api/IdGenerator.java
+++ b/money-api/src/main/java/com/comcast/money/api/IdGenerator.java
@@ -17,8 +17,8 @@
 package com.comcast.money.api;
 
 import java.util.Locale;
-import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -34,14 +34,12 @@ public class IdGenerator {
     private static final Pattern TRACE_ID_HEX_PATTERN = Pattern.compile("^(?:[0-9a-f]{16}){1,2}$", Pattern.CASE_INSENSITIVE);
     private static final Pattern ID_HEX_PATTERN = Pattern.compile("^[0-9a-f]{16}$", Pattern.CASE_INSENSITIVE);
 
-    private static final ThreadLocal<Random> threadLocalRandom = ThreadLocal.withInitial(Random::new);
-
     /**
      * Generates a random trace ID.
      */
     public static String generateRandomTraceId() {
         long hi, lo;
-        Random random = threadLocalRandom.get();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
         do {
             hi = random.nextLong();
             lo = random.nextLong();
@@ -54,7 +52,7 @@ public class IdGenerator {
      */
     public static long generateRandomId() {
         long id;
-        Random random = threadLocalRandom.get();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
         do {
             id = random.nextLong();
         } while (id == INVALID_ID);
@@ -63,7 +61,7 @@ public class IdGenerator {
 
     public static String generateRandomTraceIdAsHex() {
         long hi, lo;
-        Random random = threadLocalRandom.get();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
         do {
             hi = random.nextLong();
             lo = random.nextLong();

--- a/money-api/src/main/java/com/comcast/money/api/IdGenerator.java
+++ b/money-api/src/main/java/com/comcast/money/api/IdGenerator.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.api;
+
+import java.util.Locale;
+import java.util.Random;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class IdGenerator {
+    private IdGenerator() { }
+
+    public static final String INVALID_TRACE_ID = "00000000-0000-0000-0000-000000000000";
+    public static final String INVALID_TRACE_ID_HEX = "00000000000000000000000000000000";
+    public static final long INVALID_ID = 0L;
+    public static final String INVALID_ID_HEX = "0000000000000000";
+
+    private static final Pattern TRACE_ID_PATTERN = Pattern.compile("^([0-9a-f]{8})-?([0-9a-f]{4})-([0-9a-f]{4})-?([0-9a-f]{4})-?([0-9a-f]{12})$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern TRACE_ID_HEX_PATTERN = Pattern.compile("^(?:[0-9a-f]{16}){1,2}$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ID_HEX_PATTERN = Pattern.compile("^[0-9a-f]{16}$", Pattern.CASE_INSENSITIVE);
+
+    private static final ThreadLocal<Random> threadLocalRandom = ThreadLocal.withInitial(Random::new);
+
+    /**
+     * Generates a random trace ID.
+     */
+    public static String generateRandomTraceId() {
+        long hi, lo;
+        Random random = threadLocalRandom.get();
+        do {
+            hi = random.nextLong();
+            lo = random.nextLong();
+        } while (hi == INVALID_ID && lo == INVALID_ID);
+        return new UUID(hi, lo).toString();
+    }
+
+    /**
+     * Generates a random non-zero 64-bit ID that can be used as span ID
+     */
+    public static long generateRandomId() {
+        long id;
+        Random random = threadLocalRandom.get();
+        do {
+            id = random.nextLong();
+        } while (id == INVALID_ID);
+        return id;
+    }
+
+    public static String generateRandomTraceIdAsHex() {
+        long hi, lo;
+        Random random = threadLocalRandom.get();
+        do {
+            hi = random.nextLong();
+            lo = random.nextLong();
+        } while (hi == INVALID_ID && lo == INVALID_ID);
+        return convertIdToHex(hi) + convertIdToHex(lo);
+    }
+
+    public static String generateRandomIdAsHex() {
+        return convertIdToHex(generateRandomId());
+    }
+
+    public static String convertTraceIdToHex(String traceId) {
+        if (traceId != null) {
+            Matcher matcher = TRACE_ID_PATTERN.matcher(traceId);
+            if (matcher.matches()) {
+                return matcher.replaceFirst("$1$2$3$4$5")
+                        .toLowerCase(Locale.US);
+            }
+        }
+        return INVALID_TRACE_ID_HEX;
+    }
+
+    public static String convertIdToHex(long id) {
+        return io.opentelemetry.trace.SpanId.fromLong(id);
+    }
+
+    public static boolean isValidTraceId(String traceId) {
+        return traceId != null && TRACE_ID_PATTERN.matcher(traceId).matches();
+    }
+
+    public static boolean isValidHexTraceId(String hex) {
+        return hex != null && TRACE_ID_HEX_PATTERN.matcher(hex).matches();
+    }
+
+    /**
+     * Parses a 64-bit or 128-bit hexadecimal string into a trace ID.
+     */
+    public static String parseTraceIdFromHex(String hex) {
+        if (hex != null) {
+            Matcher matcher = TRACE_ID_HEX_PATTERN.matcher(hex);
+            if (matcher.matches()) {
+                if (hex.length() == 16) {
+                    hex = INVALID_ID_HEX + hex;
+                }
+                return new StringBuilder(36)
+                        .append(hex.subSequence(0, 8))
+                        .append('-')
+                        .append(hex.subSequence(8, 12))
+                        .append('-')
+                        .append(hex.subSequence(12, 16))
+                        .append('-')
+                        .append(hex.subSequence(16, 20))
+                        .append('-')
+                        .append(hex.subSequence(20, 32))
+                        .toString()
+                        .toLowerCase(Locale.US);
+            }
+        }
+        return INVALID_TRACE_ID;
+    }
+
+    /**
+     * Parses a 64-bit hexadecimal string into a numeric ID.
+     */
+    public static long parseIdFromHex(String hex) {
+        if (hex != null) {
+            Matcher matcher = ID_HEX_PATTERN.matcher(hex);
+            if (matcher.matches()) {
+                return Long.parseUnsignedLong(hex, 16);
+            }
+        }
+        return INVALID_ID;
+    }
+}

--- a/money-api/src/test/scala/com/comcast/money/api/IdGeneratorSpec.scala
+++ b/money-api/src/test/scala/com/comcast/money/api/IdGeneratorSpec.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.api
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class IdGeneratorSpec extends AnyWordSpec with Matchers {
+
+  "generates a random trace id" in {
+    val traceId = IdGenerator.generateRandomTraceId()
+
+    traceId should have size 36
+    traceId should fullyMatch regex """^([0-9a-f]{8})-?([0-9a-f]{4})-([0-9a-f]{4})-?([0-9a-f]{4})-?([0-9a-f]{12})$"""
+    traceId should not be IdGenerator.INVALID_TRACE_ID
+  }
+
+  "generates a random id" in {
+    val id = IdGenerator.generateRandomId()
+
+    id should not be 0
+  }
+
+  "generates a random 128-bit hex trace id" in {
+    val traceId = IdGenerator.generateRandomTraceIdAsHex()
+
+    traceId should have size 32
+    traceId should fullyMatch regex """^[0-9a-f]{32}$"""
+    traceId should not be IdGenerator.INVALID_TRACE_ID_HEX
+  }
+
+  "generates a random 64-bit hex id" in {
+    val id = IdGenerator.generateRandomIdAsHex()
+
+    id should have size 16
+    id should fullyMatch regex """^[0-9a-f]{16}$"""
+    id should not be IdGenerator.INVALID_ID_HEX
+  }
+
+  "converts a trace id to hex" in {
+    val traceId = "01234567-890A-BCDE-F012-34567890ABCD"
+
+    val hex = IdGenerator.convertTraceIdToHex(traceId)
+
+    hex shouldBe "01234567890abcdef01234567890abcd"
+  }
+
+  "converts an invalid trace id to hex" in {
+    val traceId = "foo"
+
+    val hex = IdGenerator.convertTraceIdToHex(traceId)
+
+    hex shouldBe IdGenerator.INVALID_TRACE_ID_HEX
+  }
+
+  "converts an id to hex" in {
+    val id = 81985529216486895L
+
+    val hex = IdGenerator.convertIdToHex(id)
+
+    hex shouldBe "0123456789abcdef"
+  }
+
+  "detects valid trace id" in {
+    val traceId = "01234567-890A-BCDE-F012-34567890ABCD"
+    IdGenerator.isValidTraceId(traceId) shouldBe true
+  }
+
+  "detects invalid trace id" in {
+    val traceId = "foo"
+    IdGenerator.isValidTraceId(traceId) shouldBe false
+  }
+
+  "detects valid hex trace id" in {
+    val traceId = "01234567890abcdef01234567890abcd"
+    IdGenerator.isValidHexTraceId(traceId) shouldBe true
+  }
+
+  "detects invalid hex trace id" in {
+    val traceId = "01234567-890A-BCDE-F012-34567890ABCD"
+    IdGenerator.isValidHexTraceId(traceId) shouldBe false
+  }
+
+  "parse 128-bit hex to trace id" in {
+    val hex = "01234567890abcdef01234567890abcd"
+    val traceId = IdGenerator.parseTraceIdFromHex(hex)
+
+    traceId shouldBe "01234567-890a-bcde-f012-34567890abcd"
+  }
+
+  "parse 64-bit hex to trace id" in {
+    val hex = "001234567890abcd"
+    val traceId = IdGenerator.parseTraceIdFromHex(hex)
+
+    traceId shouldBe "00000000-0000-0000-0012-34567890abcd"
+  }
+
+  "parse invalid hex trace id" in {
+    val traceId = IdGenerator.parseTraceIdFromHex("foo")
+
+    traceId shouldBe IdGenerator.INVALID_TRACE_ID
+  }
+
+  "parse 64-bit hex to id" in {
+    val id = IdGenerator.parseIdFromHex("0123456789abcdef")
+
+    id shouldBe 81985529216486895L
+  }
+
+  "parse invalid hex id" in {
+    val id = IdGenerator.parseIdFromHex("foo")
+
+    id shouldBe IdGenerator.INVALID_ID
+  }
+}

--- a/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterPropagatorSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterPropagatorSpec.scala
@@ -16,13 +16,13 @@
 
 package com.comcast.money.core.formatters
 
-import com.comcast.money.api.SpanId
+import com.comcast.money.api.{IdGenerator, SpanId}
 import io.grpc.Context
 import io.opentelemetry.context.propagation.TextMapPropagator
-import io.opentelemetry.trace.{ DefaultSpan, TraceFlags, TraceState, TracingContextUtils }
+import io.opentelemetry.trace.{DefaultSpan, TraceFlags, TraceState, TracingContextUtils}
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.any
-import org.mockito.Mockito.{ verify, when }
+import org.mockito.Mockito.{verify, when}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -65,8 +65,8 @@ class FormatterPropagatorSpec extends AnyWordSpec with MockitoSugar with Matcher
       val getter = mock[TextMapPropagator.Getter[Unit]]
       val underTest = FormatterPropagator(formatter)
 
-      val traceId = SpanId.randomTraceId()
-      val selfId = SpanId.randomNonZeroLong()
+      val traceId = IdGenerator.generateRandomTraceId()
+      val selfId = IdGenerator.generateRandomId();
       val spanId = SpanId.createRemote(traceId, selfId, selfId, TraceFlags.getSampled, TraceState.getDefault)
 
       when(formatter.fromHttpHeaders(any(), any())).thenReturn(Some(spanId))
@@ -87,8 +87,8 @@ class FormatterPropagatorSpec extends AnyWordSpec with MockitoSugar with Matcher
       val getter = mock[TextMapPropagator.Getter[Unit]]
       val underTest = FormatterPropagator(formatter)
 
-      val traceId = SpanId.randomTraceId()
-      val selfId = SpanId.randomNonZeroLong()
+      val traceId = IdGenerator.generateRandomTraceId()
+      val selfId = IdGenerator.generateRandomId();
       val spanId = SpanId.createRemote(traceId, selfId, selfId, TraceFlags.getSampled, TraceState.getDefault)
 
       when(formatter.fromHttpHeaders(any(), any())).thenReturn(None)

--- a/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterUtils.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterUtils.scala
@@ -18,7 +18,7 @@ package com.comcast.money.core.formatters
 
 import java.util.{ Locale, UUID }
 
-import com.comcast.money.api.SpanId
+import com.comcast.money.api.{ IdGenerator, SpanId }
 import io.opentelemetry.trace.{ TraceFlags, TraceState }
 
 object FormatterUtils {
@@ -29,8 +29,9 @@ object FormatterUtils {
     (traceId.getLeastSignificantBits != 0 || traceId.getMostSignificantBits != 0) && parentSpanId != 0 && spanId != 0
 
   def randomRemoteSpanId(): SpanId = {
-    val selfId = SpanId.randomNonZeroLong()
-    SpanId.createRemote(SpanId.randomTraceId(), selfId, selfId, TraceFlags.getSampled, TraceState.getDefault)
+    val traceId = IdGenerator.generateRandomTraceId()
+    val selfId = IdGenerator.generateRandomId()
+    SpanId.createRemote(traceId, selfId, selfId, TraceFlags.getSampled, TraceState.getDefault)
   }
 
   implicit class StringWithHexHeaderConversion(s: String) {


### PR DESCRIPTION
Pondering moving the logic for generating, validating and parsing of trace and span IDs into separate helper class so that `SpanId` can be less cluttered.  I don't know that I'm entirely happy with this but I thought I'd get some feedback.