### PR TITLE
Refactor CoreSpanFactory to call through CoreSpanBuilder

### DIFF
--- a/money-api/src/main/java/com/comcast/money/api/Span.java
+++ b/money-api/src/main/java/com/comcast/money/api/Span.java
@@ -73,11 +73,6 @@ public interface Span extends io.opentelemetry.trace.Span, Scope {
     void stopTimer(String timerKey);
 
     /**
-     * Updates the kind of the span
-     */
-    void updateKind(io.opentelemetry.trace.Span.Kind kind);
-
-    /**
      * Attaches a {@link Scope} to the span which will be closed when the span is stopped
      */
     Span attachScope(Scope scope);

--- a/money-api/src/main/java/com/comcast/money/api/Span.java
+++ b/money-api/src/main/java/com/comcast/money/api/Span.java
@@ -178,6 +178,11 @@ public interface Span extends io.opentelemetry.trace.Span, Scope {
         Builder setStartTimestamp(long startTimestampNanos);
 
         /**
+         * Creates the new span without starting it.
+         */
+        Span build();
+
+        /**
          * {@inheritDoc}
          */
         @Override

--- a/money-api/src/main/java/com/comcast/money/api/SpanFactory.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanFactory.java
@@ -16,24 +16,13 @@
 
 package com.comcast.money.api;
 
-import java.util.function.Function;
-
 public interface SpanFactory {
+
+    Span.Builder spanBuilder(String spanName);
 
     Span newSpan(String spanName);
 
     Span newSpan(SpanId spanId, String spanName);
-
-    /**
-     * Continues a trace by creating a child span from the given x-moneytrace header
-     * value.
-     *
-     * @param childName - the name of the child span to create
-     * @param getHeader - function for retrieving value of x-moneytrace header
-     * @return a child span with trace id and parent id from trace context header or a new root span if the
-     * traceContextHeader is malformed.
-     */
-    Span newSpanFromHeader(String childName, Function<String, String> getHeader);
 
     Span childSpan(String childName, Span span);
 

--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpan.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpan.scala
@@ -44,11 +44,11 @@ import scala.collection.mutable.ListBuffer
 private[core] case class CoreSpan(
   id: SpanId,
   var name: String,
+  kind: OtelSpan.Kind = OtelSpan.Kind.INTERNAL,
   library: InstrumentationLibrary = Money.InstrumentationLibrary,
   clock: Clock = SystemClock,
   handler: SpanHandler = DisabledSpanHandler) extends Span {
 
-  private var kind: OtelSpan.Kind = OtelSpan.Kind.INTERNAL
   private var startTimeNanos: Long = 0
   private var endTimeNanos: Long = 0
   private var status: StatusCanonicalCode = StatusCanonicalCode.UNSET
@@ -164,7 +164,6 @@ private[core] case class CoreSpan(
   }
 
   override def updateName(spanName: String): Unit = name = spanName
-  override def updateKind(spanKind: OtelSpan.Kind): Unit = kind = spanKind
 
   override def end(): Unit = stop()
   override def end(endSpanOptions: EndSpanOptions): Unit = stop(endSpanOptions.getEndTimestamp, StatusCanonicalCode.UNSET)

--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpanBuilder.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpanBuilder.scala
@@ -99,7 +99,7 @@ private[core] class CoreSpanBuilder(
     }
 
     if (spanKind != OtelSpan.Kind.INTERNAL) {
-      newSpan.updateKind(spanKind)
+      //TODO: remember to set the span kind in CoreSpan
     }
     notes.foreach { newSpan.record }
     newSpan

--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpanBuilder.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpanBuilder.scala
@@ -92,7 +92,7 @@ private[core] class CoreSpanBuilder(
     this
   }
 
-  override def startSpan(): Span = {
+  override def build(): Span = {
     val newSpan = parentSpan match {
       case Some(s) => spanFactory.childSpan(spanName, s, sticky)
       case None => spanFactory.newSpan(spanName)
@@ -102,6 +102,11 @@ private[core] class CoreSpanBuilder(
       newSpan.updateKind(spanKind)
     }
     notes.foreach { newSpan.record }
+    newSpan
+  }
+
+  override def startSpan(): Span = {
+    val newSpan = build()
 
     if (startTimeNanos <= 0) {
       newSpan.start()

--- a/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
@@ -21,7 +21,6 @@ import io.grpc.Context
 import io.opentelemetry.common.{ AttributeKey, Attributes }
 import io.opentelemetry.context.Scope
 import io.opentelemetry.trace.{ DefaultSpan, EndSpanOptions, SpanContext, StatusCanonicalCode, Span => OtelSpan }
-import java.util.function
 
 import com.comcast.money.core.formatters.Formatter
 
@@ -174,8 +173,6 @@ object DisabledSpan extends Span {
   override def recordException(exception: Throwable, additionalAttributes: Attributes): Unit = ()
 
   override def updateName(name: String): Unit = ()
-
-  override def updateKind(kind: OtelSpan.Kind): Unit = ()
 
   override def `end`(): Unit = ()
 

--- a/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
@@ -120,6 +120,8 @@ object DisabledSpanBuilder extends Span.Builder {
 
   override def setStartTimestamp(startTimestamp: Long): Span.Builder = this
 
+  override def build(): Span = DisabledSpan
+
   override def startSpan(): Span = DisabledSpan
 }
 

--- a/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
@@ -78,9 +78,9 @@ object DisabledFormatter extends Formatter {
 
 object DisabledSpanFactory extends SpanFactory {
 
-  override def newSpan(spanName: String): Span = DisabledSpan
+  override def spanBuilder(spanName: String): Span.Builder = DisabledSpanBuilder
 
-  override def newSpanFromHeader(childName: String, getHeader: function.Function[String, String]): Span = DisabledSpan
+  override def newSpan(spanName: String): Span = DisabledSpan
 
   override def childSpan(childName: String, span: Span): Span = DisabledSpan
 

--- a/money-core/src/main/scala/com/comcast/money/core/Money.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Money.scala
@@ -23,6 +23,7 @@ import com.comcast.money.api.{ InstrumentationLibrary, SpanFactory, SpanHandler 
 import com.comcast.money.core.async.{ AsyncNotificationHandler, AsyncNotifier }
 import com.comcast.money.core.formatters.{ Formatter, FormatterChain }
 import com.comcast.money.core.handlers.HandlerChain
+import com.comcast.money.core.internal.{ SpanContext, SpanLocal }
 import com.comcast.money.core.samplers.{ AlwaysOnSampler, Sampler, SamplerFactory }
 import com.typesafe.config.{ Config, ConfigFactory }
 
@@ -53,7 +54,7 @@ object Money {
       val clock = new NanoClock(SystemClock, TimeUnit.MILLISECONDS.toNanos(50L))
       val formatter = configureFormatter(conf)
       val sampler = configureSampler(conf)
-      val factory: SpanFactory = CoreSpanFactory(clock, handler, formatter, sampler, Money.InstrumentationLibrary)
+      val factory: SpanFactory = CoreSpanFactory(SpanLocal, clock, handler, formatter, sampler, Money.InstrumentationLibrary)
       val tracer = new Tracer {
         override val spanFactory: SpanFactory = factory
       }

--- a/money-core/src/main/scala/com/comcast/money/core/Tracer.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Tracer.scala
@@ -41,7 +41,7 @@ trait Tracer extends MoneyTracer with Closeable {
 
   override def withSpan(span: Span): Scope = spanContext.push(span)
 
-  override def spanBuilder(spanName: String): Span.Builder = new CoreSpanBuilder(spanContext.current, spanName, spanFactory)
+  override def spanBuilder(spanName: String): Span.Builder = spanFactory.spanBuilder(spanName)
 
   /**
    * Creates a new span if one is not present; or creates a child span for the existing Span if one is present

--- a/money-core/src/main/scala/com/comcast/money/core/UnrecordedSpan.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/UnrecordedSpan.scala
@@ -53,7 +53,6 @@ private[core] final case class UnrecordedSpan(
   override def record(note: Note[_]): Unit = ()
   override def startTimer(timerKey: String): Scope = () => ()
   override def stopTimer(timerKey: String): Unit = ()
-  override def updateKind(kind: OtelSpan.Kind): Unit = ()
   override def setAttribute(key: String, value: String): Unit = ()
   override def setAttribute(key: String, value: Long): Unit = ()
   override def setAttribute(key: String, value: Double): Unit = ()

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanBuilderSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanBuilderSpec.scala
@@ -16,7 +16,7 @@
 
 package com.comcast.money.core
 
-import com.comcast.money.api.{ InstrumentationLibrary, Note, Span, SpanFactory, SpanHandler, SpanId }
+import com.comcast.money.api.{ InstrumentationLibrary, Note, Span, SpanFactory, SpanHandler, SpanId, SpanInfo }
 import com.comcast.money.core.samplers.{ Sampler, SamplerResult }
 import io.grpc.Context
 import io.opentelemetry.common.AttributeKey
@@ -27,6 +27,7 @@ import org.mockito.Mockito.{ never, times, verify, when }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
+import scala.collection.JavaConverters._
 
 class CoreSpanBuilderSpec extends AnyWordSpec with Matchers with MockitoSugar {
   val clock = SystemClock
@@ -52,70 +53,386 @@ class CoreSpanBuilderSpec extends AnyWordSpec with Matchers with MockitoSugar {
       verify(span).start()
     }
 
-    /*
-    "create a span with a parent span" in {
-      val spanFactory = mock[SpanFactory]
-      val parentSpan = mock[Span]
-      val span = mock[Span]
-      when(spanFactory.childSpan("test", parentSpan, true)).thenReturn(span)
+    "create a span with a specific id" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
 
-      val underTest = new CoreSpanBuilder(Some(parentSpan), "test", spanFactory)
+      val spanId = SpanId.createNew()
+      val span = mock[Span]
+      when(sampler.shouldSample(argEq(spanId), argEq(None), argEq("test"))).thenReturn(SamplerResult.RecordAndSample)
+
+      val underTest = new CoreSpanBuilder(Some(spanId), None, "test", clock, handler, sampler, library) {
+        override private[core] def createSpan(id: SpanId, name: String, kind: OtelSpan.Kind) = {
+          id shouldBe spanId
+          name shouldBe "test"
+          span
+        }
+      }
 
       val result = underTest.startSpan()
       result shouldBe span
 
-      verify(spanFactory).childSpan("test", parentSpan, true)
       verify(span).start()
     }
 
-    "create a span with an explicit parent span" in {
-      val spanFactory = mock[SpanFactory]
+    "create a child span" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+
+      val parentSpanId = SpanId.createNew()
+      val parentSpanInfo = mock[SpanInfo]
       val parentSpan = mock[Span]
       val span = mock[Span]
-      when(spanFactory.childSpan("test", parentSpan, true)).thenReturn(span)
+      when(parentSpan.info).thenReturn(parentSpanInfo)
+      when(parentSpanInfo.id).thenReturn(parentSpanId)
+      when(sampler.shouldSample(any(), argEq(Some(parentSpanId)), argEq("test"))).thenReturn(SamplerResult.RecordAndSample)
 
-      val underTest = new CoreSpanBuilder(None, "test", spanFactory)
+      val underTest = new CoreSpanBuilder(None, Some(parentSpan), "test", clock, handler, sampler, library) {
+        override private[core] def createSpan(id: SpanId, name: String, kind: OtelSpan.Kind) = {
+          id.traceId shouldBe parentSpanId.traceId
+          id.parentId shouldBe parentSpanId.selfId
+          name shouldBe "test"
+          span
+        }
+      }
+
+      val result = underTest.startSpan()
+      result shouldBe span
+
+      verify(span).start()
+    }
+
+    "create a child span with an explicit parent span" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+
+      val parentSpanId = SpanId.createNew()
+      val parentSpanInfo = mock[SpanInfo]
+      val parentSpan = mock[Span]
+      val span = mock[Span]
+      when(parentSpan.info).thenReturn(parentSpanInfo)
+      when(parentSpanInfo.id).thenReturn(parentSpanId)
+      when(sampler.shouldSample(any(), argEq(Some(parentSpanId)), argEq("test"))).thenReturn(SamplerResult.RecordAndSample)
+
+      val underTest = new CoreSpanBuilder(None, None, "test", clock, handler, sampler, library) {
+        override private[core] def createSpan(id: SpanId, name: String, kind: OtelSpan.Kind) = {
+          id.traceId shouldBe parentSpanId.traceId
+          id.parentId shouldBe parentSpanId.selfId
+          name shouldBe "test"
+          span
+        }
+      }
+
+      val result = underTest
         .setParent(parentSpan)
-
-      val result = underTest.startSpan()
+        .startSpan()
       result shouldBe span
 
-      verify(spanFactory).childSpan("test", parentSpan, true)
       verify(span).start()
     }
 
-    "create a span with an explicit parent span wrapped in Option" in {
-      val spanFactory = mock[SpanFactory]
+    "create a child span with an explicit parent span wrapped in an Option" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+
+      val parentSpanId = SpanId.createNew()
+      val parentSpanInfo = mock[SpanInfo]
       val parentSpan = mock[Span]
       val span = mock[Span]
-      when(spanFactory.childSpan("test", parentSpan, true)).thenReturn(span)
+      when(parentSpan.info).thenReturn(parentSpanInfo)
+      when(parentSpanInfo.id).thenReturn(parentSpanId)
+      when(sampler.shouldSample(any(), argEq(Some(parentSpanId)), argEq("test"))).thenReturn(SamplerResult.RecordAndSample)
 
-      val underTest = new CoreSpanBuilder(None, "test", spanFactory)
+      val underTest = new CoreSpanBuilder(None, None, "test", clock, handler, sampler, library) {
+        override private[core] def createSpan(id: SpanId, name: String, kind: OtelSpan.Kind) = {
+          id.traceId shouldBe parentSpanId.traceId
+          id.parentId shouldBe parentSpanId.selfId
+          name shouldBe "test"
+          span
+        }
+      }
+
+      val result = underTest
         .setParent(Some(parentSpan))
-
-      val result = underTest.startSpan()
+        .startSpan()
       result shouldBe span
 
-      verify(spanFactory).childSpan("test", parentSpan, true)
       verify(span).start()
     }
 
-    "create a span with an parent span from context" in {
-      val spanFactory = mock[SpanFactory]
+    "create a child span with an explicit parent span wrapped in an Context" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+
+      val parentSpanId = SpanId.createNew()
+      val parentSpanInfo = mock[SpanInfo]
       val parentSpan = mock[Span]
-      val updatedContext = TracingContextUtils.withSpan(parentSpan, Context.current())
       val span = mock[Span]
-      when(spanFactory.childSpan("test", parentSpan, true)).thenReturn(span)
+      when(parentSpan.info).thenReturn(parentSpanInfo)
+      when(parentSpanInfo.id).thenReturn(parentSpanId)
+      when(sampler.shouldSample(any(), argEq(Some(parentSpanId)), argEq("test"))).thenReturn(SamplerResult.RecordAndSample)
 
-      val underTest = new CoreSpanBuilder(None, "test", spanFactory)
-        .setParent(updatedContext)
+      val underTest = new CoreSpanBuilder(None, None, "test", clock, handler, sampler, library) {
+        override private[core] def createSpan(id: SpanId, name: String, kind: OtelSpan.Kind) = {
+          id.traceId shouldBe parentSpanId.traceId
+          id.parentId shouldBe parentSpanId.selfId
+          name shouldBe "test"
+          span
+        }
+      }
+
+      val context = TracingContextUtils.withSpan(parentSpan, Context.ROOT)
+
+      val result = underTest
+        .setParent(context)
+        .startSpan()
+      result shouldBe span
+
+      verify(span).start()
+    }
+
+    "create a span explicitly without a parent span" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+      val span = mock[Span]
+      val parentSpan = mock[Span]
+      when(sampler.shouldSample(any(), argEq(None), argEq("test"))).thenReturn(SamplerResult.RecordAndSample)
+
+      val underTest = new CoreSpanBuilder(None, Some(parentSpan), "test", clock, handler, sampler, library) {
+        override private[core] def createSpan(id: SpanId, name: String, kind: OtelSpan.Kind) = {
+          name shouldBe "test"
+          span
+        }
+      }
+
+      val result = underTest
+        .setNoParent()
+        .startSpan()
+      result shouldBe span
+
+      verify(span).start()
+    }
+
+    "create a span with notes" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+      val span = mock[Span]
+      when(sampler.shouldSample(any(), argEq(None), argEq("test"))).thenReturn(SamplerResult.RecordAndSample)
+
+      val underTest = new CoreSpanBuilder(None, None, "test", clock, handler, sampler, library) {
+        override private[core] def createSpan(id: SpanId, name: String, kind: OtelSpan.Kind) = span
+      }
+
+      val result = underTest
+        .setAttribute("stringKey", "string")
+        .setAttribute("longKey", 123L)
+        .setAttribute("doubleKey", 2.2)
+        .setAttribute("booleanKey", true)
+        .setAttribute(AttributeKey.stringKey("attributeKey"), "string")
+        .record(Note.of("note", "string"))
+        .startSpan()
+
+      result shouldBe span
+      val captor: ArgumentCaptor[Note[_]] = ArgumentCaptor.forClass(classOf[Note[_]])
+      verify(span, times(6)).record(captor.capture())
+      val notes = captor.getAllValues
+      notes.get(0).name shouldBe "note"
+      notes.get(0).value shouldBe "string"
+      notes.get(1).name shouldBe "attributeKey"
+      notes.get(1).value shouldBe "string"
+      notes.get(2).name shouldBe "booleanKey"
+      notes.get(2).value shouldBe true
+      notes.get(3).name shouldBe "doubleKey"
+      notes.get(3).value shouldBe 2.2
+      notes.get(4).name shouldBe "longKey"
+      notes.get(4).value shouldBe 123L
+      notes.get(5).name shouldBe "stringKey"
+      notes.get(5).value shouldBe "string"
+      verify(span).start()
+    }
+
+    "create a child span propagating parent span notes" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+
+      val parentSpanId = SpanId.createNew()
+      val parentSpanInfo = mock[SpanInfo]
+      val parentSpan = mock[Span]
+      val span = mock[Span]
+      when(parentSpan.info).thenReturn(parentSpanInfo)
+      when(parentSpanInfo.id).thenReturn(parentSpanId)
+      val notes: Map[String, Note[_]] = Map(
+        "test" -> Note.of("some", "note", true),
+        "other" -> Note.of("other", "note", false))
+      when(parentSpanInfo.notes).thenReturn(notes.asJava)
+      when(sampler.shouldSample(any(), argEq(Some(parentSpanId)), argEq("test"))).thenReturn(SamplerResult.RecordAndSample)
+
+      val underTest = new CoreSpanBuilder(None, Some(parentSpan), "test", clock, handler, sampler, library) {
+        override private[core] def createSpan(id: SpanId, name: String, kind: OtelSpan.Kind) = span
+      }
+
+      val result = underTest
+        .setSticky(true)
+        .startSpan()
+      result shouldBe span
+
+      verify(span).start()
+      val captor: ArgumentCaptor[Note[_]] = ArgumentCaptor.forClass(classOf[Note[_]])
+      verify(span, times(1)).record(captor.capture())
+      val note = captor.getValue
+      note.name shouldBe "some"
+      note.value shouldBe "note"
+    }
+
+    "create a span without propagating parent span notes" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+
+      val parentSpanId = SpanId.createNew()
+      val parentSpanInfo = mock[SpanInfo]
+      val parentSpan = mock[Span]
+      val span = mock[Span]
+      when(parentSpan.info).thenReturn(parentSpanInfo)
+      when(parentSpanInfo.id).thenReturn(parentSpanId)
+      val notes: Map[String, Note[_]] = Map(
+        "test" -> Note.of("some", "note", true),
+        "other" -> Note.of("other", "note", false))
+      when(parentSpanInfo.notes).thenReturn(notes.asJava)
+      when(sampler.shouldSample(any(), argEq(Some(parentSpanId)), argEq("test"))).thenReturn(SamplerResult.RecordAndSample)
+
+      val underTest = new CoreSpanBuilder(None, Some(parentSpan), "test", clock, handler, sampler, library) {
+        override private[core] def createSpan(id: SpanId, name: String, kind: OtelSpan.Kind) = span
+      }
+
+      val result = underTest
+        .setSticky(false)
+        .startSpan()
+      result shouldBe span
+
+      verify(span).start()
+      verify(span, never).record(any())
+    }
+
+    "create a span with a specific kind" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+      val span = mock[Span]
+      when(sampler.shouldSample(any(), argEq(None), argEq("test"))).thenReturn(SamplerResult.RecordAndSample)
+
+      val underTest = new CoreSpanBuilder(None, None, "test", clock, handler, sampler, library)
+
+      val result = underTest
+        .setSpanKind(OtelSpan.Kind.SERVER)
+        .startSpan()
+
+      result.info.kind shouldBe OtelSpan.Kind.SERVER
+    }
+
+    "create an unrecorded span" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+      when(sampler.shouldSample(any(), argEq(None), argEq("test"))).thenReturn(SamplerResult.Drop)
+
+      val underTest = new CoreSpanBuilder(None, None, "test", clock, handler, sampler, library)
+
+      val result = underTest
+        .setSpanKind(OtelSpan.Kind.SERVER)
+        .startSpan()
+
+      result shouldBe a[UnrecordedSpan]
+    }
+
+    "create a sampled span" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+      val span = mock[Span]
+      when(sampler.shouldSample(any(), argEq(None), argEq("test"))).thenReturn(SamplerResult.RecordAndSample)
+
+      val underTest = new CoreSpanBuilder(None, None, "test", clock, handler, sampler, library)
+
+      val result = underTest.startSpan()
+
+      result.info.id.isSampled shouldBe true
+    }
+
+    "create a recorded span" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+      val span = mock[Span]
+      when(sampler.shouldSample(any(), argEq(None), argEq("test"))).thenReturn(SamplerResult.Record)
+
+      val underTest = new CoreSpanBuilder(None, None, "test", clock, handler, sampler, library)
+
+      val result = underTest.startSpan()
+
+      result.info.id.isSampled shouldBe false
+    }
+
+    "create a span with sampler notes" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+
+      val span = mock[Span]
+      when(sampler.shouldSample(any(), argEq(None), argEq("test")))
+        .thenReturn(SamplerResult.RecordAndSample.withNote(Note.of("sampler", "note")))
+
+      val underTest = new CoreSpanBuilder(None, None, "test", clock, handler, sampler, library) {
+        override private[core] def createSpan(id: SpanId, name: String, kind: OtelSpan.Kind) = span
+      }
 
       val result = underTest.startSpan()
       result shouldBe span
 
-      verify(spanFactory).childSpan("test", parentSpan, true)
       verify(span).start()
+      val captor: ArgumentCaptor[Note[_]] = ArgumentCaptor.forClass(classOf[Note[_]])
+      verify(span, times(1)).record(captor.capture())
+      val note = captor.getValue
+      note.name shouldBe "sampler"
+      note.value shouldBe "note"
     }
+
+    "create a span with an explicit start timestamp" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+      val span = mock[Span]
+      when(sampler.shouldSample(any(), argEq(None), argEq("test"))).thenReturn(SamplerResult.RecordAndSample)
+
+      val underTest = new CoreSpanBuilder(None, None, "test", clock, handler, sampler, library) {
+        override private[core] def createSpan(id: SpanId, name: String, kind: OtelSpan.Kind) = {
+          name shouldBe "test"
+          span
+        }
+      }
+
+      val result = underTest
+        .setStartTimestamp(1000000002)
+        .startSpan()
+      result shouldBe span
+
+      verify(span).start(1, 2)
+    }
+
+    "builds a span without starting it" in {
+      val handler = mock[SpanHandler]
+      val sampler = mock[Sampler]
+      val span = mock[Span]
+      when(sampler.shouldSample(any(), argEq(None), argEq("test"))).thenReturn(SamplerResult.RecordAndSample)
+
+      val underTest = new CoreSpanBuilder(None, None, "test", clock, handler, sampler, library) {
+        override private[core] def createSpan(id: SpanId, name: String, kind: OtelSpan.Kind) = {
+          name shouldBe "test"
+          span
+        }
+      }
+
+      val result = underTest.build()
+      result shouldBe span
+
+      verify(span, never).start()
+      verify(span, never).start(anyLong, anyInt)
+    }
+
+    /*
 
     "create a span with a parent span without propagating notes" in {
       val spanFactory = mock[SpanFactory]

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanBuilderSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanBuilderSpec.scala
@@ -184,9 +184,10 @@ class CoreSpanBuilderSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
       val result = underTest.startSpan()
       result shouldBe span
+      //TODO: fix test after wiring up Kind in CoreSpan
+      // result.info.kind shouldBe OtelSpan.Kind.SERVER
 
       verify(spanFactory).newSpan("test")
-      verify(span).updateKind(OtelSpan.Kind.SERVER)
       verify(span).start()
     }
 

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanBuilderSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanBuilderSpec.scala
@@ -19,9 +19,10 @@ package com.comcast.money.core
 import com.comcast.money.api.{ Note, Span, SpanFactory }
 import io.grpc.Context
 import io.opentelemetry.common.AttributeKey
-import io.opentelemetry.trace.{ Span => OtelSpan, TracingContextUtils }
+import io.opentelemetry.trace.{ TracingContextUtils, Span => OtelSpan }
 import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.{ times, verify, when }
+import org.mockito.ArgumentMatchers.{ anyInt, anyLong }
+import org.mockito.Mockito.{ never, times, verify, when }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -202,6 +203,21 @@ class CoreSpanBuilderSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
       verify(spanFactory).newSpan("test")
       verify(span).start(1, 2)
+    }
+
+    "builds a span without starting" in {
+      val spanFactory = mock[SpanFactory]
+      val span = mock[Span]
+      when(spanFactory.newSpan("test")).thenReturn(span)
+
+      val underTest = new CoreSpanBuilder(None, "test", spanFactory)
+
+      val result = underTest.build()
+      result shouldBe span
+
+      verify(spanFactory).newSpan("test")
+      verify(span, never).start()
+      verify(span, never).start(anyLong(), anyInt())
     }
   }
 }

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
@@ -19,6 +19,7 @@ package com.comcast.money.core
 import com.comcast.money.api.{ InstrumentationLibrary, Note, SpanHandler, SpanId }
 import com.comcast.money.core.formatters.MoneyTraceFormatter
 import com.comcast.money.core.handlers.TestData
+import com.comcast.money.core.internal.SpanContext
 import com.comcast.money.core.samplers.{ AlwaysOffSampler, AlwaysOnSampler, RecordResult, Sampler, SamplerResult }
 import io.opentelemetry.trace.TraceFlags
 import org.scalatest.matchers.should.Matchers
@@ -27,11 +28,12 @@ import org.scalatestplus.mockito.MockitoSugar
 
 class CoreSpanFactorySpec extends AnyWordSpec with Matchers with MockitoSugar with TestData {
 
+  val context = mock[SpanContext]
   val handler = mock[SpanHandler]
   val formatter = new MoneyTraceFormatter()
   val sampler = AlwaysOnSampler
   val instrumentationLibrary = new InstrumentationLibrary("test", "0.0.1")
-  val underTest = CoreSpanFactory(clock, handler, formatter, sampler, instrumentationLibrary)
+  val underTest = CoreSpanFactory(context, clock, handler, formatter, sampler, instrumentationLibrary)
 
   "CoreSpanFactory" should {
     "create a new span" in {

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanFactorySpec.scala
@@ -74,32 +74,6 @@ class CoreSpanFactorySpec extends AnyWordSpec with Matchers with MockitoSugar wi
       childInfo.notes shouldNot contain value nonStickyNote
     }
 
-    "create a child span from a well-formed x-moneytrace header" in {
-      val parentSpan = underTest.newSpan("parent")
-
-      formatter.toHttpHeaders(parentSpan.info.id, (headerName, headerValue) => headerName match {
-        case MoneyTraceFormatter.MoneyTraceHeader => {
-          val childSpan = underTest.newSpanFromHeader("child", _ => headerValue)
-
-          childSpan.info.id.traceId shouldBe parentSpan.info.id.traceId
-          childSpan.info.id.parentId shouldBe parentSpan.info.id.selfId
-          childSpan.info.id.selfId == parentSpan.info.id.selfId shouldBe false
-        }
-        case _ =>
-      })
-    }
-
-    "create a root span from a malformed x-moneytrace header" in {
-      val parentSpan = underTest.newSpan("parent")
-      val traceContextHeader = "mangled header value"
-      val childSpan = underTest.newSpanFromHeader("child", headerName => traceContextHeader)
-
-      childSpan.info.id.traceId == parentSpan.info.id.traceId shouldBe false
-      childSpan.info.id.parentId == parentSpan.info.id.selfId shouldBe false
-      childSpan.info.id.selfId == parentSpan.info.id.selfId shouldBe false
-      childSpan.info.id.selfId shouldBe childSpan.info.id.parentId
-    }
-
     "creates an unrecorded span when the sampler drops the span" in {
       val underTest = this.underTest.copy(sampler = AlwaysOffSampler)
       val span = underTest.newSpan("test")

--- a/money-core/src/test/scala/com/comcast/money/core/MoneyTraceProviderSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/MoneyTraceProviderSpec.scala
@@ -17,6 +17,7 @@
 package com.comcast.money.core
 
 import com.comcast.money.api.{ InstrumentationLibrary, SpanFactory }
+import com.comcast.money.core.internal.SpanLocal
 import com.comcast.money.core.samplers.AlwaysOnSampler
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -25,7 +26,7 @@ class MoneyTraceProviderSpec extends AnyWordSpec with Matchers {
 
   "MoneyTraceProvider" should {
     "wrap an existing Tracer with a decorated SpanFactory" in {
-      val factory = new CoreSpanFactory(SystemClock, DisabledSpanHandler, DisabledFormatter, AlwaysOnSampler, Money.InstrumentationLibrary)
+      val factory = new CoreSpanFactory(SpanLocal, SystemClock, DisabledSpanHandler, DisabledFormatter, AlwaysOnSampler, Money.InstrumentationLibrary)
       val tracer = new Tracer {
         override val spanFactory: SpanFactory = factory
       }
@@ -43,7 +44,7 @@ class MoneyTraceProviderSpec extends AnyWordSpec with Matchers {
     }
 
     "returns the same Tracer for equivalent InstrumentationLibraries" in {
-      val factory = new CoreSpanFactory(SystemClock, DisabledSpanHandler, DisabledFormatter, AlwaysOnSampler, Money.InstrumentationLibrary)
+      val factory = new CoreSpanFactory(SpanLocal, SystemClock, DisabledSpanHandler, DisabledFormatter, AlwaysOnSampler, Money.InstrumentationLibrary)
       val tracer = new Tracer {
         override val spanFactory: SpanFactory = factory
       }
@@ -56,7 +57,7 @@ class MoneyTraceProviderSpec extends AnyWordSpec with Matchers {
     }
 
     "return different Tracers for different InstrumentationLibraries" in {
-      val factory = new CoreSpanFactory(SystemClock, DisabledSpanHandler, DisabledFormatter, AlwaysOnSampler, Money.InstrumentationLibrary)
+      val factory = new CoreSpanFactory(SpanLocal, SystemClock, DisabledSpanHandler, DisabledFormatter, AlwaysOnSampler, Money.InstrumentationLibrary)
       val tracer = new Tracer {
         override val spanFactory: SpanFactory = factory
       }

--- a/money-core/src/test/scala/com/comcast/money/core/TracerSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/TracerSpec.scala
@@ -32,8 +32,9 @@ class TracerSpec extends AnyWordSpec
   with Matchers with MockitoSugar with TestData with BeforeAndAfterEach with OneInstancePerTest {
 
   val mockSpanFactory = mock[SpanFactory]
+  val mockSpanBuilder = mock[Span.Builder]
   val mockSpan = mock[Span]
-  val noteCaptor = ArgumentCaptor.forClass(classOf[Note[_]])
+  val noteCaptor: ArgumentCaptor[Note[_]] = ArgumentCaptor.forClass(classOf[Note[_]])
   val underTest = new Tracer {
     val spanFactory = mockSpanFactory
   }
@@ -56,7 +57,7 @@ class TracerSpec extends AnyWordSpec
       SpanLocal.current shouldBe Some(mockSpan)
     }
 
-    "start a child span if a span already exsits" in {
+    "start a child span if a span already exists" in {
       SpanLocal.push(testSpan)
 
       underTest.startSpan("bar")
@@ -228,6 +229,14 @@ class TracerSpec extends AnyWordSpec
 
       verify(mockSpan).setStatus(StatusCanonicalCode.OK)
       verify(mockSpan).close()
+    }
+
+    "obtain a span builder from the span factory" in {
+      when(mockSpanFactory.spanBuilder("test")).thenReturn(mockSpanBuilder)
+
+      underTest.spanBuilder("test") shouldBe mockSpanBuilder
+
+      verify(mockSpanFactory).spanBuilder("test")
     }
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-aspectj" % "0.11.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.2")
 
-addSbtPlugin("com.cavorite" % "sbt-avro-1-8" % "1.1.5")
+addSbtPlugin("com.cavorite" % "sbt-avro-1-8" % "1.1.9")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
 


### PR DESCRIPTION
Refactors the relationship between CoreSpanFactory and CoreSpanBuilder so that CoreSpanFactory uses CoreSpanBuilder to actually create the spans instead of vice versa.  The reason for this is that CoreSpanBuilder offers a number of members to mutate the span before it is created, after which those members should be readonly.  If CoreSpanBuilder uses a SpanFactory to create the Span instances that requires that the Span members be mutable so that the CoreSpanBuilder can update them on the created Span.

This is a prelude to implementing a few other features of OTel such as adding Links to a Span through the Span.Builder.