### PR TITLE
Update to OpenTelemetry 0.12.0

### DIFF
--- a/money-api/src/main/java/com/comcast/money/api/SpanId.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanId.java
@@ -19,10 +19,7 @@ package com.comcast.money.api;
 import java.nio.ByteBuffer;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Random;
 import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
@@ -36,11 +33,11 @@ import static com.comcast.money.api.IdGenerator.INVALID_TRACE_ID;
  */
 public final class SpanId {
 
-    private static final SpanId INVALID_SPAN_ID = new SpanId(INVALID_TRACE_ID, INVALID_ID, INVALID_ID, false, TraceFlags.getDefault(), TraceState.getDefault());
+    private static final SpanId INVALID_SPAN_ID = new SpanId(null, INVALID_TRACE_ID, INVALID_ID, false, TraceFlags.getDefault(), TraceState.getDefault());
     private static final byte SAMPLED = TraceFlags.getSampled();
 
+    private final SpanId parentSpanId;
     private final String traceId;
-    private final long parentId;
     private final long selfId;
     private final boolean remote;
     private final byte flags;
@@ -57,10 +54,16 @@ public final class SpanId {
      * Creates a new root span ID
      */
     public static SpanId createNew(boolean sampled) {
+        return createNew(sampled ? TraceFlags.getSampled() : TraceFlags.getDefault());
+    }
+
+    /**
+     * Creates a new root span ID
+     */
+    public static SpanId createNew(byte flags) {
         String traceId = IdGenerator.generateRandomTraceId();
         long selfId = IdGenerator.generateRandomId();
-        byte flags = sampled ? TraceFlags.getSampled() : TraceFlags.getDefault();
-        return new SpanId(traceId, selfId, selfId, false, flags, TraceState.getDefault());
+        return new SpanId(null, traceId, selfId, false, flags, TraceState.getDefault());
     }
 
     /**
@@ -70,7 +73,7 @@ public final class SpanId {
 
         if (parentSpanId != null && parentSpanId.isValid()) {
             long selfId = IdGenerator.generateRandomId();
-            return new SpanId(parentSpanId.traceId, parentSpanId.selfId, selfId, false, parentSpanId.flags, parentSpanId.state);
+            return new SpanId(parentSpanId, selfId, false, parentSpanId.flags, parentSpanId.state);
         } else {
             return createNew();
         }
@@ -85,7 +88,13 @@ public final class SpanId {
         if (!IdGenerator.isValidTraceId(traceId)) {
             throw new IllegalArgumentException("traceId is not in the required format: '" + traceId + "'");
         }
-        return new SpanId(traceId, parentId, selfId, true, flags, state);
+        SpanId parentSpanId;
+        if (parentId != 0 && parentId != selfId) {
+            parentSpanId = new SpanId(null, traceId, parentId, true, flags, state);
+        } else {
+            parentSpanId = null;
+        }
+        return new SpanId(parentSpanId, traceId, selfId, true, flags, state);
     }
 
     /**
@@ -99,7 +108,14 @@ public final class SpanId {
      * @return a new span from the specified parameters, should only be used for testing
      */
     public static SpanId createFrom(UUID traceId, long parentId, long selfId, boolean remote, byte flags, TraceState state) {
-        return new SpanId(traceId.toString(), parentId, selfId, remote, flags, state);
+        String traceIdString = traceId.toString();
+        SpanId parentSpanId;
+        if (parentId != 0 && parentId != selfId) {
+            parentSpanId = new SpanId(null, traceIdString, parentId, remote, flags, state);
+        } else {
+            parentSpanId = null;
+        }
+        return new SpanId(parentSpanId, traceIdString, selfId, remote, flags, state);
     }
 
     /**
@@ -113,7 +129,7 @@ public final class SpanId {
             String traceId = new UUID(traceIdHi, traceIdLo).toString();
             buffer = ByteBuffer.wrap(spanContext.getSpanIdBytes());
             long spanId = buffer.getLong();
-            return new SpanId(traceId, spanId, spanId,
+            return new SpanId(null, traceId, spanId,
                     spanContext.isRemote(),
                     spanContext.getTraceFlags(),
                     spanContext.getTraceState());
@@ -130,13 +146,25 @@ public final class SpanId {
     }
 
     // for testing purposes
-    SpanId(String traceId, long parentId, long selfId) {
-        this(traceId, parentId, selfId, false, (byte) 0, TraceState.getDefault());
+    SpanId(String traceId, long selfId) {
+        this(null, traceId, selfId, false, TraceFlags.getDefault(), TraceState.getDefault());
     }
 
-    SpanId(String traceId, long parentId, long selfId, boolean remote, byte flags, TraceState traceState) {
-        this.traceId = traceId.toLowerCase(Locale.US);
-        this.parentId = parentId != 0 ? parentId : selfId;
+    SpanId(String traceId, long selfId, boolean remote, byte flags, TraceState traceState) {
+        this(null, traceId, selfId, remote, flags, traceState);
+    }
+
+    SpanId(SpanId parentSpanId, long selfId) {
+        this(parentSpanId, selfId, false, TraceFlags.getDefault(), TraceState.getDefault());
+    }
+
+    SpanId(SpanId parentSpanId, long selfId, boolean remote, byte flags, TraceState traceState) {
+        this(parentSpanId, parentSpanId.traceId(), selfId, remote, flags, traceState);
+    }
+
+    private SpanId(SpanId parentSpanId, String traceId, long selfId, boolean remote, byte flags, TraceState traceState) {
+        this.parentSpanId = parentSpanId;
+        this.traceId = traceId.toLowerCase(Locale.ROOT);
         this.selfId = selfId;
         this.remote = remote;
         this.flags = flags;
@@ -165,17 +193,24 @@ public final class SpanId {
     }
 
     /**
+     * @return the parent span ID
+     */
+    public SpanId parentSpanId() {
+        return parentSpanId;
+    }
+
+    /**
      * @return the parent span ID, which will be the same as the span ID in the case of a root span
      */
     public long parentId() {
-        return parentId;
+        return isRoot() ? selfId : parentSpanId.selfId;
     }
 
     /**
      * @return the parent span ID, formatted as 16 lowercase hexadecimal characters
      */
     public String parentIdAsHex() {
-        return IdGenerator.convertIdToHex(parentId);
+        return IdGenerator.convertIdToHex(this.parentId());
     }
 
     /**
@@ -210,7 +245,11 @@ public final class SpanId {
      * @return {@code true} if the span ID is a root span; otherwise, {@code false}
      */
     public boolean isRoot() {
-        return parentId == selfId;
+        return !(parentSpanId != null && parentSpanId.isValid());
+    }
+
+    public boolean isChild() {
+        return parentSpanId != null && parentSpanId.isValid();
     }
 
     /**
@@ -225,6 +264,10 @@ public final class SpanId {
      */
     public boolean isRemote() {
         return remote;
+    }
+
+    public boolean isParentRemote() {
+        return !isRoot() && parentSpanId.isRemote();
     }
 
     /**
@@ -246,7 +289,7 @@ public final class SpanId {
      */
     public SpanId withTraceFlags(byte flags) {
         if (flags != this.flags) {
-            return new SpanId(traceId, parentId, selfId, remote, flags, state);
+            return new SpanId(parentSpanId, traceId, selfId, remote, flags, state);
         }
         return this;
     }
@@ -276,7 +319,7 @@ public final class SpanId {
 
         SpanId spanId = (SpanId) o;
 
-        if (parentId != spanId.parentId) return false;
+        if (parentId() != spanId.parentId()) return false;
         if (selfId != spanId.selfId) return false;
         if (remote != spanId.remote) return false;
         if (flags != spanId.flags) return false;
@@ -287,6 +330,7 @@ public final class SpanId {
     @Override
     public int hashCode() {
         int result = traceId.hashCode();
+        long parentId = this.parentId();
         result = 31 * result + (int) (parentId ^ (parentId >>> 32));
         result = 31 * result + (int) (selfId ^ (selfId >>> 32));
         result = 31 * result + (remote ? 1 : 0);
@@ -299,7 +343,7 @@ public final class SpanId {
     public String toString() {
         return "SpanId{" +
                 "traceId='" + traceId + '\'' +
-                ", parentId=" + parentId +
+                ", parentId=" + parentId() +
                 ", selfId=" + selfId +
                 ", remote=" + remote +
                 ", flags=" + flags +

--- a/money-api/src/main/java/com/comcast/money/api/SpanId.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanId.java
@@ -196,7 +196,7 @@ public final class SpanId {
      * @return the parent span ID
      */
     public SpanId parentSpanId() {
-        return parentSpanId;
+        return parentSpanId != null ? parentSpanId : INVALID_SPAN_ID;
     }
 
     /**
@@ -248,6 +248,9 @@ public final class SpanId {
         return !(parentSpanId != null && parentSpanId.isValid());
     }
 
+    /**
+     * @return {@code true} if the span ID is a child span; otherwise, {@code false}
+     */
     public boolean isChild() {
         return parentSpanId != null && parentSpanId.isValid();
     }

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/TraceContextFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/TraceContextFormatter.scala
@@ -16,11 +16,11 @@
 
 package com.comcast.money.core.formatters
 
-import io.opentelemetry.api.trace.propagation.HttpTraceContext
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 
 object TraceContextFormatter {
   private[core] val TraceParentHeader = "traceparent"
   private[core] val TraceStateHeader = "tracestate"
 }
 
-final class TraceContextFormatter extends OtelFormatter(HttpTraceContext.getInstance)
+final class TraceContextFormatter extends OtelFormatter(W3CTraceContextPropagator.getInstance)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val jodaV = "2.9.9"
   val json4sV = "3.6.10"
   val typesafeConfigV = "1.3.3"
-  val openTelemetryV = "0.11.0"
+  val openTelemetryV = "0.12.0"
 
   val akka =            "com.typesafe.akka"         %% "akka-actor"                  % akkaV
   val akkaStream =      "com.typesafe.akka"         %% "akka-stream"                 % akkaV


### PR DESCRIPTION
Updates to OpenTelemetry API and SDK 0.12.0.

Major changes:

1. `SpanData` now has `getParentSpanContext` method which returns the `SpanContext` for the parent span.
    * This necessitated changes to `SpanId` to be able to track the parent `SpanId` which is the bulk of the changes of this PR.
2. `HttpTraceContext` renamed to `W3CTraceContextPropagator`
