### PR TITLE
WIP: Tracer per instrumentation library, flow through to SpanInfo

### DIFF
--- a/money-api/src/main/java/com/comcast/money/api/InstrumentationLibrary.java
+++ b/money-api/src/main/java/com/comcast/money/api/InstrumentationLibrary.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.api;
+
+import java.util.Objects;
+
+public final class InstrumentationLibrary {
+    public static final InstrumentationLibrary UNKNOWN = new InstrumentationLibrary("unknown");
+
+    private final String name;
+    private final String version;
+
+    public InstrumentationLibrary(String name) {
+        this(name, null);
+    }
+
+    public InstrumentationLibrary(String name, String version) {
+        Objects.requireNonNull(name);
+        this.name = name;
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        InstrumentationLibrary that = (InstrumentationLibrary) o;
+
+        if (!name.equals(that.name)) return false;
+        return Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + (version != null ? version.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        if (version != null) {
+            return "{name='" + name + "', version='" + version + "'}";
+        } else {
+            return "{name='" + name + "'}";
+        }
+
+    }
+}

--- a/money-api/src/main/java/com/comcast/money/api/MoneyTracerProvider.java
+++ b/money-api/src/main/java/com/comcast/money/api/MoneyTracerProvider.java
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-package com.comcast.money.core
+package com.comcast.money.api;
 
-import io.opentelemetry.trace
-import io.opentelemetry.trace.TracerProvider
+import io.opentelemetry.trace.TracerProvider;
 
-final case class MoneyTracerProvider(tracer: Tracer) extends TracerProvider {
-  override def get(instrumentationName: String): trace.Tracer = tracer
-  override def get(instrumentationName: String, instrumentationVersion: String): trace.Tracer = tracer
+public interface MoneyTracerProvider extends TracerProvider {
+    @Override
+    MoneyTracer get(String instrumentationName);
+
+    @Override
+    MoneyTracer get(String instrumentationName, String instrumentationVersion);
 }

--- a/money-api/src/main/java/com/comcast/money/api/SpanInfo.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanInfo.java
@@ -138,6 +138,11 @@ public interface SpanInfo {
     long durationNanos();
 
     /**
+     * @return the instrumentation library from which the span originated
+     */
+    InstrumentationLibrary instrumentationLibrary();
+
+    /**
      * @return the current application name
      */
     String appName();

--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpan.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpan.scala
@@ -45,6 +45,7 @@ private[core] case class CoreSpan(
   id: SpanId,
   var name: String,
   var kind: OtelSpan.Kind = OtelSpan.Kind.INTERNAL,
+  instrumentationLibrary: InstrumentationLibrary = InstrumentationLibrary.UNKNOWN,
   clock: Clock = SystemClock,
   handler: SpanHandler) extends Span {
 
@@ -126,7 +127,8 @@ private[core] case class CoreSpan(
       status = status,
       description = description,
       notes = noted.toMap[String, Note[_]].asJava,
-      events = events.asJava)
+      events = events.asJava,
+      instrumentationLibrary = instrumentationLibrary)
 
   override def close(): Unit = stop()
 

--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpanFactory.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpanFactory.scala
@@ -18,7 +18,7 @@ package com.comcast.money.core
 
 import java.util.function
 
-import com.comcast.money.api.{ Span, SpanFactory, SpanHandler, SpanId }
+import com.comcast.money.api.{ InstrumentationLibrary, Span, SpanFactory, SpanHandler, SpanId }
 import com.comcast.money.core.formatters.Formatter
 import org.slf4j.LoggerFactory
 
@@ -27,7 +27,8 @@ import scala.collection.JavaConverters._
 private[core] class CoreSpanFactory(
   clock: Clock,
   handler: SpanHandler,
-  formatter: Formatter) extends SpanFactory {
+  formatter: Formatter,
+  instrumentationLibrary: InstrumentationLibrary = InstrumentationLibrary.UNKNOWN) extends SpanFactory {
 
   private val logger = LoggerFactory.getLogger(classOf[CoreSpanFactory])
 
@@ -65,10 +66,11 @@ private[core] class CoreSpanFactory(
     child
   }
 
-  def newSpan(spanId: SpanId, spanName: String): Span =
+  override def newSpan(spanId: SpanId, spanName: String): Span =
     CoreSpan(
       id = spanId,
       name = spanName,
       clock = clock,
+      instrumentationLibrary = instrumentationLibrary,
       handler = handler)
 }

--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpanInfo.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpanInfo.scala
@@ -18,7 +18,7 @@ package com.comcast.money.core
 
 import java.util.Collections
 
-import com.comcast.money.api.{ Event, Note, SpanId, SpanInfo }
+import com.comcast.money.api.{ Event, InstrumentationLibrary, Note, SpanId, SpanInfo }
 import io.opentelemetry.trace.{ Span, StatusCanonicalCode }
 
 private[core] case class CoreSpanInfo(
@@ -32,5 +32,6 @@ private[core] case class CoreSpanInfo(
   description: String = "",
   notes: java.util.Map[String, Note[_]] = Collections.emptyMap(),
   events: java.util.List[Event] = Collections.emptyList(),
+  instrumentationLibrary: InstrumentationLibrary = InstrumentationLibrary.UNKNOWN,
   appName: String = Money.Environment.applicationName,
   host: String = Money.Environment.hostName) extends SpanInfo

--- a/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
@@ -31,6 +31,18 @@ object DisabledSpanHandler extends SpanHandler {
   override def handle(spanInfo: SpanInfo): Unit = ()
 }
 
+object DisabledTracerProvider extends TracerProvider {
+  override val clock: Clock = SystemClock
+  override val formatter: Formatter = DisabledFormatter
+  override val handler: SpanHandler = DisabledSpanHandler
+
+  override def get(instrumentationName: String): MoneyTracer = DisabledTracer
+
+  override def get(instrumentationName: String, instrumentationVersion: String): MoneyTracer = DisabledTracer
+
+  override def get(instrumentationLibrary: InstrumentationLibrary): Tracer = DisabledTracer
+}
+
 object DisabledTracer extends Tracer {
 
   val spanFactory: SpanFactory = DisabledSpanFactory

--- a/money-core/src/main/scala/com/comcast/money/core/TracerProvider.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/TracerProvider.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.core
+
+import com.comcast.money.api.{ InstrumentationLibrary, MoneyTracer, MoneyTracerProvider, SpanFactory, SpanHandler }
+import com.comcast.money.core.formatters.Formatter
+
+import scala.collection.concurrent.TrieMap
+
+trait TracerProvider extends MoneyTracerProvider {
+  val clock: Clock
+  val formatter: Formatter
+  val handler: SpanHandler
+
+  private val tracers = new TrieMap[InstrumentationLibrary, Tracer]()
+
+  override def get(instrumentationName: String): MoneyTracer =
+    get(new InstrumentationLibrary(instrumentationName, null))
+
+  override def get(instrumentationName: String, instrumentationVersion: String): MoneyTracer =
+    get(new InstrumentationLibrary(instrumentationName, instrumentationVersion))
+
+  def get(instrumentationLibrary: InstrumentationLibrary): Tracer = {
+    tracers.getOrElseUpdate(instrumentationLibrary, {
+      new Tracer {
+        override val spanFactory: SpanFactory = new CoreSpanFactory(clock, handler, formatter, instrumentationLibrary)
+      }
+    })
+  }
+}

--- a/money-core/src/main/scala/com/comcast/money/core/spi/MoneyTracerProviderFactory.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/spi/MoneyTracerProviderFactory.scala
@@ -16,14 +16,12 @@
 
 package com.comcast.money.core.spi
 
-import com.comcast.money.core.{ Money, MoneyTracerProvider, Tracer }
+import com.comcast.money.core.Money
 import io.opentelemetry.trace.TracerProvider
 import io.opentelemetry.trace.spi.TracerProviderFactory
 
-class MoneyTracerProviderFactory(tracer: Tracer) extends TracerProviderFactory {
-  def this() = this(Money.Environment.tracer)
+class MoneyTracerProviderFactory(money: Money) extends TracerProviderFactory {
+  def this() = this(Money.Environment)
 
-  override def create(): TracerProvider = {
-    MoneyTracerProvider(tracer)
-  }
+  override def create(): TracerProvider = money.tracerProvider
 }

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
@@ -16,7 +16,7 @@
 
 package com.comcast.money.core
 
-import com.comcast.money.api.{ Note, SpanHandler, SpanId }
+import com.comcast.money.api.{ InstrumentationLibrary, Note, SpanHandler, SpanId }
 import com.comcast.money.core.formatters.{ Formatter, MoneyTraceFormatter }
 import com.comcast.money.core.handlers.TestData
 import org.scalatest.matchers.should.Matchers

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanSpec.scala
@@ -19,7 +19,7 @@ package com.comcast.money.core
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
-import com.comcast.money.api.{ SpanHandler, SpanId, SpanInfo }
+import com.comcast.money.api.{ InstrumentationLibrary, SpanHandler, SpanId, SpanInfo }
 import com.comcast.money.core.handlers.TestData
 import io.opentelemetry.common.{ AttributeKey, Attributes }
 import io.opentelemetry.context.Scope
@@ -35,7 +35,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
   "CoreSpan" should {
     "set the startTimeMillis and startTimeMicros when started" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
       underTest.start()
 
       val state = underTest.info
@@ -45,7 +45,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set the startTimeMillis and startTimeMicros when started with time stamps" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
       val instant = Instant.now
       underTest.start(instant.getEpochSecond, instant.getNano)
 
@@ -56,7 +56,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "record a timer" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       underTest.startTimer("foo")
       underTest.stopTimer("foo")
@@ -65,7 +65,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "record a note" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       underTest.record(testLongNote)
 
@@ -73,7 +73,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a String attribute" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       underTest.setAttribute("foo", "bar")
 
@@ -84,7 +84,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a long attribute" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       underTest.setAttribute("foo", 200L)
 
@@ -95,7 +95,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a double attribute" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       underTest.setAttribute("foo", 2.2)
 
@@ -106,7 +106,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a boolean attribute" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       underTest.setAttribute("foo", true)
 
@@ -117,7 +117,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a attribute with an attribute key" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       underTest.setAttribute(AttributeKey.stringKey("foo"), "bar")
 
@@ -128,7 +128,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "add an event with name" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       underTest.addEvent("event")
 
@@ -141,7 +141,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "add an event with name and timestamp" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       underTest.addEvent("event", 100L)
 
@@ -154,7 +154,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "add an event with name and attributes" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       underTest.addEvent("event", Attributes.of(AttributeKey.stringKey("foo"), "bar"))
 
@@ -167,7 +167,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "add an event with name, attributes and timestamp" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       underTest.addEvent("event", Attributes.of(AttributeKey.stringKey("foo"), "bar"), 100L)
 
@@ -181,7 +181,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "record an exception" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       val exception = new RuntimeException("BOOM")
       underTest.recordException(exception)
@@ -198,7 +198,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "record an exception with attributes" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       val exception = new RuntimeException("BOOM")
       underTest.recordException(exception, Attributes.of(AttributeKey.stringKey("foo"), "bar"))
@@ -217,7 +217,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "set the status to OK" in {
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, handler)
 
       underTest.setStatus(StatusCanonicalCode.OK)
 
@@ -230,7 +230,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "set the status to ERROR" in {
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, handler)
 
       underTest.setStatus(StatusCanonicalCode.ERROR)
 
@@ -243,7 +243,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "set the status to OK and stop with false result" in {
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, handler)
 
       underTest.setStatus(StatusCanonicalCode.OK)
 
@@ -256,7 +256,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "set the status to ERROR and stop with true result" in {
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, handler)
 
       underTest.setStatus(StatusCanonicalCode.ERROR)
 
@@ -269,7 +269,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "set the status with description" in {
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, handler)
 
       underTest.setStatus(StatusCanonicalCode.OK, "description")
 
@@ -277,7 +277,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "update the span name" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       underTest.name shouldBe "test"
       underTest.info.name shouldBe "test"
@@ -291,7 +291,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "gets isRecording" in {
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, handler)
 
       underTest.isRecording shouldBe false
 
@@ -306,7 +306,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "gets SpanContext" in {
       val spanId = SpanId.createRemote("01234567-890A-BCDE-F012-34567890ABCD", 81985529216486895L, 81985529216486895L, TraceFlags.getSampled, TraceState.getDefault)
-      val underTest = CoreSpan(spanId, "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(spanId, "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
       val context = underTest.getContext
 
@@ -316,7 +316,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "set the endTimeMillis and endTimeMicros when stopped" in {
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, handler)
 
       underTest.stop(true)
 
@@ -329,7 +329,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     "invoke the span handler when stopped" in {
       val handler = mock[SpanHandler]
       val handleCaptor = ArgumentCaptor.forClass(classOf[SpanInfo])
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, handler)
 
       underTest.start()
       underTest.record(testLongNote)
@@ -350,7 +350,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     "invoke the span handler when closed" in {
       val handler = mock[SpanHandler]
       val handleCaptor = ArgumentCaptor.forClass(classOf[SpanInfo])
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, handler)
 
       underTest.start()
       underTest.record(testLongNote)
@@ -373,7 +373,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
       val scope2 = mock[Scope]
 
       val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, handler)
 
       underTest.attachScope(scope1)
       underTest.attachScope(scope2)
@@ -387,7 +387,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     "invoke the span handler when ended" in {
       val handler = mock[SpanHandler]
       val handleCaptor = ArgumentCaptor.forClass(classOf[SpanInfo])
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, handler)
 
       underTest.start()
       underTest.record(testLongNote)
@@ -408,7 +408,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     "invoke the span handler when ended with options" in {
       val handler = mock[SpanHandler]
       val handleCaptor = ArgumentCaptor.forClass(classOf[SpanInfo])
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, handler)
 
       underTest.start()
       underTest.record(testLongNote)

--- a/money-core/src/test/scala/com/comcast/money/core/MoneyTraceProviderSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/MoneyTraceProviderSpec.scala
@@ -24,12 +24,12 @@ class MoneyTraceProviderSpec extends AnyWordSpec with MockitoSugar with Matchers
 
   "MoneyTraceProvider" should {
     "wrap an existing tracer" in {
-      val tracer = mock[Tracer]
+      val money = mock[Money]
 
-      val underTest = MoneyTracerProvider(tracer)
+      val underTest = MoneyTracerProvider(money)
 
-      underTest.get("test") shouldBe tracer
-      underTest.get("test", "1.0") shouldBe tracer
+      underTest.get("test") shouldBe money
+      underTest.get("test", "1.0") shouldBe money
     }
   }
 }

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/TestData.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/TestData.scala
@@ -18,7 +18,7 @@ package com.comcast.money.core.handlers
 
 import java.util.Collections
 
-import com.comcast.money.api.{ Note, SpanHandler, SpanId, SpanInfo }
+import com.comcast.money.api.{ InstrumentationLibrary, Note, SpanHandler, SpanId, SpanInfo }
 import com.comcast.money.core.{ Clock, CoreSpan, CoreSpanInfo, SystemClock }
 import com.typesafe.config.Config
 import io.opentelemetry.trace.{ StatusCanonicalCode, TraceFlags, TraceState, Span => OtelSpan }
@@ -59,9 +59,9 @@ trait TestData {
     events = Collections.emptyList())
 
   val testSpanId = SpanId.createNew()
-  val testSpan = CoreSpan(testSpanId, "test-span", OtelSpan.Kind.INTERNAL, SystemClock, null)
+  val testSpan = CoreSpan(testSpanId, "test-span", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
   val childSpanId = testSpanId.createChild()
-  val childSpan = CoreSpan(childSpanId, "child-span", OtelSpan.Kind.INTERNAL, SystemClock, null)
+  val childSpan = CoreSpan(childSpanId, "child-span", OtelSpan.Kind.INTERNAL, InstrumentationLibrary.UNKNOWN, SystemClock, null)
 
   val fixedTestSpanId = SpanId.createRemote("5092ddfe-3701-4f84-b3d2-21f5501c0d28", 5176425846116696835L, 5176425846116696835L, TraceFlags.getSampled, TraceState.getDefault)
   val fixedTestSpanInfo = CoreSpanInfo(

--- a/money-core/src/test/scala/com/comcast/money/core/spi/MoneyTracerProviderFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/spi/MoneyTracerProviderFactorySpec.scala
@@ -18,6 +18,7 @@ package com.comcast.money.core.spi
 
 import java.util.ServiceLoader
 
+import com.comcast.money.api.MoneyTracer
 import com.comcast.money.core.{ Money, Tracer }
 import io.opentelemetry.OpenTelemetry
 import io.opentelemetry.trace.spi.TracerProviderFactory
@@ -31,7 +32,7 @@ class MoneyTracerProviderFactorySpec extends AnyWordSpec with MockitoSugar with 
 
   "MoneyTracerProviderFactory" should {
     "wrap an existing tracer in a TracerProvider" in {
-      val tracer = mock[Tracer]
+      val tracer = mock[Money]
       val underTest = new MoneyTracerProviderFactory(tracer)
 
       val provider = underTest.create()
@@ -50,7 +51,7 @@ class MoneyTracerProviderFactorySpec extends AnyWordSpec with MockitoSugar with 
 
     "integrates with OpenTelemetry.getTracer" in {
       val tracer = OpenTelemetry.getTracer("test")
-      tracer shouldBe Money.Environment.tracer
+      tracer shouldBe a[MoneyTracer]
     }
   }
 }

--- a/money-otel-handler/src/main/scala/com/comcast/money/otel/handlers/OtelSpanHandler.scala
+++ b/money-otel-handler/src/main/scala/com/comcast/money/otel/handlers/OtelSpanHandler.scala
@@ -23,10 +23,6 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo
 import io.opentelemetry.sdk.trace.SpanProcessor
 import io.opentelemetry.sdk.trace.`export`.{ BatchSpanProcessor, SimpleSpanProcessor, SpanExporter }
 
-object OtelSpanHandler {
-  val instrumentationLibraryInfo: InstrumentationLibraryInfo = InstrumentationLibraryInfo.create("money", "0.10.0")
-}
-
 /**
  * An abstract `SpanHandler` that can wrap an OpenTelemetry `SpanExporter` implementation
  * and export spans to an OpenTelemetry-compatible exporter such as ZipKin or Jaeger.

--- a/money-otel-handler/src/test/java/com/comcast/money/otel/handlers/TestSpanInfo.java
+++ b/money-otel-handler/src/test/java/com/comcast/money/otel/handlers/TestSpanInfo.java
@@ -24,6 +24,7 @@ import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.StatusCanonicalCode;
 
 import com.comcast.money.api.Event;
+import com.comcast.money.api.InstrumentationLibrary;
 import com.comcast.money.api.Note;
 import com.comcast.money.api.SpanId;
 import com.comcast.money.api.SpanInfo;
@@ -93,5 +94,10 @@ public class TestSpanInfo implements SpanInfo {
     @Override
     public String host() {
         return "host";
+    }
+
+    @Override
+    public InstrumentationLibrary instrumentationLibrary() {
+        return new InstrumentationLibrary("instrumentation-library", "0.0.1");
     }
 }

--- a/money-otel-handler/src/test/scala/com/comcast/money/otel/handlers/MoneyReadableSpanDataSpec.scala
+++ b/money-otel-handler/src/test/scala/com/comcast/money/otel/handlers/MoneyReadableSpanDataSpec.scala
@@ -19,7 +19,7 @@ package com.comcast.money.otel.handlers
 import java.util
 import java.util.UUID
 
-import com.comcast.money.api.{ Event, Note, SpanId, SpanInfo }
+import com.comcast.money.api.{ Event, InstrumentationLibrary, Note, SpanId, SpanInfo }
 import io.opentelemetry.common.{ AttributeKey, Attributes }
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.data.ImmutableStatus
@@ -37,7 +37,8 @@ class MoneyReadableSpanDataSpec extends AnyWordSpec with Matchers {
     "wrap Money SpanInfo" in {
       val underTest = new MoneyReadableSpanData(TestSpanInfo(spanId))
 
-      underTest.getInstrumentationLibraryInfo.getName shouldBe "money"
+      underTest.getInstrumentationLibraryInfo.getName shouldBe "instrumentation-library"
+      underTest.getInstrumentationLibraryInfo.getVersion shouldBe "0.0.1"
       underTest.getTraceId shouldBe "01234567890abcdef01234567890abcd"
       underTest.getSpanId shouldBe "0123456789abcdef"
       underTest.getParentSpanId shouldBe "0000000000000000"
@@ -65,7 +66,8 @@ class MoneyReadableSpanDataSpec extends AnyWordSpec with Matchers {
     "wrap child Money SpanInfo" in {
       val underTest = new MoneyReadableSpanData(TestSpanInfo(childSpanId))
 
-      underTest.getInstrumentationLibraryInfo.getName shouldBe "money"
+      underTest.getInstrumentationLibraryInfo.getName shouldBe "instrumentation-library"
+      underTest.getInstrumentationLibraryInfo.getVersion shouldBe "0.0.1"
       underTest.getTraceId shouldBe "01234567890abcdef01234567890abcd"
       underTest.getSpanId shouldBe "0123456789abcdef"
       underTest.getParentSpanId shouldBe "0fedcba987654321"
@@ -95,6 +97,8 @@ class MoneyReadableSpanDataSpec extends AnyWordSpec with Matchers {
     override def appName(): String = "app"
     override def host(): String = "host"
     override def name(): String = "name"
+    override def instrumentationLibrary(): InstrumentationLibrary =
+      new InstrumentationLibrary("instrumentation-library", "0.0.1")
     override def kind(): Span.Kind = Span.Kind.INTERNAL
     override def startTimeNanos(): Long = 1000000L
     override def endTimeNanos(): Long = 3000000L

--- a/money-otel-inmemory-exporter/src/test/java/com/comcast/money/otel/handlers/inmemory/InMemorySpanHandlerSpec.java
+++ b/money-otel-inmemory-exporter/src/test/java/com/comcast/money/otel/handlers/inmemory/InMemorySpanHandlerSpec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.otel.handlers.inmemory;
 
 import java.util.Collection;

--- a/money-otel-logging-exporter/src/test/java/com/comcast/money/otel/handlers/logging/LoggingSpanHandlerSpec.java
+++ b/money-otel-logging-exporter/src/test/java/com/comcast/money/otel/handlers/logging/LoggingSpanHandlerSpec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.otel.handlers.logging;
 
 import java.util.Collection;

--- a/money-otlp-exporter/src/test/java/com/comcast/money/otel/handlers/otlp/OtlpHandlerSpec.java
+++ b/money-otlp-exporter/src/test/java/com/comcast/money/otel/handlers/otlp/OtlpHandlerSpec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.otel.handlers.otlp;
 
 import java.util.Collection;

--- a/money-spring/src/test/java/com/comcast/money/spring/MoneyClientHttpInterceptorSpec.java
+++ b/money-spring/src/test/java/com/comcast/money/spring/MoneyClientHttpInterceptorSpec.java
@@ -59,6 +59,8 @@ public class MoneyClientHttpInterceptorSpec {
                 "",
                 Collections.emptyMap(),
                 Collections.emptyList(),
+                "instrumentation-library",
+                "0.0.1",
                 "testAppName",
                 "testHost");
 

--- a/money-wire/src/main/scala/com/comcast/money/wire/SpanConverters.scala
+++ b/money-wire/src/main/scala/com/comcast/money/wire/SpanConverters.scala
@@ -22,7 +22,7 @@ import java.util.Collections
 import java.util.concurrent.TimeUnit
 
 import com.comcast.money.api
-import com.comcast.money.api.{ Event, Note, SpanId, SpanInfo }
+import com.comcast.money.api.{ Event, InstrumentationLibrary, Note, SpanId, SpanInfo }
 import com.comcast.money.core._
 import com.comcast.money.wire.avro
 import com.comcast.money.wire.avro.NoteType
@@ -142,6 +142,7 @@ trait SpanWireConverters {
       override def durationNanos(): Long = TimeUnit.MICROSECONDS.toNanos(from.getDuration)
       override def appName(): String = from.getAppName
       override def host(): String = from.getHost
+      override def instrumentationLibrary(): InstrumentationLibrary = InstrumentationLibrary.UNKNOWN
     }
   }
 }

--- a/money-wire/src/test/scala/com/comcast/money/wire/TestSpanInfo.scala
+++ b/money-wire/src/test/scala/com/comcast/money/wire/TestSpanInfo.scala
@@ -29,6 +29,8 @@ case class TestSpanInfo(
   startTimeNanos: Long = 0L,
   endTimeNanos: Long = 0L,
   durationNanos: Long = 0L,
+  instrumentationName: String = "",
+  instrumentationVersion: String = "",
   status: StatusCanonicalCode = StatusCanonicalCode.UNSET,
   description: String = "",
   notes: java.util.Map[String, Note[_]] = Collections.emptyMap(),


### PR DESCRIPTION
Explore handling `TracerProvider` and instrumentation library info "correctly".  It involves being able to provide a different tracer per library name+version and each span created by that tracer will have that library info written into it.  That will then be copied into the SpanInfo.

