### PR TITLE
Wire instrumentation library info through SpanFactory to SpanInfo

### DIFF
--- a/money-api/src/main/java/com/comcast/money/api/InstrumentationLibrary.java
+++ b/money-api/src/main/java/com/comcast/money/api/InstrumentationLibrary.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.money.api;
+
+import java.util.Objects;
+
+public class InstrumentationLibrary {
+    public static final InstrumentationLibrary UNKNOWN = new InstrumentationLibrary("unknown");
+
+    private final String name;
+    private final String version;
+
+    public InstrumentationLibrary(String name) {
+        this(name, null);
+    }
+
+    public InstrumentationLibrary(String name, String version) {
+        Objects.requireNonNull(name);
+        this.name = name;
+        this.version = version;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String version() {
+        return version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        InstrumentationLibrary that = (InstrumentationLibrary) o;
+
+        if (!name.equals(that.name)) return false;
+        return Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + (version != null ? version.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "InstrumentationLibrary{" +
+                "name='" + name + '\'' +
+                ", version='" + version + '\'' +
+                '}';
+    }
+}

--- a/money-api/src/main/java/com/comcast/money/api/InstrumentationLibrary.java
+++ b/money-api/src/main/java/com/comcast/money/api/InstrumentationLibrary.java
@@ -62,9 +62,10 @@ public class InstrumentationLibrary {
 
     @Override
     public String toString() {
-        return "InstrumentationLibrary{" +
-                "name='" + name + '\'' +
-                ", version='" + version + '\'' +
-                '}';
+        if (version == null || version.isEmpty()) {
+            return name;
+        } else {
+            return name + ':' + version;
+        }
     }
 }

--- a/money-api/src/main/java/com/comcast/money/api/SpanFactory.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanFactory.java
@@ -38,6 +38,4 @@ public interface SpanFactory {
     Span childSpan(String childName, Span span);
 
     Span childSpan(String childName, Span span, boolean sticky);
-
-    SpanFactory forInstrumentationLibrary(InstrumentationLibrary library);
 }

--- a/money-api/src/main/java/com/comcast/money/api/SpanFactory.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanFactory.java
@@ -38,4 +38,6 @@ public interface SpanFactory {
     Span childSpan(String childName, Span span);
 
     Span childSpan(String childName, Span span, boolean sticky);
+
+    SpanFactory forInstrumentationLibrary(InstrumentationLibrary library);
 }

--- a/money-api/src/main/java/com/comcast/money/api/SpanInfo.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanInfo.java
@@ -138,6 +138,11 @@ public interface SpanInfo {
     long durationNanos();
 
     /**
+     * @return the instrumentation library that initiated the span
+     */
+    InstrumentationLibrary library();
+
+    /**
      * @return the current application name
      */
     String appName();

--- a/money-api/src/test/scala/com/comcast/money/api/InstrumentationLibrarySpec.scala
+++ b/money-api/src/test/scala/com/comcast/money/api/InstrumentationLibrarySpec.scala
@@ -1,0 +1,64 @@
+package com.comcast.money.api
+
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
+
+class InstrumentationLibrarySpec extends AnyWordSpec with Matchers {
+
+  "An InstrumentationLibrary" should {
+    "have the specified name" in {
+      val library = new InstrumentationLibrary("test")
+      library.name shouldBe "test"
+    }
+
+    "have the specified name and version" in {
+      val library = new InstrumentationLibrary("test", "0.0.1")
+      library.name shouldBe "test"
+      library.version shouldBe "0.0.1"
+    }
+
+    "support a null version" in {
+      val library = new InstrumentationLibrary("test", null)
+      library.name shouldBe "test"
+      library.version shouldBe null
+    }
+
+    "not allow a null name" in {
+      assertThrows[NullPointerException] {
+        new InstrumentationLibrary(null)
+      }
+    }
+
+    "support equality" in {
+      val lib1 = new InstrumentationLibrary("test", "0.0.1")
+      val lib2 = new InstrumentationLibrary("test", "0.0.1")
+
+      lib1 shouldBe lib2
+      lib1.hashCode() shouldBe lib2.hashCode()
+    }
+
+    "not consider different names to be equal" in {
+      val lib1 = new InstrumentationLibrary("foo", "0.0.1")
+      val lib2 = new InstrumentationLibrary("bar", "0.0.1")
+
+      lib1 should not be lib2
+    }
+
+    "not consider different versions to be equal" in {
+      val lib1 = new InstrumentationLibrary("test", "0.0.1")
+      val lib2 = new InstrumentationLibrary("test", "0.0.2")
+
+      lib1 should not be lib2
+    }
+
+    "format string with only name" in {
+      val library = new InstrumentationLibrary("test")
+      library.toString shouldBe "test"
+    }
+
+    "format string with name and version" in {
+      val library = new InstrumentationLibrary("test", "0.0.1")
+      library.toString shouldBe "test:0.0.1"
+    }
+  }
+}

--- a/money-api/src/test/scala/com/comcast/money/api/InstrumentationLibrarySpec.scala
+++ b/money-api/src/test/scala/com/comcast/money/api/InstrumentationLibrarySpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.api
 
 import org.scalatest.wordspec.AnyWordSpec

--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpan.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpan.scala
@@ -44,11 +44,11 @@ import scala.collection.mutable.ListBuffer
 private[core] case class CoreSpan(
   id: SpanId,
   var name: String,
-  var kind: OtelSpan.Kind = OtelSpan.Kind.INTERNAL,
+  library: InstrumentationLibrary = Money.InstrumentationLibrary,
   clock: Clock = SystemClock,
-  handler: SpanHandler,
-  var library: InstrumentationLibrary = Money.InstrumentationLibrary) extends Span {
+  handler: SpanHandler = DisabledSpanHandler) extends Span {
 
+  private var kind: OtelSpan.Kind = OtelSpan.Kind.INTERNAL
   private var startTimeNanos: Long = 0
   private var endTimeNanos: Long = 0
   private var status: StatusCanonicalCode = StatusCanonicalCode.UNSET

--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpan.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpan.scala
@@ -46,7 +46,8 @@ private[core] case class CoreSpan(
   var name: String,
   var kind: OtelSpan.Kind = OtelSpan.Kind.INTERNAL,
   clock: Clock = SystemClock,
-  handler: SpanHandler) extends Span {
+  handler: SpanHandler,
+  var library: InstrumentationLibrary = Money.InstrumentationLibrary) extends Span {
 
   private var startTimeNanos: Long = 0
   private var endTimeNanos: Long = 0
@@ -120,6 +121,7 @@ private[core] case class CoreSpan(
       id = id,
       name = name,
       kind = kind,
+      library = library,
       startTimeNanos = startTimeNanos,
       endTimeNanos = endTimeNanos,
       durationNanos = calculateDurationNanos,

--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpanFactory.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpanFactory.scala
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 
-private[core] class CoreSpanFactory(
+private[core] final case class CoreSpanFactory(
   clock: Clock,
   handler: SpanHandler,
   formatter: Formatter,
@@ -73,7 +73,4 @@ private[core] class CoreSpanFactory(
       library = library,
       clock = clock,
       handler = handler)
-
-  override def forInstrumentationLibrary(library: InstrumentationLibrary): SpanFactory =
-    new CoreSpanFactory(clock, handler, formatter, library)
 }

--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpanFactory.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpanFactory.scala
@@ -18,7 +18,7 @@ package com.comcast.money.core
 
 import java.util.function
 
-import com.comcast.money.api.{ Span, SpanFactory, SpanHandler, SpanId }
+import com.comcast.money.api.{ InstrumentationLibrary, Span, SpanFactory, SpanHandler, SpanId }
 import com.comcast.money.core.formatters.Formatter
 import org.slf4j.LoggerFactory
 
@@ -27,7 +27,8 @@ import scala.collection.JavaConverters._
 private[core] class CoreSpanFactory(
   clock: Clock,
   handler: SpanHandler,
-  formatter: Formatter) extends SpanFactory {
+  formatter: Formatter,
+  library: InstrumentationLibrary) extends SpanFactory {
 
   private val logger = LoggerFactory.getLogger(classOf[CoreSpanFactory])
 
@@ -69,6 +70,10 @@ private[core] class CoreSpanFactory(
     CoreSpan(
       id = spanId,
       name = spanName,
+      library = library,
       clock = clock,
       handler = handler)
+
+  override def forInstrumentationLibrary(library: InstrumentationLibrary): SpanFactory =
+    new CoreSpanFactory(clock, handler, formatter, library)
 }

--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpanInfo.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpanInfo.scala
@@ -18,7 +18,7 @@ package com.comcast.money.core
 
 import java.util.Collections
 
-import com.comcast.money.api.{ Event, Note, SpanId, SpanInfo }
+import com.comcast.money.api.{ Event, InstrumentationLibrary, Note, SpanId, SpanInfo }
 import io.opentelemetry.trace.{ Span, StatusCanonicalCode }
 
 private[core] case class CoreSpanInfo(
@@ -32,5 +32,6 @@ private[core] case class CoreSpanInfo(
   description: String = "",
   notes: java.util.Map[String, Note[_]] = Collections.emptyMap(),
   events: java.util.List[Event] = Collections.emptyList(),
+  library: InstrumentationLibrary = Money.InstrumentationLibrary,
   appName: String = Money.Environment.applicationName,
   host: String = Money.Environment.hostName) extends SpanInfo

--- a/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
@@ -87,8 +87,6 @@ object DisabledSpanFactory extends SpanFactory {
   override def childSpan(childName: String, span: Span, sticky: Boolean): Span = DisabledSpan
 
   override def newSpan(spanId: SpanId, spanName: String): Span = DisabledSpan
-
-  override def forInstrumentationLibrary(library: InstrumentationLibrary): SpanFactory = DisabledSpanFactory
 }
 
 object DisabledSpanBuilder extends Span.Builder {

--- a/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
@@ -87,6 +87,8 @@ object DisabledSpanFactory extends SpanFactory {
   override def childSpan(childName: String, span: Span, sticky: Boolean): Span = DisabledSpan
 
   override def newSpan(spanId: SpanId, spanName: String): Span = DisabledSpan
+
+  override def forInstrumentationLibrary(library: InstrumentationLibrary): SpanFactory = DisabledSpanFactory
 }
 
 object DisabledSpanBuilder extends Span.Builder {

--- a/money-core/src/main/scala/com/comcast/money/core/Money.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Money.scala
@@ -19,7 +19,7 @@ package com.comcast.money.core
 import java.net.InetAddress
 import java.util.concurrent.TimeUnit
 
-import com.comcast.money.api.{ SpanFactory, SpanHandler }
+import com.comcast.money.api.{ InstrumentationLibrary, SpanFactory, SpanHandler }
 import com.comcast.money.core.async.{ AsyncNotificationHandler, AsyncNotifier }
 import com.comcast.money.core.formatters.{ Formatter, FormatterChain }
 import com.comcast.money.core.handlers.HandlerChain
@@ -39,6 +39,7 @@ case class Money(
 
 object Money {
 
+  val InstrumentationLibrary = new InstrumentationLibrary("money-core", "0.10.0")
   lazy val Environment: Money = apply(ConfigFactory.load().getConfig("money"))
 
   def apply(conf: Config): Money = {

--- a/money-core/src/main/scala/com/comcast/money/core/Money.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Money.scala
@@ -55,7 +55,7 @@ object Money {
       } else {
         FormatterChain.default
       }
-      val factory: SpanFactory = new CoreSpanFactory(clock, handler, formatter)
+      val factory: SpanFactory = new CoreSpanFactory(clock, handler, formatter, Money.InstrumentationLibrary)
       val tracer = new Tracer {
         override val spanFactory: SpanFactory = factory
       }

--- a/money-core/src/main/scala/com/comcast/money/core/Money.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Money.scala
@@ -55,7 +55,7 @@ object Money {
       } else {
         FormatterChain.default
       }
-      val factory: SpanFactory = new CoreSpanFactory(clock, handler, formatter, Money.InstrumentationLibrary)
+      val factory: SpanFactory = CoreSpanFactory(clock, handler, formatter, Money.InstrumentationLibrary)
       val tracer = new Tracer {
         override val spanFactory: SpanFactory = factory
       }

--- a/money-core/src/main/scala/com/comcast/money/core/MoneyTracerProvider.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/MoneyTracerProvider.scala
@@ -30,9 +30,11 @@ final case class MoneyTracerProvider(tracer: Tracer) extends TracerProvider {
   override def get(instrumentationName: String, instrumentationVersion: String): trace.Tracer = {
     val library = new InstrumentationLibrary(instrumentationName, instrumentationVersion)
     tracers.getOrElseUpdate(library, {
-      val factory = tracer.spanFactory.forInstrumentationLibrary(library)
-      new Tracer {
-        override val spanFactory: SpanFactory = factory
+      tracer.spanFactory match {
+        case csf: CoreSpanFactory => new Tracer {
+          override val spanFactory: SpanFactory = csf.copy(library = library)
+        }
+        case _ => tracer
       }
     })
   }

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
@@ -28,7 +28,7 @@ class CoreSpanFactorySpec extends AnyWordSpec with Matchers with MockitoSugar wi
   val handler = mock[SpanHandler]
   val formatter = new MoneyTraceFormatter()
   val instrumentationLibrary = new InstrumentationLibrary("test", "0.0.1")
-  val underTest = new CoreSpanFactory(clock, handler, formatter, instrumentationLibrary)
+  val underTest = CoreSpanFactory(clock, handler, formatter, instrumentationLibrary)
 
   "CoreSpanFactory" should {
     "create a new span" in {

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
@@ -16,7 +16,7 @@
 
 package com.comcast.money.core
 
-import com.comcast.money.api.{ Note, SpanHandler, SpanId }
+import com.comcast.money.api.{ InstrumentationLibrary, Note, SpanHandler, SpanId }
 import com.comcast.money.core.formatters.{ Formatter, MoneyTraceFormatter }
 import com.comcast.money.core.handlers.TestData
 import org.scalatest.matchers.should.Matchers
@@ -27,7 +27,8 @@ class CoreSpanFactorySpec extends AnyWordSpec with Matchers with MockitoSugar wi
 
   val handler = mock[SpanHandler]
   val formatter = new MoneyTraceFormatter()
-  val underTest = new CoreSpanFactory(clock, handler, formatter)
+  val instrumentationLibrary = new InstrumentationLibrary("test", "0.0.1")
+  val underTest = new CoreSpanFactory(clock, handler, formatter, instrumentationLibrary)
 
   "CoreSpanFactory" should {
     "create a new span" in {

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanInfoSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanInfoSpec.scala
@@ -31,6 +31,7 @@ class CoreSpanInfoSpec extends AnyWordSpec with Matchers {
       underTest.name shouldBe "test"
       underTest.appName shouldBe Money.Environment.applicationName
       underTest.host shouldBe Money.Environment.hostName
+      underTest.library shouldBe Money.InstrumentationLibrary
       underTest.notes shouldBe empty
       underTest.success shouldBe null
       underTest.durationMicros shouldBe 0L

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanSpec.scala
@@ -35,7 +35,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
   "CoreSpan" should {
     "set the startTimeMillis and startTimeMicros when started" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
       underTest.start()
 
       val state = underTest.info
@@ -45,7 +45,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set the startTimeMillis and startTimeMicros when started with time stamps" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
       val instant = Instant.now
       underTest.start(instant.getEpochSecond, instant.getNano)
 
@@ -56,7 +56,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "record a timer" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.startTimer("foo")
       underTest.stopTimer("foo")
@@ -65,7 +65,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "record a note" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.record(testLongNote)
 
@@ -73,7 +73,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a String attribute" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.setAttribute("foo", "bar")
 
@@ -84,7 +84,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a long attribute" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.setAttribute("foo", 200L)
 
@@ -95,7 +95,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a double attribute" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.setAttribute("foo", 2.2)
 
@@ -106,7 +106,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a boolean attribute" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.setAttribute("foo", true)
 
@@ -117,7 +117,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set a attribute with an attribute key" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.setAttribute(AttributeKey.stringKey("foo"), "bar")
 
@@ -128,7 +128,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "add an event with name" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.addEvent("event")
 
@@ -141,7 +141,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "add an event with name and timestamp" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.addEvent("event", 100L)
 
@@ -154,7 +154,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "add an event with name and attributes" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.addEvent("event", Attributes.of(AttributeKey.stringKey("foo"), "bar"))
 
@@ -167,7 +167,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "add an event with name, attributes and timestamp" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.addEvent("event", Attributes.of(AttributeKey.stringKey("foo"), "bar"), 100L)
 
@@ -181,7 +181,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "record an exception" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       val exception = new RuntimeException("BOOM")
       underTest.recordException(exception)
@@ -198,7 +198,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "record an exception with attributes" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       val exception = new RuntimeException("BOOM")
       underTest.recordException(exception, Attributes.of(AttributeKey.stringKey("foo"), "bar"))
@@ -216,8 +216,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set the status to OK" in {
-      val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.setStatus(StatusCanonicalCode.OK)
 
@@ -229,8 +228,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set the status to ERROR" in {
-      val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.setStatus(StatusCanonicalCode.ERROR)
 
@@ -242,8 +240,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set the status to OK and stop with false result" in {
-      val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.setStatus(StatusCanonicalCode.OK)
 
@@ -255,8 +252,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set the status to ERROR and stop with true result" in {
-      val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.setStatus(StatusCanonicalCode.ERROR)
 
@@ -268,8 +264,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set the status with description" in {
-      val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.setStatus(StatusCanonicalCode.OK, "description")
 
@@ -277,7 +272,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "update the span name" in {
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.name shouldBe "test"
       underTest.info.name shouldBe "test"
@@ -290,8 +285,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "gets isRecording" in {
-      val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.isRecording shouldBe false
 
@@ -306,7 +300,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
 
     "gets SpanContext" in {
       val spanId = SpanId.createRemote("01234567-890A-BCDE-F012-34567890ABCD", 81985529216486895L, 81985529216486895L, TraceFlags.getSampled, TraceState.getDefault)
-      val underTest = CoreSpan(spanId, "test", OtelSpan.Kind.INTERNAL, SystemClock, null)
+      val underTest = CoreSpan(spanId, "test")
 
       val context = underTest.getContext
 
@@ -315,8 +309,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     }
 
     "set the endTimeMillis and endTimeMicros when stopped" in {
-      val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.stop(true)
 
@@ -329,7 +322,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     "invoke the span handler when stopped" in {
       val handler = mock[SpanHandler]
       val handleCaptor = ArgumentCaptor.forClass(classOf[SpanInfo])
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", handler = handler)
 
       underTest.start()
       underTest.record(testLongNote)
@@ -350,7 +343,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     "invoke the span handler when closed" in {
       val handler = mock[SpanHandler]
       val handleCaptor = ArgumentCaptor.forClass(classOf[SpanInfo])
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", handler = handler)
 
       underTest.start()
       underTest.record(testLongNote)
@@ -372,8 +365,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
       val scope1 = mock[Scope]
       val scope2 = mock[Scope]
 
-      val handler = mock[SpanHandler]
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test")
 
       underTest.attachScope(scope1)
       underTest.attachScope(scope2)
@@ -387,7 +379,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     "invoke the span handler when ended" in {
       val handler = mock[SpanHandler]
       val handleCaptor = ArgumentCaptor.forClass(classOf[SpanInfo])
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", handler = handler)
 
       underTest.start()
       underTest.record(testLongNote)
@@ -408,7 +400,7 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
     "invoke the span handler when ended with options" in {
       val handler = mock[SpanHandler]
       val handleCaptor = ArgumentCaptor.forClass(classOf[SpanInfo])
-      val underTest = CoreSpan(SpanId.createNew(), "test", OtelSpan.Kind.INTERNAL, SystemClock, handler)
+      val underTest = CoreSpan(SpanId.createNew(), "test", handler = handler)
 
       underTest.start()
       underTest.record(testLongNote)

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/TestData.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/TestData.scala
@@ -59,9 +59,9 @@ trait TestData {
     events = Collections.emptyList())
 
   val testSpanId = SpanId.createNew()
-  val testSpan = CoreSpan(testSpanId, "test-span", OtelSpan.Kind.INTERNAL, SystemClock, null)
+  val testSpan = CoreSpan(testSpanId, "test-span")
   val childSpanId = testSpanId.createChild()
-  val childSpan = CoreSpan(childSpanId, "child-span", OtelSpan.Kind.INTERNAL, SystemClock, null)
+  val childSpan = CoreSpan(childSpanId, "child-span")
 
   val fixedTestSpanId = SpanId.createRemote("5092ddfe-3701-4f84-b3d2-21f5501c0d28", 5176425846116696835L, 5176425846116696835L, TraceFlags.getSampled, TraceState.getDefault)
   val fixedTestSpanInfo = CoreSpanInfo(

--- a/money-core/src/test/scala/com/comcast/money/core/spi/MoneyTracerProviderFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/spi/MoneyTracerProviderFactorySpec.scala
@@ -18,7 +18,7 @@ package com.comcast.money.core.spi
 
 import java.util.ServiceLoader
 
-import com.comcast.money.core.{ Money, Tracer }
+import com.comcast.money.core.{ Money, MoneyTracerProvider, Tracer }
 import io.opentelemetry.OpenTelemetry
 import io.opentelemetry.trace.spi.TracerProviderFactory
 import org.scalatest.matchers.should.Matchers
@@ -35,8 +35,7 @@ class MoneyTracerProviderFactorySpec extends AnyWordSpec with MockitoSugar with 
       val underTest = new MoneyTracerProviderFactory(tracer)
 
       val provider = underTest.create()
-      provider.get("test") shouldBe tracer
-      provider.get("test", "1.0") shouldBe tracer
+      provider shouldBe a[MoneyTracerProvider]
     }
 
     "integrates with Java SPI" in {
@@ -50,7 +49,7 @@ class MoneyTracerProviderFactorySpec extends AnyWordSpec with MockitoSugar with 
 
     "integrates with OpenTelemetry.getTracer" in {
       val tracer = OpenTelemetry.getTracer("test")
-      tracer shouldBe Money.Environment.tracer
+      tracer shouldBe a[Tracer]
     }
   }
 }

--- a/money-otel-handler/src/main/scala/com/comcast/money/otel/handlers/MoneyReadableSpanData.scala
+++ b/money-otel-handler/src/main/scala/com/comcast/money/otel/handlers/MoneyReadableSpanData.scala
@@ -19,28 +19,28 @@ package com.comcast.money.otel.handlers
 import java.util
 import java.util.Collections
 
-import com.comcast.money.api.{ Event, Note, SpanInfo }
+import com.comcast.money.api.{ Event, InstrumentationLibrary, Note, SpanInfo }
+import com.comcast.money.core.Money
 import io.opentelemetry.common.{ Attributes, ReadableAttributes }
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.ReadableSpan
 import io.opentelemetry.sdk.trace.data.{ ImmutableStatus, SpanData }
-import io.opentelemetry.trace.{ Span => OtelSpan, SpanContext, SpanId, TraceState }
+import io.opentelemetry.trace.{ SpanContext, SpanId, TraceState, Span => OtelSpan }
 
 import scala.collection.JavaConverters._
 
 private[otel] class MoneyReadableSpanData(info: SpanInfo) extends ReadableSpan with SpanData {
-  import OtelSpanHandler.instrumentationLibraryInfo
-
   private val id = info.id
   private lazy val spanContext = id.toSpanContext
+  private lazy val libraryInfo = convertLibraryInfo(info.library)
   private lazy val attributes = convertAttributes(info.notes)
   private lazy val events = convertEvents(info.events)
 
   override def getSpanContext: SpanContext = spanContext
   override def getName: String = info.name
   override def toSpanData: SpanData = this
-  override def getInstrumentationLibraryInfo: InstrumentationLibraryInfo = instrumentationLibraryInfo
+  override def getInstrumentationLibraryInfo: InstrumentationLibraryInfo = libraryInfo
   override def hasEnded: Boolean = info.endTimeNanos > 0L
   override def getLatencyNanos: Long = info.durationNanos
   override def getTraceId: String = id.traceIdAsHex
@@ -61,6 +61,13 @@ private[otel] class MoneyReadableSpanData(info: SpanInfo) extends ReadableSpan w
   override def getTotalAttributeCount: Int = info.notes.size
   override def getAttributes: ReadableAttributes = attributes
   override def getEvents: util.List[SpanData.Event] = events
+
+  private def convertLibraryInfo(library: InstrumentationLibrary): InstrumentationLibraryInfo =
+    if (library != null) {
+      InstrumentationLibraryInfo.create(library.name, library.version)
+    } else {
+      InstrumentationLibraryInfo.getEmpty
+    }
 
   private def appendNoteToBuilder[T](builder: Attributes.Builder, note: Note[T]): Attributes.Builder =
     builder.setAttribute(note.key, note.value)

--- a/money-otel-handler/src/main/scala/com/comcast/money/otel/handlers/OtelSpanHandler.scala
+++ b/money-otel-handler/src/main/scala/com/comcast/money/otel/handlers/OtelSpanHandler.scala
@@ -23,10 +23,6 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo
 import io.opentelemetry.sdk.trace.SpanProcessor
 import io.opentelemetry.sdk.trace.`export`.{ BatchSpanProcessor, SimpleSpanProcessor, SpanExporter }
 
-object OtelSpanHandler {
-  val instrumentationLibraryInfo: InstrumentationLibraryInfo = InstrumentationLibraryInfo.create("money", "0.10.0")
-}
-
 /**
  * An abstract `SpanHandler` that can wrap an OpenTelemetry `SpanExporter` implementation
  * and export spans to an OpenTelemetry-compatible exporter such as ZipKin or Jaeger.

--- a/money-otel-handler/src/test/java/com/comcast/money/otel/handlers/TestSpanInfo.java
+++ b/money-otel-handler/src/test/java/com/comcast/money/otel/handlers/TestSpanInfo.java
@@ -24,6 +24,7 @@ import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.StatusCanonicalCode;
 
 import com.comcast.money.api.Event;
+import com.comcast.money.api.InstrumentationLibrary;
 import com.comcast.money.api.Note;
 import com.comcast.money.api.SpanId;
 import com.comcast.money.api.SpanInfo;
@@ -63,6 +64,11 @@ public class TestSpanInfo implements SpanInfo {
     @Override
     public Span.Kind kind() {
         return Span.Kind.INTERNAL;
+    }
+
+    @Override
+    public InstrumentationLibrary library() {
+        return new InstrumentationLibrary("test", "0.0.1");
     }
 
     @Override

--- a/money-otel-handler/src/test/scala/com/comcast/money/otel/handlers/MoneyReadableSpanDataSpec.scala
+++ b/money-otel-handler/src/test/scala/com/comcast/money/otel/handlers/MoneyReadableSpanDataSpec.scala
@@ -19,7 +19,7 @@ package com.comcast.money.otel.handlers
 import java.util
 import java.util.UUID
 
-import com.comcast.money.api.{ Event, Note, SpanId, SpanInfo }
+import com.comcast.money.api.{ Event, InstrumentationLibrary, Note, SpanId, SpanInfo }
 import io.opentelemetry.common.{ AttributeKey, Attributes }
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.data.ImmutableStatus
@@ -94,6 +94,7 @@ class MoneyReadableSpanDataSpec extends AnyWordSpec with Matchers {
   case class TestSpanInfo(id: SpanId) extends SpanInfo {
     override def appName(): String = "app"
     override def host(): String = "host"
+    override def library(): InstrumentationLibrary = new InstrumentationLibrary("test", "0.0.1")
     override def name(): String = "name"
     override def kind(): Span.Kind = Span.Kind.INTERNAL
     override def startTimeNanos(): Long = 1000000L

--- a/money-otel-handler/src/test/scala/com/comcast/money/otel/handlers/MoneyReadableSpanDataSpec.scala
+++ b/money-otel-handler/src/test/scala/com/comcast/money/otel/handlers/MoneyReadableSpanDataSpec.scala
@@ -37,7 +37,7 @@ class MoneyReadableSpanDataSpec extends AnyWordSpec with Matchers {
     "wrap Money SpanInfo" in {
       val underTest = new MoneyReadableSpanData(TestSpanInfo(spanId))
 
-      underTest.getInstrumentationLibraryInfo.getName shouldBe "money"
+      underTest.getInstrumentationLibraryInfo.getName shouldBe "test"
       underTest.getTraceId shouldBe "01234567890abcdef01234567890abcd"
       underTest.getSpanId shouldBe "0123456789abcdef"
       underTest.getParentSpanId shouldBe "0000000000000000"
@@ -65,7 +65,7 @@ class MoneyReadableSpanDataSpec extends AnyWordSpec with Matchers {
     "wrap child Money SpanInfo" in {
       val underTest = new MoneyReadableSpanData(TestSpanInfo(childSpanId))
 
-      underTest.getInstrumentationLibraryInfo.getName shouldBe "money"
+      underTest.getInstrumentationLibraryInfo.getName shouldBe "test"
       underTest.getTraceId shouldBe "01234567890abcdef01234567890abcd"
       underTest.getSpanId shouldBe "0123456789abcdef"
       underTest.getParentSpanId shouldBe "0fedcba987654321"

--- a/money-otel-inmemory-exporter/src/test/java/com/comcast/money/otel/handlers/inmemory/InMemorySpanHandlerSpec.java
+++ b/money-otel-inmemory-exporter/src/test/java/com/comcast/money/otel/handlers/inmemory/InMemorySpanHandlerSpec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.otel.handlers.inmemory;
 
 import java.util.Collection;

--- a/money-otel-logging-exporter/src/test/java/com/comcast/money/otel/handlers/logging/LoggingSpanHandlerSpec.java
+++ b/money-otel-logging-exporter/src/test/java/com/comcast/money/otel/handlers/logging/LoggingSpanHandlerSpec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.otel.handlers.logging;
 
 import java.util.Collection;

--- a/money-otlp-exporter/src/test/java/com/comcast/money/otel/handlers/otlp/OtlpHandlerSpec.java
+++ b/money-otlp-exporter/src/test/java/com/comcast/money/otel/handlers/otlp/OtlpHandlerSpec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.otel.handlers.otlp;
 
 import java.util.Collection;

--- a/money-spring/src/test/java/com/comcast/money/spring/MoneyClientHttpInterceptorSpec.java
+++ b/money-spring/src/test/java/com/comcast/money/spring/MoneyClientHttpInterceptorSpec.java
@@ -16,6 +16,7 @@
 
 package com.comcast.money.spring;
 
+import com.comcast.money.api.InstrumentationLibrary;
 import com.comcast.money.api.Span;
 import com.comcast.money.api.SpanId;
 import com.comcast.money.api.SpanInfo;
@@ -59,6 +60,7 @@ public class MoneyClientHttpInterceptorSpec {
                 "",
                 Collections.emptyMap(),
                 Collections.emptyList(),
+                new InstrumentationLibrary("test", "0.0.1"),
                 "testAppName",
                 "testHost");
 

--- a/money-wire/src/main/avro/money.avsc
+++ b/money-wire/src/main/avro/money.avsc
@@ -17,6 +17,16 @@
             "type": "string"
         },
         {
+            "name": "libraryName",
+            "type": ["null","string"],
+            "default": null
+        },
+        {
+            "name": "libraryVersion",
+            "type": ["null","string"],
+            "default": null
+        },
+        {
             "name": "duration",
             "type": "long",
             "default": 0

--- a/money-wire/src/main/scala/com/comcast/money/wire/SpanConverters.scala
+++ b/money-wire/src/main/scala/com/comcast/money/wire/SpanConverters.scala
@@ -22,7 +22,7 @@ import java.util.Collections
 import java.util.concurrent.TimeUnit
 
 import com.comcast.money.api
-import com.comcast.money.api.{ Event, Note, SpanId, SpanInfo }
+import com.comcast.money.api.{ Event, InstrumentationLibrary, Note, SpanId, SpanInfo }
 import com.comcast.money.core._
 import com.comcast.money.wire.avro
 import com.comcast.money.wire.avro.NoteType
@@ -140,6 +140,7 @@ trait SpanWireConverters {
       override def id(): SpanId = implicitly[TypeConverter[avro.SpanId, api.SpanId]].convert(from.getId)
       override def name(): String = from.getName
       override def durationNanos(): Long = TimeUnit.MICROSECONDS.toNanos(from.getDuration)
+      override def library(): InstrumentationLibrary = InstrumentationLibrary.UNKNOWN
       override def appName(): String = from.getAppName
       override def host(): String = from.getHost
     }

--- a/money-wire/src/main/scala/com/comcast/money/wire/SpanConverters.scala
+++ b/money-wire/src/main/scala/com/comcast/money/wire/SpanConverters.scala
@@ -114,6 +114,8 @@ trait SpanWireConverters {
       span.name,
       span.appName,
       span.host,
+      span.library.name,
+      span.library.version,
       span.durationMicros,
       if (success == null) true else success,
       span.startTimeMillis,
@@ -129,6 +131,13 @@ trait SpanWireConverters {
       res
     }
 
+    def toInstrumentationLibrary(span: avro.Span): InstrumentationLibrary =
+      if (span.getLibraryName != null && !span.getLibraryName.isEmpty) {
+        new InstrumentationLibrary(span.getLibraryName, span.getLibraryVersion)
+      } else {
+        InstrumentationLibrary.UNKNOWN
+      }
+
     new SpanInfo {
       override def notes(): util.Map[String, Note[_]] = toNotesMap(from.getNotes)
       override def events(): util.List[Event] = Collections.emptyList()
@@ -140,7 +149,7 @@ trait SpanWireConverters {
       override def id(): SpanId = implicitly[TypeConverter[avro.SpanId, api.SpanId]].convert(from.getId)
       override def name(): String = from.getName
       override def durationNanos(): Long = TimeUnit.MICROSECONDS.toNanos(from.getDuration)
-      override def library(): InstrumentationLibrary = InstrumentationLibrary.UNKNOWN
+      override def library(): InstrumentationLibrary = toInstrumentationLibrary(from)
       override def appName(): String = from.getAppName
       override def host(): String = from.getHost
     }

--- a/money-wire/src/test/scala/com/comcast/money/wire/TestSpanInfo.scala
+++ b/money-wire/src/test/scala/com/comcast/money/wire/TestSpanInfo.scala
@@ -18,7 +18,7 @@ package com.comcast.money.wire
 
 import java.util.Collections
 
-import com.comcast.money.api.{ Event, Note, SpanId, SpanInfo }
+import com.comcast.money.api.{ Event, InstrumentationLibrary, Note, SpanId, SpanInfo }
 import com.comcast.money.core.Money
 import io.opentelemetry.trace.{ Span, StatusCanonicalCode }
 
@@ -26,6 +26,7 @@ case class TestSpanInfo(
   id: SpanId,
   name: String,
   kind: Span.Kind = Span.Kind.INTERNAL,
+  library: InstrumentationLibrary = new InstrumentationLibrary("test", "0.0.1"),
   startTimeNanos: Long = 0L,
   endTimeNanos: Long = 0L,
   durationNanos: Long = 0L,


### PR DESCRIPTION
To support SPI scenarios where an instrumentation library will request a tracer with the instrumentation library information which may be used by the span handler/exporter wire the instrumentation library information (name and version) through the CoreSpan and SpanInfo.