### PR TITLE
Change ConfigurableTypeFactory to not fail silently

### DIFF
--- a/money-core/src/main/scala/com/comcast/money/core/Money.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Money.scala
@@ -69,8 +69,9 @@ object Money {
   }
 
   private def configureContextFilters(conf: Config): Unit = {
-    val filters = if (conf.hasPath("context")) {
-      ContextStorageFilterChain(conf.getConfig("context"))
+    val ContextKey = "context"
+    val filters = if (conf.hasPath(ContextKey)) {
+      ContextStorageFilterChain(conf.getConfig(ContextKey))
     } else {
       Seq(MdcContextStorageFilter(conf))
     }
@@ -85,20 +86,24 @@ object Money {
     }
   }
 
-  private def configureFormatter(conf: Config): Formatter =
-    if (conf.hasPath("formatting")) {
-      FormatterChain(conf.getConfig("formatting"))
+  private def configureFormatter(conf: Config): Formatter = {
+    val FormattingKey = "formatting"
+    if (conf.hasPath(FormattingKey)) {
+      FormatterChain(conf.getConfig(FormattingKey))
     } else {
       FormatterChain.default
     }
+  }
 
-  private def configureSampler(conf: Config): Sampler =
-    if (conf.hasPath("sampling")) {
-      SamplerFactory.create(conf.getConfig("sampling"))
+  private def configureSampler(conf: Config): Sampler = {
+    val SamplingKey = "sampling"
+    if (conf.hasPath(SamplingKey)) {
+      SamplerFactory.create(conf.getConfig(SamplingKey))
         .getOrElse(AlwaysOnSampler)
     } else {
       AlwaysOnSampler
     }
+  }
 
   private def disabled(applicationName: String, hostName: String): Money =
     Money(enabled = false, DisabledSpanHandler, applicationName, hostName, DisabledSpanFactory, DisabledTracer, DisabledFormatter)

--- a/money-core/src/main/scala/com/comcast/money/core/context/ContextStorageFilterChain.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/context/ContextStorageFilterChain.scala
@@ -21,8 +21,5 @@ import scala.collection.JavaConverters._
 
 object ContextStorageFilterChain {
   def apply(conf: Config): Seq[ContextStorageFilter] =
-    conf.getConfigList("filters")
-      .asScala
-      .flatMap(ContextStorageFilterFactory.create)
-      .toSeq
+    ContextStorageFilterFactory.create(conf.getConfigList("filters").asScala).get
 }

--- a/money-core/src/main/scala/com/comcast/money/core/context/ContextStorageFilterFactory.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/context/ContextStorageFilterFactory.scala
@@ -16,14 +16,13 @@
 
 package com.comcast.money.core.context
 
-import com.comcast.money.core.{ ConfigurableTypeFactory, DisabledContextStorageFilter }
+import com.comcast.money.core.ConfigurableTypeFactory
 import com.typesafe.config.Config
 
 import scala.reflect.ClassTag
 
 object ContextStorageFilterFactory extends ConfigurableTypeFactory[ContextStorageFilter] {
   override protected val tag: ClassTag[ContextStorageFilter] = ClassTag(classOf[ContextStorageFilter])
-  override protected val defaultValue: Option[ContextStorageFilter] = Some(DisabledContextStorageFilter)
   override protected val knownTypes: PartialFunction[String, Config => ContextStorageFilter] = {
     case "mdc" => config => MdcContextStorageFilter(config)
   }

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/FormatterChain.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/FormatterChain.scala
@@ -41,10 +41,7 @@ object FormatterChain {
   import FormatterFactory.create
 
   def apply(config: Config): FormatterChain = {
-    val formatters = config.getConfigList("formatters")
-      .asScala
-      .flatMap(create)
-      .toSeq
+    val formatters = create(config.getConfigList("formatters").asScala).get
 
     FormatterChain(formatters)
   }

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/FormatterFactory.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/FormatterFactory.scala
@@ -16,7 +16,7 @@
 
 package com.comcast.money.core.formatters
 
-import com.comcast.money.core.{ ConfigurableTypeFactory, DisabledFormatter }
+import com.comcast.money.core.ConfigurableTypeFactory
 import com.typesafe.config.Config
 
 import scala.reflect.ClassTag
@@ -24,7 +24,6 @@ import scala.reflect.ClassTag
 object FormatterFactory extends ConfigurableTypeFactory[Formatter] {
 
   override protected val tag: ClassTag[Formatter] = ClassTag(classOf[Formatter])
-  override protected val defaultValue: Option[Formatter] = Some(DisabledFormatter)
   override protected val knownTypes: PartialFunction[String, Config => Formatter] = {
     case "trace-context" => _ => TraceContextFormatter
     case "money-trace" => _ => MoneyTraceFormatter

--- a/money-core/src/main/scala/com/comcast/money/core/handlers/HandlerChain.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/handlers/HandlerChain.scala
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 
-case class HandlerChain(handlers: Seq[SpanHandler]) extends SpanHandler {
+final case class HandlerChain(handlers: Seq[SpanHandler]) extends SpanHandler {
 
   private val logger = LoggerFactory.getLogger(classOf[HandlerChain])
 
@@ -42,10 +42,7 @@ object HandlerChain {
   import HandlerFactory.create
 
   def apply(config: Config): SpanHandler = {
-    val handlers = config.getConfigList("handlers")
-      .asScala
-      .flatMap(create)
-      .toSeq
+    val handlers = create(config.getConfigList("handlers").asScala).get
 
     if (config.getBoolean("async")) {
       new AsyncSpanHandler(scala.concurrent.ExecutionContext.global, HandlerChain(handlers))

--- a/money-core/src/main/scala/com/comcast/money/core/handlers/HandlerFactory.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/handlers/HandlerFactory.scala
@@ -17,11 +17,10 @@
 package com.comcast.money.core.handlers
 
 import com.comcast.money.api.SpanHandler
-import com.comcast.money.core.{ ConfigurableTypeFactory, DisabledSpanHandler }
+import com.comcast.money.core.ConfigurableTypeFactory
 
 import scala.reflect.ClassTag
 
 object HandlerFactory extends ConfigurableTypeFactory[SpanHandler] {
   override protected val tag: ClassTag[SpanHandler] = ClassTag(classOf[SpanHandler])
-  override protected val defaultValue: Option[SpanHandler] = Some(DisabledSpanHandler)
 }

--- a/money-core/src/main/scala/com/comcast/money/core/samplers/SamplerFactory.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/samplers/SamplerFactory.scala
@@ -23,7 +23,6 @@ import scala.reflect.ClassTag
 
 object SamplerFactory extends ConfigurableTypeFactory[Sampler] {
   override protected val tag: ClassTag[Sampler] = ClassTag(classOf[Sampler])
-  override protected val defaultValue: Option[Sampler] = Some(AlwaysOnSampler)
 
   override protected val knownTypes: PartialFunction[String, Config => Sampler] = {
     case "always-on" => _ => AlwaysOnSampler

--- a/money-core/src/test/scala/com/comcast/money/core/handlers/HandlerFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/handlers/HandlerFactorySpec.scala
@@ -21,6 +21,8 @@ import org.scalatest.Inside.inside
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.util.Success
+
 class HandlerFactorySpec extends AnyWordSpec with Matchers {
 
   "HandlerFactory" should {
@@ -29,7 +31,7 @@ class HandlerFactorySpec extends AnyWordSpec with Matchers {
 
       val createdHandler = HandlerFactory.create(config)
       inside(createdHandler) {
-        case Some(_: NonConfiguredHandler) =>
+        case Success(_: NonConfiguredHandler) =>
       }
     }
 
@@ -38,7 +40,7 @@ class HandlerFactorySpec extends AnyWordSpec with Matchers {
 
       val createdHandler = HandlerFactory.create(config)
       inside(createdHandler) {
-        case Some(handler: ConfiguredHandler) =>
+        case Success(handler: ConfiguredHandler) =>
           handler.config shouldBe config
       }
     }

--- a/money-core/src/test/scala/com/comcast/money/core/samplers/SamplerFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/samplers/SamplerFactorySpec.scala
@@ -21,20 +21,22 @@ import org.scalatest.Inside.inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.util.Success
+
 class SamplerFactorySpec extends AnyWordSpec with Matchers {
   "SamplerFactory" should {
     "return AlwaysOnSampler" in {
       val config = ConfigFactory.parseString("""type = "always-on"""")
 
       val sampler = SamplerFactory.create(config)
-      sampler shouldBe Some(AlwaysOnSampler)
+      sampler shouldBe Success(AlwaysOnSampler)
     }
 
     "return AlwaysOffSampler" in {
       val config = ConfigFactory.parseString("""type = "always-off"""")
 
       val sampler = SamplerFactory.create(config)
-      sampler shouldBe Some(AlwaysOffSampler)
+      sampler shouldBe Success(AlwaysOffSampler)
     }
 
     "return a RatioBasedSampler" in {
@@ -46,7 +48,7 @@ class SamplerFactorySpec extends AnyWordSpec with Matchers {
 
       val sampler = SamplerFactory.create(config)
       inside(sampler) {
-        case Some(ratioBasedSampler: RatioBasedSampler) =>
+        case Success(ratioBasedSampler: RatioBasedSampler) =>
           ratioBasedSampler.ratio shouldBe 0.5
       }
     }
@@ -64,7 +66,7 @@ class SamplerFactorySpec extends AnyWordSpec with Matchers {
 
       val sampler = SamplerFactory.create(config)
       inside(sampler) {
-        case Some(parentBasedSampler: ParentBasedSampler) =>
+        case Success(parentBasedSampler: ParentBasedSampler) =>
           parentBasedSampler.root shouldBe AlwaysOffSampler
           parentBasedSampler.localSampled shouldBe AlwaysOffSampler
           parentBasedSampler.localNotSampled shouldBe AlwaysOnSampler
@@ -82,7 +84,7 @@ class SamplerFactorySpec extends AnyWordSpec with Matchers {
 
       val sampler = SamplerFactory.create(config)
       inside(sampler) {
-        case Some(_: TestSampler) =>
+        case Success(_: TestSampler) =>
       }
     }
 
@@ -95,7 +97,7 @@ class SamplerFactorySpec extends AnyWordSpec with Matchers {
 
       val sampler = SamplerFactory.create(config)
       inside(sampler) {
-        case Some(s: TestConfigurableSampler) =>
+        case Success(s: TestConfigurableSampler) =>
           s.config shouldBe config
       }
     }


### PR DESCRIPTION
Changes the `ConfigurableTypeFactory[T]` trait so that instead of returning `Option[T]` that it returns `Try[T]` that will reflect the cause of any configuration, reflection or validation errors that occur when trying to determine the implementation of a specific trait by class name.