### PR TITLE
Update to Mockito 3.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -183,7 +183,8 @@ lazy val moneySpring =
           junitInterface,
           assertj,
           springTest,
-          springOckito
+          springBootTest,
+          aspectJ
         ) ++ commonTestDependencies,
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
     )

--- a/money-core/src/test/scala/com/comcast/money/core/TracerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/TracerSpec.scala
@@ -20,7 +20,7 @@ import com.comcast.money.api.{ Note, Span, SpanFactory, SpanId }
 import com.comcast.money.core.handlers.TestData
 import com.comcast.money.core.internal.SpanLocal
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.{ BeforeAndAfterEach, OneInstancePerTest }
 import org.scalatest.matchers.should.Matchers
@@ -41,10 +41,10 @@ class TracerSpec extends AnyWordSpec
   override def beforeEach(): Unit = {
     SpanLocal.clear()
 
-    doReturn(mockSpan).when(mockSpanFactory).newSpan(any[SpanId], anyString())
-    doReturn(mockSpan).when(mockSpanFactory).newSpan(anyString())
-    doReturn(mockSpan).when(mockSpanFactory).childSpan(anyString(), any[Span])
-    doReturn(testSpanInfo).when(mockSpan).info()
+    when(mockSpanFactory.newSpan(any[SpanId], anyString())).thenReturn(mockSpan)
+    when(mockSpanFactory.newSpan(anyString())).thenReturn(mockSpan)
+    when(mockSpanFactory.childSpan(anyString(), any[Span])).thenReturn(mockSpan)
+    when(mockSpan.info).thenReturn(testSpanInfo)
   }
 
   "Tracer" should {

--- a/money-core/src/test/scala/com/comcast/money/core/async/AsyncNotifierSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/async/AsyncNotifierSpec.scala
@@ -19,7 +19,7 @@ package com.comcast.money.core.async
 import com.comcast.money.core.SpecHelpers
 import com.comcast.money.core.concurrent.ConcurrentSupport
 import com.typesafe.config.ConfigFactory
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 
 import scala.concurrent.Future
@@ -82,7 +82,7 @@ class AsyncNotifierSpec
       val future = mock[Future[String]]
 
       val asyncNotifier = AsyncNotifier(Seq(mockHandler))
-      doReturn(true).when(mockHandler).supports(futureClass, future)
+      when(mockHandler.supports(futureClass, future)).thenReturn(true)
 
       val result = asyncNotifier.resolveHandler(futureClass, future)
 
@@ -96,7 +96,7 @@ class AsyncNotifierSpec
       val future = mock[Future[String]]
 
       val asyncNotifier = AsyncNotifier(Seq(mockHandler))
-      doReturn(true).when(mockHandler).supports(any[Class[_]], any)
+      when(mockHandler.supports(any[Class[_]], any)).thenReturn(true)
 
       val result = asyncNotifier.resolveHandler(null, future)
 
@@ -107,7 +107,7 @@ class AsyncNotifierSpec
       val mockHandler = mock[AsyncNotificationHandler]
 
       val asyncNotifier = AsyncNotifier(Seq(mockHandler))
-      doReturn(true).when(mockHandler).supports(any[Class[_]], any)
+      when(mockHandler.supports(any[Class[_]], any)).thenReturn(true)
 
       val result = asyncNotifier.resolveHandler(classOf[Future[_]], null)
 
@@ -118,7 +118,7 @@ class AsyncNotifierSpec
       val mockHandler = mock[AsyncNotificationHandler]
 
       val asyncNotifier = AsyncNotifier(Seq(mockHandler))
-      doReturn(false).when(mockHandler).supports(any[Class[_]], any)
+      when(mockHandler.supports(any[Class[_]], any)).thenReturn(false)
 
       val result = asyncNotifier.resolveHandler(classOf[Future[_]], new Object)
 

--- a/money-core/src/test/scala/com/comcast/money/core/async/CompletableFutureNotificationHandlerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/async/CompletableFutureNotificationHandlerSpec.scala
@@ -20,8 +20,8 @@ import java.util.concurrent.{ CompletableFuture, Future }
 
 import com.comcast.money.core.SpecHelpers
 import com.comcast.money.core.concurrent.ConcurrentSupport
-import org.mockito.Matchers.{ any, eq => argEq }
-import org.mockito.Mockito.{ doReturn, never, times, verify }
+import org.mockito.ArgumentMatchers.{ any, eq => argEq }
+import org.mockito.Mockito.{ doReturn, never, times, verify, when }
 
 import scala.util.{ Failure, Try }
 import org.scalatest.wordspec.AnyWordSpec
@@ -77,7 +77,7 @@ class CompletableFutureNotificationHandlerSpec
     }
     "calls whenComplete method on the future" in {
       val future = mock[CompletableFuture[String]]
-      doReturn(future).when(future).whenComplete(any())
+      when(future.whenComplete(any())).thenReturn(future)
 
       val result = underTest.whenComplete(futureClass, future) { _ => {} }
 

--- a/money-core/src/test/scala/com/comcast/money/core/async/CompletionStageNotificationHandlerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/async/CompletionStageNotificationHandlerSpec.scala
@@ -20,8 +20,8 @@ import java.util.concurrent.{ CompletableFuture, CompletionStage }
 
 import com.comcast.money.core.SpecHelpers
 import com.comcast.money.core.concurrent.ConcurrentSupport
-import org.mockito.Matchers.{ any, eq => argEq }
-import org.mockito.Mockito.{ doReturn, never, times, verify }
+import org.mockito.ArgumentMatchers.{ any, eq => argEq }
+import org.mockito.Mockito.{ doReturn, never, times, verify, when }
 
 import scala.util.{ Failure, Try }
 import org.scalatest.wordspec.AnyWordSpec
@@ -72,7 +72,7 @@ class CompletionStageNotificationHandlerSpec
     }
     "calls whenComplete method on the completion stage" in {
       val stage = mock[CompletionStage[String]]
-      doReturn(stage).when(stage).whenComplete(any())
+      when(stage.whenComplete(any())).thenReturn(stage)
 
       val result = underTest.whenComplete(futureClass, stage) { _ => {} }
 

--- a/money-core/src/test/scala/com/comcast/money/core/async/ScalaFutureNotificationHandlerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/async/ScalaFutureNotificationHandlerSpec.scala
@@ -19,7 +19,7 @@ package com.comcast.money.core.async
 import com.comcast.money.core.SpecHelpers
 import com.comcast.money.core.concurrent.ConcurrentSupport
 import org.mockito.Mockito._
-import org.mockito.Matchers.{ any, eq => argEq }
+import org.mockito.ArgumentMatchers.{ any, eq => argEq }
 
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.{ Failure, Try }
@@ -77,7 +77,7 @@ class ScalaFutureNotificationHandlerSpec
     "calls transform method on the future" in {
       val future = mock[Future[String]]
       val transformed = mock[Future[String]]
-      doReturn(transformed).when(future).transform(any(), any())(argEq(underTest.executionContext))
+      when(future.transform(any(), any())(argEq(underTest.executionContext))).thenReturn(transformed.asInstanceOf[Future[Nothing]])
 
       val result = underTest.whenComplete(futureClass, future)(_ => {})
 

--- a/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterPropagatorSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterPropagatorSpec.scala
@@ -16,13 +16,14 @@
 
 package com.comcast.money.core.formatters
 
-import com.comcast.money.api.{IdGenerator, SpanId}
+import com.comcast.money.api.{ IdGenerator, SpanId }
 import io.grpc.Context
 import io.opentelemetry.context.propagation.TextMapPropagator
-import io.opentelemetry.trace.{DefaultSpan, TraceFlags, TraceState, TracingContextUtils}
+import io.opentelemetry.trace.{ DefaultSpan, TraceFlags, TraceState, TracingContextUtils }
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.any
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito.{ verify, when }
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{ verify, when }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar

--- a/money-core/src/test/scala/com/comcast/money/core/formatters/OtelFormatterSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/formatters/OtelFormatterSpec.scala
@@ -23,7 +23,7 @@ import io.opentelemetry.context.propagation.TextMapPropagator
 import io.opentelemetry.context.propagation.TextMapPropagator.{ Getter, Setter }
 import io.opentelemetry.trace.TracingContextUtils
 import org.mockito.{ ArgumentCaptor, Mockito }
-import org.mockito.Matchers.{ any, eq => argEq }
+import org.mockito.ArgumentMatchers.{ any, eq => argEq }
 import org.mockito.Mockito.{ verify, when }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/LoggingSpanHandlerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/LoggingSpanHandlerSpec.scala
@@ -19,7 +19,7 @@ package com.comcast.money.core.handlers
 import com.comcast.money.api.SpanInfo
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.slf4j.Logger
 import org.scalatest.wordspec.AnyWordSpec
@@ -36,8 +36,8 @@ class LoggingSpanHandlerSpec extends AnyWordSpec
   val sampleMessage = "sample formatted log message"
   val sampleFormatterConfig = ConfigFactory.parseString("formatting { this=that }")
 
-  doReturn(mockFormatter).when(mockMakeFormatter).apply(any[Config])
-  doReturn(sampleMessage).when(mockFormatter).buildMessage(any[SpanInfo])
+  when(mockMakeFormatter.apply(any[Config])).thenReturn(mockFormatter)
+  when(mockFormatter.buildMessage(any[SpanInfo])).thenReturn(sampleMessage)
 
   val logEntryCaptor = ArgumentCaptor.forClass(classOf[String])
   val underTest = new LoggingSpanHandler(mockLogger, mockMakeFormatter)

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/MetricsHandlerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/MetricsHandlerSpec.scala
@@ -20,7 +20,7 @@ import com.codahale.metrics.{ Histogram, Meter, MetricRegistry }
 import com.typesafe.config.Config
 import io.opentelemetry.trace.StatusCanonicalCode
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
@@ -29,8 +29,8 @@ import org.scalatest.OneInstancePerTest
 class MetricsHandlerSpec extends AnyWordSpec with Matchers with MockitoSugar with TestData with OneInstancePerTest {
 
   val conf = mock[Config]
-  doReturn(true).when(conf).hasPath("metrics-registry.class-name")
-  doReturn("com.comcast.money.core.metrics.MockMetricRegistryFactory").when(conf).getString("metrics-registry.class-name")
+  when(conf.hasPath("metrics-registry.class-name")).thenReturn(true)
+  when(conf.getString("metrics-registry.class-name")).thenReturn("com.comcast.money.core.metrics.MockMetricRegistryFactory")
 
   "MetricsSpanHandler" should {
     "configure the metrics registry" in {
@@ -46,8 +46,8 @@ class MetricsHandlerSpec extends AnyWordSpec with Matchers with MockitoSugar wit
 
       val latencyMetric = mock[Histogram]
       val errorMetric = mock[Meter]
-      doReturn(latencyMetric).when(underTest.metricRegistry).histogram(anyString())
-      doReturn(errorMetric).when(underTest.metricRegistry).meter(anyString())
+      when(underTest.metricRegistry.histogram(anyString())).thenReturn(latencyMetric)
+      when(underTest.metricRegistry.meter(anyString())).thenReturn(errorMetric)
 
       underTest.handle(testSpanInfo)
 
@@ -61,8 +61,8 @@ class MetricsHandlerSpec extends AnyWordSpec with Matchers with MockitoSugar wit
 
       val latencyMetric = mock[Histogram]
       val errorMetric = mock[Meter]
-      doReturn(latencyMetric).when(underTest.metricRegistry).histogram(anyString())
-      doReturn(errorMetric).when(underTest.metricRegistry).meter(anyString())
+      when(underTest.metricRegistry.histogram(anyString())).thenReturn(latencyMetric)
+      when(underTest.metricRegistry.meter(anyString())).thenReturn(errorMetric)
 
       underTest.handle(testSpanInfo.copy(status = StatusCanonicalCode.ERROR))
 

--- a/money-core/src/test/scala/com/comcast/money/core/japi/JMoneySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/japi/JMoneySpec.scala
@@ -22,7 +22,7 @@ import com.comcast.money.core.Tracer
 import com.comcast.money.core.internal.SpanLocal
 import com.comcast.money.core.japi.JMoney._
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.Mockito.doReturn
 import org.scalatest._
@@ -140,7 +140,7 @@ class JMoneySpec extends AnyWordSpec
     }
     "support callable lambda" in {
       val callable = mock[CheckedCallable[String, Exception]]
-      doReturn("Hello").when(callable).call()
+      when(callable.call()).thenReturn("Hello")
       val result = JMoney.trace("callable", callable)
 
       result shouldBe "Hello"
@@ -162,7 +162,7 @@ class JMoneySpec extends AnyWordSpec
     }
     "support function lambda with span" in {
       val function = mock[CheckedFunction[TraceSpan, String, Exception]]
-      doReturn("Hello").when(function).apply(any())
+      when(function.apply(any())).thenReturn("Hello")
 
       val result = JMoney.trace("function", function)
 
@@ -236,7 +236,7 @@ class JMoneySpec extends AnyWordSpec
     }
     "support callable timer lambda" in {
       val callable = mock[CheckedCallable[String, Exception]]
-      doReturn("Hello").when(callable).call()
+      when(callable.call()).thenReturn("Hello")
 
       val result = JMoney.time("the-timer", callable)
 

--- a/money-core/src/test/scala/com/comcast/money/core/logging/MethodTracerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/logging/MethodTracerSpec.scala
@@ -24,7 +24,7 @@ import com.comcast.money.core.Tracer
 import com.comcast.money.core.async.{ AsyncNotificationHandler, AsyncNotifier }
 import com.comcast.money.core.internal.{ MDCSupport, SpanContext }
 import io.opentelemetry.context.Scope
-import org.mockito.Matchers.{ any => argAny }
+import org.mockito.ArgumentMatchers.{ any => argAny }
 import org.mockito.Mockito._
 
 import scala.util.{ Failure, Success, Try }

--- a/money-core/src/test/scala/com/comcast/money/core/metrics/MetricRegistryFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/metrics/MetricRegistryFactorySpec.scala
@@ -43,7 +43,7 @@ class MetricRegistryFactorySpec extends AnyWordSpec with BeforeAndAfter with Moc
     "use the DefaultMetricRegistryFactory" should {
       "creating MetricRegistries" in {
 
-        doReturn("com.comcast.money.metrics.DefaultMetricRegistryFactory").when(conf).getString("metrics-registry.class-name")
+        when(conf.getString("metrics-registry.class-name")).thenReturn("com.comcast.money.metrics.DefaultMetricRegistryFactory")
 
         val registry = MetricRegistryFactory.metricRegistry(conf)
 
@@ -55,8 +55,8 @@ class MetricRegistryFactorySpec extends AnyWordSpec with BeforeAndAfter with Moc
   "fall back to the DefaultMetricRegistryFactory" should {
     "when the config is broken" in {
 
-      doReturn(true).when(conf).hasPath("metrics-registry.class-name")
-      doReturn("lorem ipsum").when(conf).getString("metrics-registry.class-name")
+      when(conf.hasPath("metrics-registry.class-name")).thenReturn(true)
+      when(conf.getString("metrics-registry.class-name")).thenReturn("lorem ipsum")
 
       intercept[ClassNotFoundException] {
         val registry = MetricRegistryFactory.metricRegistry(conf)
@@ -67,8 +67,8 @@ class MetricRegistryFactorySpec extends AnyWordSpec with BeforeAndAfter with Moc
   "use the MockMetricRegistryFactory" should {
     "when configured so" in {
 
-      doReturn(true).when(conf).hasPath("metrics-registry.class-name")
-      doReturn("com.comcast.money.core.metrics.MockMetricRegistryFactory").when(conf).getString("metrics-registry.class-name")
+      when(conf.hasPath("metrics-registry.class-name")).thenReturn(true)
+      when(conf.getString("metrics-registry.class-name")).thenReturn("com.comcast.money.core.metrics.MockMetricRegistryFactory")
 
       val registry1 = MetricRegistryFactory.metricRegistry(conf)
       val registry2 = MetricRegistryFactory.metricRegistry(conf)

--- a/money-http-client/src/test/scala/com/comcast/money/http/client/HttpTraceAspectSpec.scala
+++ b/money-http-client/src/test/scala/com/comcast/money/http/client/HttpTraceAspectSpec.scala
@@ -80,13 +80,13 @@ class HttpTraceAspectSpec
   }
 
   before {
-    doReturn(responseEntityStream).when(mockHttpEntity).getContent
-    doReturn(200).when(mockStatusLine).getStatusCode
-    doReturn(mockStatusLine).when(mockHttpResponse).getStatusLine
-    doReturn(mockHttpEntity).when(mockHttpResponse).getEntity
-    doReturn(mockHttpResponse).when(mockHttpClient).execute(mockHttpRequest)
-    doReturn(mockHttpResponse).when(mockJoinPoint).proceed()
-    doReturn("test-response").when(mockHttpResponseHandler).handleResponse(mockHttpResponse)
+    when(mockHttpEntity.getContent).thenReturn(responseEntityStream)
+    when(mockStatusLine.getStatusCode).thenReturn(200)
+    when(mockHttpResponse.getStatusLine).thenReturn(mockStatusLine)
+    when(mockHttpResponse.getEntity).thenReturn(mockHttpEntity)
+    when(mockHttpClient.execute(mockHttpRequest)).thenReturn(mockHttpResponse)
+    when(mockJoinPoint.proceed()).thenReturn(mockHttpResponse, Nil: _*)
+    when(mockHttpResponseHandler.handleResponse(mockHttpResponse)).thenReturn("test-response")
   }
 
   after {
@@ -148,7 +148,7 @@ class HttpTraceAspectSpec
   feature("Capturing http metrics on a method that calls http client and passes in a response handler") {
     scenario("happy path") {
       Given("the method calls execute on an Http Client passing in a response handler")
-      doReturn("test-response").when(mockHttpClient).execute(mockHttpRequest, mockHttpResponseHandler)
+      when(mockHttpClient.execute(mockHttpRequest, mockHttpResponseHandler)).thenReturn("test-response")
 
       When("the method is invoked")
       val result = methodWithHttpCallUsingResponseHandler()
@@ -170,14 +170,14 @@ class HttpTraceAspectSpec
   feature("advising calls to the http response handler") {
     scenario("happy path") {
       Given("a response handler that returns a simple value is advised")
-      doReturn("test-result").when(mockJoinPoint).proceed()
+      when(mockJoinPoint.proceed()).thenReturn("test-result", Nil: _*)
 
       And("a traced annotation is present")
-      doReturn("test-annotation").when(mockTracedAnnotation).value()
+      when(mockTracedAnnotation.value()).thenReturn("test-annotation")
 
       And("a http response has a 200 status code")
-      doReturn(200).when(mockStatusLine).getStatusCode
-      doReturn(mockStatusLine).when(mockHttpResponse).getStatusLine
+      when(mockStatusLine.getStatusCode).thenReturn(200)
+      when(mockHttpResponse.getStatusLine).thenReturn(mockStatusLine)
 
       When("the response handler is advised by the Http Trace Aspect")
       val result = testAspect.adviseHttpResponseHandler(mockJoinPoint, mockHttpResponse, mockTracedAnnotation)
@@ -199,7 +199,7 @@ class HttpTraceAspectSpec
       doThrow(new IllegalStateException()).when(mockJoinPoint).proceed()
 
       And("a traced annotation is present")
-      doReturn("test-annotation").when(mockTracedAnnotation).value()
+      when(mockTracedAnnotation.value()).thenReturn("test-annotation")
 
       When("the response handler is advised by the Http Trace Aspect")
       intercept[IllegalStateException] {
@@ -217,7 +217,7 @@ class HttpTraceAspectSpec
       doThrow(new IllegalStateException()).when(mockHttpResponse).getStatusLine
 
       And("a traced annotation is present")
-      doReturn("test-annotation").when(mockTracedAnnotation).value()
+      when(mockTracedAnnotation.value()).thenReturn("test-annotation")
 
       When("the response handler is advised by the Http Trace Aspect")
       intercept[IllegalStateException] {
@@ -234,7 +234,7 @@ class HttpTraceAspectSpec
       Given("a call to the response handler passes in an http response that is null")
 
       And("a traced annotation is present")
-      doReturn("test-annotation").when(mockTracedAnnotation).value()
+      when(mockTracedAnnotation.value()).thenReturn("test-annotation")
 
       When("the response handler is advised by the Http Trace Aspect")
       testAspect.adviseHttpResponseHandler(mockJoinPoint, null, mockTracedAnnotation)
@@ -249,7 +249,7 @@ class HttpTraceAspectSpec
   feature("advising the call to http client execute with a response handler") {
     scenario("happy path") {
       Given("A call to http client that takes an http response handler")
-      doReturn("test-annotation").when(mockTracedAnnotation).value()
+      when(mockTracedAnnotation.value()).thenReturn("test-annotation")
 
       And("a span has been started")
       SpanLocal.push(testSpan(spanId))
@@ -268,7 +268,7 @@ class HttpTraceAspectSpec
     }
     scenario("no span has been started") {
       Given("A call to http client that takes an http response handler")
-      doReturn("test-annotation").when(mockTracedAnnotation).value()
+      when(mockTracedAnnotation.value()).thenReturn("test-annotation")
 
       And("a span has NOT been started")
       // no span started here
@@ -287,7 +287,7 @@ class HttpTraceAspectSpec
     }
     scenario("the http request is null") {
       Given("A call to http client that takes an http response handler")
-      doReturn("test-annotation").when(mockTracedAnnotation).value()
+      when(mockTracedAnnotation.value()).thenReturn("test-annotation")
 
       And("a span has been started")
       SpanLocal.push(testSpan(spanId))
@@ -308,10 +308,10 @@ class HttpTraceAspectSpec
   feature("advising a method that calls http client execute that returns an HttpResponse") {
     scenario("happy path") {
       Given("A call to http client that returns an http response is being traced")
-      doReturn("test-annotation").when(mockTracedAnnotation).value()
+      when(mockTracedAnnotation.value()).thenReturn("test-annotation")
 
       And("the http response code returned is a 204")
-      doReturn(204).when(mockStatusLine).getStatusCode
+      when(mockStatusLine.getStatusCode).thenReturn(204)
 
       And("a span has been started")
       SpanLocal.push(testSpan(spanId))

--- a/money-http-client/src/test/scala/com/comcast/money/http/client/TraceFriendlyHttpClientSpec.scala
+++ b/money-http-client/src/test/scala/com/comcast/money/http/client/TraceFriendlyHttpClientSpec.scala
@@ -27,7 +27,7 @@ import org.apache.http.client.{ HttpClient, ResponseHandler }
 import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.protocol.HttpContext
 import org.apache.http.{ HttpHost, HttpResponse, StatusLine }
-import org.mockito.Matchers.anyString
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito._
 import org.scalatest._
 import org.scalatest.matchers.should.Matchers

--- a/money-spring/src/main/scala/com/comcast/money/spring/TracedMethodInterceptor.scala
+++ b/money-spring/src/main/scala/com/comcast/money/spring/TracedMethodInterceptor.scala
@@ -22,6 +22,7 @@ import com.comcast.money.annotations.Traced
 import com.comcast.money.core.logging.MethodTracer
 import org.aopalliance.aop.Advice
 import org.aopalliance.intercept.{ MethodInterceptor, MethodInvocation }
+import org.aspectj.lang.annotation.Aspect
 import org.springframework.aop.Pointcut
 import org.springframework.aop.support.{ AbstractPointcutAdvisor, StaticMethodMatcherPointcut }
 import org.springframework.beans.factory.annotation.{ Autowired, Qualifier }
@@ -49,6 +50,7 @@ class TracedMethodInterceptor @Autowired() (@Qualifier("springTracer") override 
  * Used by spring so that only those methods that have the @Traced annotation
  * are actually advised
  */
+@Aspect
 @Component
 class TracedMethodAdvisor @Autowired() (val interceptor: TracedMethodInterceptor) extends AbstractPointcutAdvisor {
 

--- a/money-spring/src/test/java/com/comcast/money/spring/SpringTracerSpec.java
+++ b/money-spring/src/test/java/com/comcast/money/spring/SpringTracerSpec.java
@@ -20,7 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.comcast.money.core.Money$;
 import com.comcast.money.core.Tracer;
@@ -28,7 +28,7 @@ import com.comcast.money.core.Tracer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SpringTracerSpec {
 
     @Mock

--- a/money-spring/src/test/java/com/comcast/money/spring/TracedMethodInterceptorSpec.java
+++ b/money-spring/src/test/java/com/comcast/money/spring/TracedMethodInterceptorSpec.java
@@ -63,9 +63,6 @@ public class TracedMethodInterceptorSpec {
 
     @Before
     public void setUp() {
-        // Needed to init the Argument Captor
-        // MockitoAnnotations.initMocks(this);
-
         when(springTracer.spanBuilder(anyString())).thenReturn(spanBuilder);
         when(spanBuilder.startSpan()).thenReturn(span);
         when(springTracer.withSpan(span)).thenReturn(scope);

--- a/money-spring/src/test/java/com/comcast/money/spring/TracedMethodInterceptorSpec.java
+++ b/money-spring/src/test/java/com/comcast/money/spring/TracedMethodInterceptorSpec.java
@@ -22,29 +22,35 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import com.comcast.money.api.Note;
 import com.comcast.money.api.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration("classpath:test-context.xml")
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {TracedMethodInterceptorSpec.TestConfig.class})
 public class TracedMethodInterceptorSpec {
+
+    @MockBean
+    private SpringTracer springTracer;
 
     @Autowired
     private SampleTraceBean sampleTraceBean;
-
-    // This bean is intercepted by springockito, so it is actually a mock!  Living the life!
-    @Autowired
-    private SpringTracer springTracer;
 
     @Mock
     private Span.Builder spanBuilder;
@@ -55,13 +61,10 @@ public class TracedMethodInterceptorSpec {
     @Mock
     private Scope scope;
 
-    @Captor
-    private ArgumentCaptor<Boolean> spanResultCaptor;
-
     @Before
     public void setUp() {
         // Needed to init the Argument Captor
-        MockitoAnnotations.initMocks(this);
+        // MockitoAnnotations.initMocks(this);
 
         when(springTracer.spanBuilder(anyString())).thenReturn(spanBuilder);
         when(spanBuilder.startSpan()).thenReturn(span);
@@ -164,5 +167,24 @@ public class TracedMethodInterceptorSpec {
     public void testTracingIgnoresException() {
         sampleTraceBean.doSomethingButIgnoreException();
         verify(span).stop(true);
+    }
+
+    @Configuration
+    @EnableAspectJAutoProxy
+    public static class TestConfig {
+        @Bean
+        public TracedMethodInterceptor tracedMethodInterceptor(SpringTracer springTracer) {
+            return new TracedMethodInterceptor(springTracer);
+        }
+
+        @Bean
+        public TracedMethodAdvisor tracedMethodAdvisor(TracedMethodInterceptor tracedMethodInterceptor) {
+            return new TracedMethodAdvisor(tracedMethodInterceptor);
+        }
+
+        @Bean
+        public SampleTraceBean sampleTraceBean() {
+            return new SampleTraceBean();
+        }
     }
 }

--- a/money-spring/src/test/resources/test-context.xml
+++ b/money-spring/src/test/resources/test-context.xml
@@ -1,17 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:mockito="http://www.mockito.org/spring/mockito"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
-		http://www.mockito.org/spring/mockito http://www.mockito.org/spring/mockito.xsd">
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
     <context:annotation-config/>
     <context:component-scan base-package="com.comcast.money.spring"/>
-
-    <!-- Uses SpringOckito to supplant the real spring tracer for a mock so we can verify -->
-    <mockito:mock id="springTracer" class="com.comcast.money.spring.SpringTracer" />
 
     <bean class="org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator">
         <property name="proxyTargetClass" value="true"/>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -81,7 +81,7 @@ object Dependencies {
   val scalaTest = "org.scalatest" %% "scalatest" % "3.2.2" % Test
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.14.3" % Test
   val scalaTestWordSpec = "org.scalatest" %% "scalatest-wordspec" % "3.2.2" % Test
-  val scalaTestPlus = "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2" % Test
+  val scalaTestPlus = "org.scalatestplus" %% "mockito-3-4" % "3.2.2.0" % Test
   val scalaTestCheck = "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % Test
 
   val junit = "junit" % "junit" % "4.12" % Test
@@ -90,7 +90,8 @@ object Dependencies {
   val powerMockApi = "org.powermock" % "powermock-api-mockito2" % "2.0.7" % Test
   val springTest = ("org.springframework" % "spring-test" % "4.3.17.RELEASE")
     .exclude("commons-logging", "commons-logging")
-  val springOckito = "org.kubek2k" % "springockito" % "1.0.9" % Test
+  val springBootTest = "org.springframework.boot" % "spring-boot-starter-test" % "1.5.11.RELEASE" % Test
+  val aspectJ = "org.aspectj" % "aspectjweaver" % "1.8.9" % Test
   val assertj = "org.assertj" % "assertj-core" % "3.17.2" % Test
   val awaitility = "org.awaitility" % "awaitility" % "4.0.3" % Test
   val zipkinJunit = "io.zipkin.zipkin2" % "zipkin-junit" % "2.18.3" % Test

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,3 +18,5 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
Updates tests to using Mockito 3.4.  This is good for tech debt in general but it's also in anticipation of updating to OpenTelemetry 0.10.0 which is looking at putting core functionality behind default method implementations in interfaces which Mockito 1.x does not support calling through to when that interface is mocked.

I had to replace Springockito with SpringBootTest for mocking beans with the aspect in the Spring tests and I had to switch from `doReturn(...).when(...)` to `when(...).thenReturn(...)` due to how Scala resolves overload candidates with varargs, but otherwise there were few required changes.