### PR TITLE
Adds configurable formatters and ingress/egress-specific formatters

### DIFF
--- a/money-core/src/main/scala/com/comcast/money/core/formatters/ConfigurableFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/ConfigurableFormatter.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core.formatters
 
 import com.typesafe.config.Config

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/ConfigurableFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/ConfigurableFormatter.scala
@@ -1,0 +1,7 @@
+package com.comcast.money.core.formatters
+
+import com.typesafe.config.Config
+
+trait ConfigurableFormatter extends Formatter {
+  def configure(conf: Config): Unit
+}

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/EgressFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/EgressFormatter.scala
@@ -1,0 +1,12 @@
+package com.comcast.money.core.formatters
+import com.comcast.money.api.SpanId
+
+/**
+ * Decorates a formatter so that it writes headers for outgoing requests but does not interpret headers for incoming requests.
+ */
+class EgressFormatter(val formatter: Formatter) extends Formatter {
+  override def toHttpHeaders(spanId: SpanId, addHeader: (String, String) => Unit): Unit =
+    formatter.toHttpHeaders(spanId, addHeader)
+  override def fromHttpHeaders(getHeader: String => String, log: String => Unit): Option[SpanId] = None
+  override def fields: Seq[String] = Nil
+}

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/EgressFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/EgressFormatter.scala
@@ -20,7 +20,7 @@ import com.comcast.money.api.SpanId
 /**
  * Decorates a formatter so that it writes headers for outgoing requests but does not interpret headers for incoming requests.
  */
-class EgressFormatter(val formatter: Formatter) extends Formatter {
+final class EgressFormatter(val formatter: Formatter) extends Formatter {
   override def toHttpHeaders(spanId: SpanId, addHeader: (String, String) => Unit): Unit =
     formatter.toHttpHeaders(spanId, addHeader)
   override def fromHttpHeaders(getHeader: String => String, log: String => Unit): Option[SpanId] = None

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/EgressFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/EgressFormatter.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core.formatters
 import com.comcast.money.api.SpanId
 

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/Formatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/Formatter.scala
@@ -18,6 +18,9 @@ package com.comcast.money.core.formatters
 
 import com.comcast.money.api.SpanId
 
+/**
+ * Formats the span id into HTTP headers so that it can be propagated to other services.
+ */
 trait Formatter {
   def toHttpHeaders(spanId: SpanId, addHeader: (String, String) => Unit): Unit
   def fromHttpHeaders(getHeader: String => String, log: String => Unit = _ => {}): Option[SpanId]

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/IngressFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/IngressFormatter.scala
@@ -1,0 +1,12 @@
+package com.comcast.money.core.formatters
+import com.comcast.money.api.SpanId
+
+/**
+ * Decorates a formatter so that it interprets headers for incoming requests but does not write headers for outgoing requests.
+ */
+class IngressFormatter(val formatter: Formatter) extends Formatter {
+  override def toHttpHeaders(spanId: SpanId, addHeader: (String, String) => Unit): Unit = ()
+  override def fromHttpHeaders(getHeader: String => String, log: String => Unit): Option[SpanId] =
+    formatter.fromHttpHeaders(getHeader, log)
+  override def fields: Seq[String] = formatter.fields
+}

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/IngressFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/IngressFormatter.scala
@@ -20,7 +20,7 @@ import com.comcast.money.api.SpanId
 /**
  * Decorates a formatter so that it interprets headers for incoming requests but does not write headers for outgoing requests.
  */
-class IngressFormatter(val formatter: Formatter) extends Formatter {
+final class IngressFormatter(val formatter: Formatter) extends Formatter {
   override def toHttpHeaders(spanId: SpanId, addHeader: (String, String) => Unit): Unit = ()
   override def fromHttpHeaders(getHeader: String => String, log: String => Unit): Option[SpanId] =
     formatter.fromHttpHeaders(getHeader, log)

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/IngressFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/IngressFormatter.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core.formatters
 import com.comcast.money.api.SpanId
 

--- a/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterChainSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterChainSpec.scala
@@ -45,9 +45,11 @@ class FormatterChainSpec extends AnyWordSpec with MockitoSugar with Matchers {
         """
           | formatters = [
           |   {
+          |     type = custom
           |     class = com.comcast.money.core.formatters.TraceContextFormatter
           |   },
           |   {
+          |     type = custom
           |     class = com.comcast.money.core.formatters.MoneyTraceFormatter
           |   }
           | ]

--- a/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterFactorySpec.scala
@@ -16,17 +16,91 @@
 
 package com.comcast.money.core.formatters
 
+import com.comcast.money.core.DisabledFormatter
 import com.typesafe.config.ConfigFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class FormatterFactorySpec extends AnyWordSpec with Matchers {
   "FormatterFactory" should {
-    "create an instance of a Formatter" in {
-      val config = ConfigFactory.parseString(s"class=${classOf[MoneyTraceFormatter].getCanonicalName}")
+    "return an instance of money-trace Formatter" in {
+      val config = ConfigFactory.parseString("type = \"money-trace\"")
 
       val formatter = FormatterFactory.create(config)
       formatter shouldBe a[MoneyTraceFormatter]
+    }
+
+    "return an instance of trace-context Formatter" in {
+      val config = ConfigFactory.parseString("type = \"trace-context\"")
+
+      val formatter = FormatterFactory.create(config)
+      formatter shouldBe a[TraceContextFormatter]
+    }
+
+    "return an instance of an ingress Formatter" in {
+      val config = ConfigFactory.parseString(
+        """
+          |type = "ingress"
+          |formatters = [
+          | { type = "money-trace" },
+          | { type = "trace-context" }
+          |]
+          |""".stripMargin)
+
+      val formatter = FormatterFactory.create(config)
+      formatter shouldBe a[IngressFormatter]
+      val chain = formatter.asInstanceOf[IngressFormatter].formatter
+      chain should matchPattern {
+        case FormatterChain(Seq(_: MoneyTraceFormatter, _: TraceContextFormatter)) =>
+      }
+    }
+
+    "return an instance of an egress Formatter" in {
+      val config = ConfigFactory.parseString(
+        """
+          |type = "egress"
+          |formatters = [
+          | { type = "money-trace" },
+          | { type = "trace-context" }
+          |]
+          |""".stripMargin)
+
+      val formatter = FormatterFactory.create(config)
+      formatter shouldBe a[EgressFormatter]
+      val chain = formatter.asInstanceOf[EgressFormatter].formatter
+      chain should matchPattern {
+        case FormatterChain(Seq(_: MoneyTraceFormatter, _: TraceContextFormatter)) =>
+      }
+    }
+
+    "create an instance of a custom Formatter" in {
+      val config = ConfigFactory.parseString(
+        s"""
+           |type = "custom"
+           |class = "${classOf[NonConfiguredFormatter].getCanonicalName}"
+           |""".stripMargin)
+
+      val formatter = FormatterFactory.create(config)
+      formatter shouldBe a[NonConfiguredFormatter]
+    }
+
+    "create an instance of a custom configurable Formatter" in {
+      val config = ConfigFactory.parseString(
+        s"""
+           |type = "custom"
+           |class = "${classOf[ConfiguredFormatter].getCanonicalName}"
+           |""".stripMargin)
+
+      val formatter = FormatterFactory.create(config)
+      formatter shouldBe a[ConfiguredFormatter]
+      formatter.asInstanceOf[ConfiguredFormatter].calledConfigure shouldBe true
+    }
+
+    "returns a disabled formatter on an unknown type" in {
+      val config = ConfigFactory.parseString("type = \"unknown\"")
+
+      val formatter = FormatterFactory.create(config)
+      formatter shouldBe DisabledFormatter
     }
   }
 }

--- a/money-core/src/test/scala/com/comcast/money/core/formatters/TestData.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/formatters/TestData.scala
@@ -1,0 +1,20 @@
+package com.comcast.money.core.formatters
+
+import com.comcast.money.api.SpanId
+import com.typesafe.config.Config
+
+class ConfiguredFormatter extends ConfigurableFormatter {
+
+  var calledConfigure = false
+
+  def configure(config: Config): Unit = calledConfigure = true
+  override def toHttpHeaders(spanId: SpanId, addHeader: (String, String) => Unit): Unit = ()
+  override def fromHttpHeaders(getHeader: String => String, log: String => Unit): Option[SpanId] = None
+  override def fields: Seq[String] = Nil
+}
+
+class NonConfiguredFormatter extends Formatter {
+  override def toHttpHeaders(spanId: SpanId, addHeader: (String, String) => Unit): Unit = ()
+  override def fromHttpHeaders(getHeader: String => String, log: String => Unit): Option[SpanId] = None
+  override def fields: Seq[String] = Nil
+}

--- a/money-core/src/test/scala/com/comcast/money/core/formatters/TestData.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/formatters/TestData.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.money.core.formatters
 
 import com.comcast.money.api.SpanId

--- a/money-spring/src/test/scala/com/comcast/money/spring/TracedMethodInterceptorScalaSpec.scala
+++ b/money-spring/src/test/scala/com/comcast/money/spring/TracedMethodInterceptorScalaSpec.scala
@@ -18,8 +18,8 @@ package com.comcast.money.spring
 
 import java.lang.reflect.AccessibleObject
 
-import com.comcast.money.annotations.{Traced, TracedData}
-import com.comcast.money.api.{Note, Span}
+import com.comcast.money.annotations.{ Traced, TracedData }
+import com.comcast.money.api.{ Note, Span }
 import com.sun.istack.internal.NotNull
 import io.opentelemetry.context.Scope
 import org.aopalliance.intercept.MethodInvocation
@@ -33,10 +33,10 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.{Bean, Configuration, EnableAspectJAutoProxy}
+import org.springframework.context.annotation.{ Bean, Configuration, EnableAspectJAutoProxy }
 import org.springframework.stereotype.Component
 import org.springframework.test.context.junit4.SpringRunner
-import org.springframework.test.context.{ContextConfiguration, TestContextManager}
+import org.springframework.test.context.{ ContextConfiguration, TestContextManager }
 
 @RunWith(classOf[SpringRunner])
 @ContextConfiguration(classes = Array(classOf[TestConfig]))


### PR DESCRIPTION
Adds support for a Formatter to be configurable.  Also adds "ingress" and "egress" formatter decorators which are a Formatter implementation which only reads or writes HTTP headers for trace propagation respectively.

The following would be a configuration that would cause Money to only read W3C Trace Context headers from downstream requests, but that will write W3C Trace Context headers and Money Trace headers to upstream services.

```
formatting = {
    formatters = [
        {
            type = ingress
            formatters = [
                { type = trace-context }
            ]
        },
        {
            type = egress
            formatters = [
                { type = trace-context },
                { type = money-trace }
            ]
        },
    ]
}
```