### PR TITLE
WIP: Add X-MoneyState header for sampling and state propagation

### DIFF
--- a/money-core/src/main/scala/com/comcast/money/core/formatters/MoneyTraceFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/MoneyTraceFormatter.scala
@@ -17,11 +17,11 @@
 package com.comcast.money.core.formatters
 
 import com.comcast.money.api.SpanId
-import com.comcast.money.core.formatters.MoneyTraceFormatter.{KeyValueDelimiter, MoneyStateDelimiter, MoneyStateHeader, ParentIdKey, SampledKey, SpanIdKey, TraceIdKey}
-import io.opentelemetry.trace.{TraceFlags, TraceState}
+import com.comcast.money.core.formatters.MoneyTraceFormatter.{ KeyValueDelimiter, MoneyStateDelimiter, MoneyStateHeader, ParentIdKey, SampledKey, SpanIdKey, TraceIdKey }
+import io.opentelemetry.trace.{ TraceFlags, TraceState }
 
 import scala.collection.JavaConverters._
-import scala.util.{Success, Try}
+import scala.util.{ Success, Try }
 
 object MoneyTraceFormatter {
   private[core] val MoneyTraceHeader = "X-MoneyTrace"
@@ -47,15 +47,15 @@ final class MoneyTraceFormatter extends Formatter {
     val stateEntries = sampled +: spanId.traceState.getEntries.asScala.toStream
       .map { entry => entry.getKey -> entry.getValue }
 
-    addHeader(MoneyStateHeader, stateEntries.map { case (k, v) => s"$k=$v"}.mkString(";"))
+    addHeader(MoneyStateHeader, stateEntries.map { case (k, v) => s"$k=$v" }.mkString(";"))
   }
 
   override def fromHttpHeaders(getHeader: String => String, log: String => Unit): Option[SpanId] = {
     def parseHeaderMap(header: String): Map[String, String] = MoneyStateDelimiter.split(header)
-        .map { KeyValueDelimiter.split }
-        .filter { _.length == 2 }
-        .map { case Array(key, value) => key -> value }
-        .toMap
+      .map { KeyValueDelimiter.split }
+      .filter { _.length == 2 }
+      .map { case Array(key, value) => key -> value }
+      .toMap
 
     def parseStateHeader(stateHeader: String): (Byte, TraceState) = {
 

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/MoneyTraceFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/MoneyTraceFormatter.scala
@@ -17,41 +17,82 @@
 package com.comcast.money.core.formatters
 
 import com.comcast.money.api.SpanId
-import io.opentelemetry.trace.{ TraceFlags, TraceState }
+import com.comcast.money.core.formatters.MoneyTraceFormatter.{KeyValueDelimiter, MoneyStateDelimiter, MoneyStateHeader, ParentIdKey, SampledKey, SpanIdKey, TraceIdKey}
+import io.opentelemetry.trace.{TraceFlags, TraceState}
 
-import scala.util.{ Failure, Success, Try }
+import scala.collection.JavaConverters._
+import scala.util.{Success, Try}
 
 object MoneyTraceFormatter {
   private[core] val MoneyTraceHeader = "X-MoneyTrace"
+  private[core] val MoneyStateHeader = "X-MoneyState"
+
   private[core] val MoneyHeaderFormat = "trace-id=%s;parent-id=%s;span-id=%s"
+  private[core] val MoneyStateDelimiter = """[ \t]*;[ \t]*""".r
+  private[core] val KeyValueDelimiter = """[ \t]*=[ \t]*""".r
+
+  private[core] val TraceIdKey = "trace-id"
+  private[core] val ParentIdKey = "parent-id"
+  private[core] val SpanIdKey = "span-id"
+  private[core] val SampledKey = "sampled"
 }
 
 final class MoneyTraceFormatter extends Formatter {
   import com.comcast.money.core.formatters.MoneyTraceFormatter.{ MoneyHeaderFormat, MoneyTraceHeader }
 
-  override def toHttpHeaders(spanId: SpanId, addHeader: (String, String) => Unit): Unit =
+  override def toHttpHeaders(spanId: SpanId, addHeader: (String, String) => Unit): Unit = {
     addHeader(MoneyTraceHeader, MoneyHeaderFormat.format(spanId.traceId, spanId.parentId, spanId.selfId))
 
-  override def fromHttpHeaders(getHeader: String => String, log: String => Unit): Option[SpanId] = {
-    def spanIdFromMoneyHeader(httpHeader: String): Try[SpanId] = Try {
-      val parts = httpHeader.split(';')
-      val traceId = parts(0).split('=')(1)
-      val parentId = parts(1).split('=')(1)
-      val selfId = parts(2).split('=')(1)
+    val sampled = ("sampled", if (spanId.isSampled) "1" else "0")
+    val stateEntries = sampled +: spanId.traceState.getEntries.asScala.toStream
+      .map { entry => entry.getKey -> entry.getValue }
 
-      SpanId.createRemote(traceId, parentId.toLong, selfId.toLong, TraceFlags.getSampled, TraceState.getDefault)
+    addHeader(MoneyStateHeader, stateEntries.map { case (k, v) => s"$k=$v"}.mkString(";"))
+  }
+
+  override def fromHttpHeaders(getHeader: String => String, log: String => Unit): Option[SpanId] = {
+    def parseHeaderMap(header: String): Map[String, String] = MoneyStateDelimiter.split(header)
+        .map { KeyValueDelimiter.split }
+        .filter { _.length == 2 }
+        .map { case Array(key, value) => key -> value }
+        .toMap
+
+    def parseStateHeader(stateHeader: String): (Byte, TraceState) = {
+
+      var flags: Byte = 0
+      val stateBuilder = TraceState.builder
+      parseHeaderMap(stateHeader).foreach {
+        case (SampledKey, "1") => flags = TraceFlags.getSampled
+        case (SampledKey, _) => flags = TraceFlags.getDefault
+        case (key, value) => stateBuilder.set(key, value)
+      }
+
+      (flags, stateBuilder.build)
+    }
+
+    def parseLong(value: String): Option[Long] = Try { value.toLong } toOption
+
+    def spanIdFromMoneyHeader(httpHeader: String, stateHeader: Option[String]): Try[Option[SpanId]] = Try {
+
+      val map = parseHeaderMap(httpHeader)
+      for {
+        traceId <- map.get(TraceIdKey)
+        parentId <- map.get(ParentIdKey) flatMap { parseLong }
+        selfId <- map.get(SpanIdKey) flatMap { parseLong }
+        (flags, state) = stateHeader.map { parseStateHeader } getOrElse (TraceFlags.getSampled, TraceState.getDefault)
+      } yield SpanId.createRemote(traceId, parentId, selfId, flags, state)
     }
 
     def parseHeader(headerValue: String): Option[SpanId] =
-      spanIdFromMoneyHeader(headerValue) match {
-        case Success(spanId) => Some(spanId)
-        case Failure(_) =>
-          log(s"Unable to parse money trace for request header $headerValue")
+      spanIdFromMoneyHeader(headerValue, Option(getHeader(MoneyStateHeader))) match {
+        case Success(Some(spanId)) => Some(spanId)
+        case _ =>
+          log(s"Unable to parse money trace for request header '$headerValue'")
           None
       }
 
     Option(getHeader(MoneyTraceHeader)).flatMap(parseHeader)
   }
 
-  override def fields: Seq[String] = Seq(MoneyTraceHeader)
+  override def fields: Seq[String] = Seq(MoneyTraceHeader, MoneyStateHeader)
 }

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/MoneyTraceFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/MoneyTraceFormatter.scala
@@ -59,7 +59,7 @@ final class MoneyTraceFormatter extends Formatter {
 
     def parseStateHeader(stateHeader: String): (Byte, TraceState) = {
 
-      var flags: Byte = 0
+      var flags: Byte = TraceFlags.getSampled
       val stateBuilder = TraceState.builder
       parseHeaderMap(stateHeader).foreach {
         case (SampledKey, "1") => flags = TraceFlags.getSampled

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/OtelFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/OtelFormatter.scala
@@ -40,7 +40,7 @@ class OtelFormatter(propagator: TextMapPropagator) extends Formatter {
     } yield spanId
   }
 
-  override def fields: Seq[String] = propagator.fields.asScala
+  override def fields: Seq[String] = propagator.fields.asScala.toSeq
 
   private case class PropagatingSpan(spanId: SpanId) extends Span {
     override def getContext: SpanContext = spanId.toSpanContext

--- a/money-core/src/test/scala/com/comcast/money/core/formatters/MoneyTraceFormatterSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/formatters/MoneyTraceFormatterSpec.scala
@@ -20,9 +20,9 @@ import java.util.UUID
 
 import com.comcast.money.api.SpanId
 import com.comcast.money.core.TraceGenerators
-import com.comcast.money.core.formatters.MoneyTraceFormatter.{MoneyHeaderFormat, MoneyStateHeader, MoneyTraceHeader}
-import io.opentelemetry.trace.{TraceFlags, TraceState}
-import org.mockito.Mockito.{verify, verifyNoMoreInteractions}
+import com.comcast.money.core.formatters.MoneyTraceFormatter.{ MoneyHeaderFormat, MoneyStateHeader, MoneyTraceHeader }
+import io.opentelemetry.trace.{ TraceFlags, TraceState }
+import org.mockito.Mockito.{ verify, verifyNoMoreInteractions }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar

--- a/money-spring/src/test/java/com/comcast/money/spring/MoneyClientHttpInterceptorSpec.java
+++ b/money-spring/src/test/java/com/comcast/money/spring/MoneyClientHttpInterceptorSpec.java
@@ -90,7 +90,7 @@ public class MoneyClientHttpInterceptorSpec {
         underTest.intercept(httpRequest, new byte[0], clientHttpRequestExecution);
 
         verify(httpRequest).getHeaders();
-        Assert.assertEquals(2, httpHeaders.size());
+        Assert.assertEquals(3, httpHeaders.size());
         Assert.assertEquals(expectedMoneyHeaderVal, httpHeaders.get("X-MoneyTrace").get(0));
         Assert.assertEquals(expectedTraceParentHeaderVal, httpHeaders.get("traceparent").get(0));
     }

--- a/money-spring/src/test/java/com/comcast/money/spring/MoneyClientHttpInterceptorSpec.java
+++ b/money-spring/src/test/java/com/comcast/money/spring/MoneyClientHttpInterceptorSpec.java
@@ -85,6 +85,7 @@ public class MoneyClientHttpInterceptorSpec {
         when(httpRequest.getHeaders()).thenReturn(httpHeaders);
 
         String expectedMoneyHeaderVal = String.format("trace-id=%s;parent-id=%s;span-id=%s", traceId, parentSpanId, spanId);
+        String expectedMoneyStateVal = "sampled=1";
         String expectedTraceParentHeaderVal = String.format("00-%s-%016x-01", traceId.replace("-", ""), spanId);
 
         underTest.intercept(httpRequest, new byte[0], clientHttpRequestExecution);
@@ -92,6 +93,7 @@ public class MoneyClientHttpInterceptorSpec {
         verify(httpRequest).getHeaders();
         Assert.assertEquals(3, httpHeaders.size());
         Assert.assertEquals(expectedMoneyHeaderVal, httpHeaders.get("X-MoneyTrace").get(0));
+        Assert.assertEquals(expectedMoneyStateVal, httpHeaders.get("X-MoneyState").get(0));
         Assert.assertEquals(expectedTraceParentHeaderVal, httpHeaders.get("traceparent").get(0));
     }
 }

--- a/money-spring/src/test/scala/com/comcast/money/spring/TracedMethodInterceptorScalaSpec.scala
+++ b/money-spring/src/test/scala/com/comcast/money/spring/TracedMethodInterceptorScalaSpec.scala
@@ -18,8 +18,8 @@ package com.comcast.money.spring
 
 import java.lang.reflect.AccessibleObject
 
-import com.comcast.money.annotations.{Traced, TracedData}
-import com.comcast.money.api.{Note, Span}
+import com.comcast.money.annotations.{ Traced, TracedData }
+import com.comcast.money.api.{ Note, Span }
 import com.sun.istack.internal.NotNull
 import io.opentelemetry.context.Scope
 import org.aopalliance.intercept.MethodInvocation
@@ -33,10 +33,10 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.{Bean, Configuration, EnableAspectJAutoProxy}
+import org.springframework.context.annotation.{ Bean, Configuration, EnableAspectJAutoProxy }
 import org.springframework.stereotype.Component
 import org.springframework.test.context.junit4.SpringRunner
-import org.springframework.test.context.{ContextConfiguration, TestContextManager}
+import org.springframework.test.context.{ ContextConfiguration, TestContextManager }
 
 @RunWith(classOf[SpringRunner])
 @ContextConfiguration(classes = Array(classOf[TestConfig]))


### PR DESCRIPTION
Adds an `X-MoneyState` header for propagating additional span information.  This header will include a series of name/value pairs.  Recognized entries can be interpreted directly and the remainder will be appended to the `TraceState` of the span.

This will enable adding a sampling flag without affecting the entries or format of the `X-MoneyTrace` flag which may break one or more of the alternate implementations of Money.
