### PR TITLE
Fix Scala 2.13 error converting List[Config] to Seq[Config]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.12]
+        scala: [2.12.12, 2.13.3]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/money-core/src/main/scala/com/comcast/money/core/ConfigurableTypeFactory.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/ConfigurableTypeFactory.scala
@@ -19,6 +19,7 @@ package com.comcast.money.core
 import com.typesafe.config.{ Config, ConfigException }
 
 import java.lang.reflect.Modifier
+import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success, Try }
 
@@ -60,7 +61,10 @@ trait ConfigurableTypeFactory[T <: AnyRef] {
   protected val tag: ClassTag[T]
   protected val knownTypes: PartialFunction[String, Config => T] = Map.empty
 
-  def create(config: Seq[Config]): Try[Seq[T]] = {
+  def create(config: java.util.List[_ <: Config]): Try[Seq[T]] =
+    create(config.asScala.toSeq)
+
+  def create(config: Seq[_ <: Config]): Try[Seq[T]] = {
     val seq = config.map(create)
     if (seq.isEmpty) Success(Seq.empty)
     else Try(seq.map(_.get))

--- a/money-core/src/main/scala/com/comcast/money/core/context/ContextStorageFilterChain.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/context/ContextStorageFilterChain.scala
@@ -17,9 +17,8 @@
 package com.comcast.money.core.context
 
 import com.typesafe.config.Config
-import scala.collection.JavaConverters._
 
 object ContextStorageFilterChain {
   def apply(conf: Config): Seq[ContextStorageFilter] =
-    ContextStorageFilterFactory.create(conf.getConfigList("filters").asScala).get
+    ContextStorageFilterFactory.create(conf.getConfigList("filters")).get
 }

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/FormatterChain.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/FormatterChain.scala
@@ -17,7 +17,6 @@
 package com.comcast.money.core.formatters
 import com.comcast.money.api.SpanId
 import com.typesafe.config.Config
-import scala.collection.JavaConverters._
 
 final case class FormatterChain(formatters: Seq[Formatter]) extends Formatter {
   override def toHttpHeaders(spanId: SpanId, addHeader: (String, String) => Unit): Unit = formatters.foreach {
@@ -41,7 +40,7 @@ object FormatterChain {
   import FormatterFactory.create
 
   def apply(config: Config): FormatterChain = {
-    val formatters = create(config.getConfigList("formatters").asScala).get
+    val formatters = create(config.getConfigList("formatters")).get
 
     FormatterChain(formatters)
   }

--- a/money-core/src/main/scala/com/comcast/money/core/handlers/HandlerChain.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/handlers/HandlerChain.scala
@@ -20,8 +20,6 @@ import com.comcast.money.api.{ SpanHandler, SpanInfo }
 import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters._
-
 final case class HandlerChain(handlers: Seq[SpanHandler]) extends SpanHandler {
 
   private val logger = LoggerFactory.getLogger(classOf[HandlerChain])
@@ -42,7 +40,7 @@ object HandlerChain {
   import HandlerFactory.create
 
   def apply(config: Config): SpanHandler = {
-    val handlers = create(config.getConfigList("handlers").asScala).get
+    val handlers = create(config.getConfigList("handlers")).get
 
     if (config.getBoolean("async")) {
       new AsyncSpanHandler(scala.concurrent.ExecutionContext.global, HandlerChain(handlers))


### PR DESCRIPTION
In Scala 2.12 `JavaConverters.asScala` with a `java.util.List[T]` returns a type compatible with `Seq[T]`, in Scala 2.13 it does not and requires an extra call to `toSeq`.