### PR TITLE
Update to OpenTelemetry 0.15.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,9 +43,10 @@ lazy val moneyApi =
     .enablePlugins(AutomateHeaderPlugin)
     .settings(projectSettings: _*)
     .settings(
-      libraryDependencies ++= Seq(
+      libraryDependencies ++=
+        Seq(
           openTelemetryApi
-      ) ++ commonTestDependencies
+        ) ++ commonTestDependencies
     )
 
 lazy val moneyCore =
@@ -351,7 +352,7 @@ def basicSettings =  Defaults.itSettings ++ Seq(
   resolvers ++= Seq(
     ("spray repo" at "http://repo.spray.io/").withAllowInsecureProtocol(true),
     "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases/",
-    "JFrog OSS Snapshots" at "https://oss.jfrog.org/artifactory/oss-snapshot-local"
+    "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
   ),
   scalacOptions ++= Seq(
     "-unchecked",

--- a/money-core/src/test/scala/com/comcast/money/core/context/ContextStorageFilterFactorySpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/context/ContextStorageFilterFactorySpec.scala
@@ -23,7 +23,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 
-import scala.util.{Failure, Success}
+import scala.util.{ Failure, Success }
 
 class ContextStorageFilterFactorySpec extends AnyWordSpec with Matchers with MockitoSugar {
 
@@ -75,7 +75,7 @@ class ContextStorageFilterFactorySpec extends AnyWordSpec with Matchers with Moc
       val config = ConfigFactory.parseString("type = \"unknown\"")
 
       val filter = ContextStorageFilterFactory.create(config)
-      inside (filter) {
+      inside(filter) {
         case Failure(exception: FactoryException) =>
           exception.getMessage shouldBe "Could not resolve known ContextStorageFilter type 'unknown'."
       }

--- a/money-otel-jaeger-exporter/src/main/scala/com/comcast/money/otel/handlers/jaeger/JaegerOtelSpanHandler.scala
+++ b/money-otel-jaeger-exporter/src/main/scala/com/comcast/money/otel/handlers/jaeger/JaegerOtelSpanHandler.scala
@@ -21,6 +21,8 @@ import com.typesafe.config.Config
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter
 import io.opentelemetry.sdk.trace.`export`.SpanExporter
 
+import java.time.Duration
+
 /**
  * A Money [[com.comcast.money.api.SpanHandler]] that can export spans to Jaeger
  * through the OpenTelemetry [[JaegerGrpcSpanExporter]].
@@ -34,15 +36,13 @@ import io.opentelemetry.sdk.trace.`export`.SpanExporter
  *       {
  *         class = "com.comcast.money.otel.handlers.jaeger.JaegerOtelSpanHandler"
  *         batch = true
- *         export-only-sampled = true
  *         exporter-timeout-ms = 30000
  *         max-batch-size = 512
  *         max-queue-size = 2048
  *         schedule-delay-ms = 5000
  *         exporter {
- *           service-name = "myApp"
  *           endpoint = "localhost:14250"
- *           deadline-ms = 1000
+ *           timeout-ms = 1000
  *         }
  *       }
  *     ]
@@ -54,16 +54,14 @@ class JaegerOtelSpanHandler(config: Config) extends OtelSpanHandler(config) {
   override protected def createSpanExporter(config: Config): SpanExporter = {
     val builder = JaegerGrpcSpanExporter.builder()
 
-    val serviceNameKey = "service-name"
     val endpointKey = "endpoint"
-    val deadlineMillisKey = "deadline-ms"
+    val deadlineMillisKey = "timeout-ms"
 
-    builder.setServiceName(config.getString(serviceNameKey))
     if (config.hasPath(endpointKey)) {
       builder.setEndpoint(config.getString(endpointKey))
     }
     if (config.hasPath(deadlineMillisKey)) {
-      builder.setDeadlineMs(config.getLong(deadlineMillisKey))
+      builder.setTimeout(Duration.ofMillis(config.getLong(deadlineMillisKey)))
     }
 
     builder.build()

--- a/money-otel-jaeger-exporter/src/test/java/com/comcast/money/otel/handlers/jaeger/JaegerOtelSpanHandlerSpec.java
+++ b/money-otel-jaeger-exporter/src/test/java/com/comcast/money/otel/handlers/jaeger/JaegerOtelSpanHandlerSpec.java
@@ -16,6 +16,7 @@
 
 package com.comcast.money.otel.handlers.jaeger;
 
+import java.time.Duration;
 import java.util.Collection;
 
 import com.typesafe.config.Config;
@@ -67,19 +68,12 @@ public class JaegerOtelSpanHandlerSpec {
 
     @Test
     public void configuresJaegerExporter() {
-        Config config = ConfigFactory.parseString(
-                "batch = false\n" +
-                "export-only-sampled = true\n" +
-                "exporter {\n" +
-                "  service-name = \"service-name\"\n" +
-                "}"
-        );
+        Config config = ConfigFactory.parseString("batch = false");
 
         JaegerOtelSpanHandler underTest = new JaegerOtelSpanHandler(config);
 
         PowerMockito.verifyStatic(JaegerGrpcSpanExporter.class);
         JaegerGrpcSpanExporter.builder();
-        Mockito.verify(spanExporterBuilder).setServiceName("service-name");
         Mockito.verify(spanExporterBuilder).build();
 
         SpanId spanId = SpanId.createNew();
@@ -103,20 +97,17 @@ public class JaegerOtelSpanHandlerSpec {
     public void configuresJaegerExporterWithEndpoint() {
         Config config = ConfigFactory.parseString(
                 "batch = false\n" +
-                        "export-only-sampled = true\n" +
-                        "exporter {\n" +
-                        "  service-name = \"service-name\"\n" +
-                        "  endpoint = \"endpoint\"\n" +
-                        "}"
+                "exporter {\n" +
+                "  endpoint = \"endpoint\"\n" +
+                "}"
         );
 
         JaegerOtelSpanHandler underTest = new JaegerOtelSpanHandler(config);
 
         PowerMockito.verifyStatic(JaegerGrpcSpanExporter.class);
         JaegerGrpcSpanExporter.builder();
-        Mockito.verify(spanExporterBuilder).setServiceName("service-name");
         Mockito.verify(spanExporterBuilder).setEndpoint("endpoint");
-        Mockito.verify(spanExporterBuilder, never()).setDeadlineMs(anyLong());
+        Mockito.verify(spanExporterBuilder, never()).setTimeout(any());
         Mockito.verify(spanExporterBuilder).build();
     }
 
@@ -124,20 +115,17 @@ public class JaegerOtelSpanHandlerSpec {
     public void configuresJaegerExporterWithDeadline() {
         Config config = ConfigFactory.parseString(
                 "batch = false\n" +
-                        "export-only-sampled = true\n" +
-                        "exporter {\n" +
-                        "  service-name = \"service-name\"\n" +
-                        "  deadline-ms = 1000\n" +
-                        "}"
+                "exporter {\n" +
+                "  timeout-ms = 1000\n" +
+                "}"
         );
 
         JaegerOtelSpanHandler underTest = new JaegerOtelSpanHandler(config);
 
         PowerMockito.verifyStatic(JaegerGrpcSpanExporter.class);
         JaegerGrpcSpanExporter.builder();
-        Mockito.verify(spanExporterBuilder).setServiceName("service-name");
         Mockito.verify(spanExporterBuilder, never()).setEndpoint(anyString());
-        Mockito.verify(spanExporterBuilder).setDeadlineMs(1000);
+        Mockito.verify(spanExporterBuilder).setTimeout(Duration.ofMillis(1000));
         Mockito.verify(spanExporterBuilder).build();
     }
 }

--- a/money-otel-logging-exporter/src/main/scala/com/comcast/money/otel/handlers/logging/LoggingSpanHandler.scala
+++ b/money-otel-logging-exporter/src/main/scala/com/comcast/money/otel/handlers/logging/LoggingSpanHandler.scala
@@ -33,7 +33,6 @@ import io.opentelemetry.sdk.trace.`export`.SpanExporter
  *       {
  *         class = "com.comcast.money.otel.handlers.logging.LoggingSpanHandler"
  *         batch = true
- *         export-only-sampled = true
  *         exporter-timeout-ms = 30000
  *         max-batch-size = 512
  *         max-queue-size = 2048

--- a/money-otel-zipkin-exporter/src/main/scala/com/comcast/money/otel/handlers/zipkin/ZipkinOtelSpanHandler.scala
+++ b/money-otel-zipkin-exporter/src/main/scala/com/comcast/money/otel/handlers/zipkin/ZipkinOtelSpanHandler.scala
@@ -35,7 +35,6 @@ import zipkin2.codec.SpanBytesEncoder
  *       {
  *         class = "com.comcast.money.otel.handlers.zipkin.ZipkinOtelSpanHandler"
  *         batch = true
- *         export-only-sampled = true
  *         exporter-timeout-ms = 30000
  *         max-batch-size = 512
  *         max-queue-size = 2048

--- a/money-otlp-exporter/src/main/scala/com/comcast/money/otel/handlers/otlp/OtlpHandler.scala
+++ b/money-otlp-exporter/src/main/scala/com/comcast/money/otel/handlers/otlp/OtlpHandler.scala
@@ -21,6 +21,8 @@ import com.typesafe.config.Config
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
 import io.opentelemetry.sdk.trace.`export`.SpanExporter
 
+import java.time.Duration
+
 /**
  * A Money [[com.comcast.money.api.SpanHandler]] that can export spans to OTLP Collector
  * through the OpenTelemetry OTLP `SpanExporter`.
@@ -34,15 +36,13 @@ import io.opentelemetry.sdk.trace.`export`.SpanExporter
  *       {
  *         class = "com.comcast.money.otel.handlers.otlp.OtlpHandler"
  *         batch = true
- *         export-only-sampled = true
  *         exporter-timeout-ms = 30000
  *         max-batch-size = 512
  *         max-queue-size = 2048
  *         schedule-delay-ms = 5000
  *         exporter {
- *           endpoint = "localhost:14250"
- *           deadline-ms = 1000
- *           use-tls = true
+ *           endpoint = "https://localhost:14250"
+ *           timeout-ms = 1000
  *         }
  *       }
  *     ]
@@ -55,17 +55,13 @@ class OtlpHandler(config: Config) extends OtelSpanHandler(config) {
     val builder = OtlpGrpcSpanExporter.builder()
 
     val endpointKey = "endpoint"
-    val deadlineMillisKey = "deadline-ms"
-    val useTlsKey = "use-tls"
+    val deadlineMillisKey = "timeout-ms"
 
     if (config.hasPath(endpointKey)) {
       builder.setEndpoint(config.getString(endpointKey))
     }
     if (config.hasPath(deadlineMillisKey)) {
-      builder.setDeadlineMs(config.getLong(deadlineMillisKey))
-    }
-    if (config.hasPath(useTlsKey)) {
-      builder.setUseTls(config.getBoolean(useTlsKey))
+      builder.setTimeout(Duration.ofMillis(config.getLong(deadlineMillisKey)))
     }
 
     builder.build()

--- a/money-otlp-exporter/src/test/java/com/comcast/money/otel/handlers/otlp/OtlpHandlerSpec.java
+++ b/money-otlp-exporter/src/test/java/com/comcast/money/otel/handlers/otlp/OtlpHandlerSpec.java
@@ -16,6 +16,7 @@
 
 package com.comcast.money.otel.handlers.otlp;
 
+import java.time.Duration;
 import java.util.Collection;
 
 import com.typesafe.config.Config;
@@ -66,10 +67,7 @@ public class OtlpHandlerSpec {
 
     @Test
     public void configuresOtlpExporter() {
-        Config config = ConfigFactory.parseString(
-                "batch = false\n" +
-                "export-only-sampled = true"
-        );
+        Config config = ConfigFactory.parseString("batch = false");
 
         OtlpHandler underTest = new OtlpHandler(config);
 
@@ -98,7 +96,6 @@ public class OtlpHandlerSpec {
     public void configuresOtlpExporterWithEndpoint() {
         Config config = ConfigFactory.parseString(
                 "batch = false\n" +
-                "export-only-sampled = true\n" +
                 "exporter {\n" +
                 "  endpoint = \"endpoint\"\n" +
                 "}"
@@ -116,9 +113,8 @@ public class OtlpHandlerSpec {
     public void configuresOtlpExporterWithDeadlineMillis() {
         Config config = ConfigFactory.parseString(
                 "batch = false\n" +
-                "export-only-sampled = true\n" +
                 "exporter {\n" +
-                "  deadline-ms = 500\n" +
+                "  timeout-ms = 500\n" +
                 "}"
         );
 
@@ -126,25 +122,7 @@ public class OtlpHandlerSpec {
 
         PowerMockito.verifyStatic(OtlpGrpcSpanExporter.class);
         OtlpGrpcSpanExporter.builder();
-        Mockito.verify(spanExporterBuilder).setDeadlineMs(500L);
-        Mockito.verify(spanExporterBuilder).build();
-    }
-
-    @Test
-    public void configuresOtlpExporterWithUseTLS() {
-        Config config = ConfigFactory.parseString(
-                "batch = false\n" +
-                        "export-only-sampled = true\n" +
-                        "exporter {\n" +
-                        "  use-tls = true\n" +
-                        "}"
-        );
-
-        OtlpHandler underTest = new OtlpHandler(config);
-
-        PowerMockito.verifyStatic(OtlpGrpcSpanExporter.class);
-        OtlpGrpcSpanExporter.builder();
-        Mockito.verify(spanExporterBuilder).setUseTls(true);
+        Mockito.verify(spanExporterBuilder).setTimeout(Duration.ofMillis(500L));
         Mockito.verify(spanExporterBuilder).build();
     }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,8 +9,9 @@ object Dependencies {
   val jodaV = "2.9.9"
   val json4sV = "3.6.10"
   val typesafeConfigV = "1.3.3"
-  val openTelemetryV = "0.14.1"
-  val openTelemetryInstV = "0.14.1"
+  val openTelemetryV = "0.15.0"
+  val openTelemetryInstV = "0.15.0"
+  val openTelemetrySemConvV = "0.15.0-alpha"
 
   val akka =            "com.typesafe.akka"         %% "akka-actor"                  % akkaV
   val akkaStream =      "com.typesafe.akka"         %% "akka-stream"                 % akkaV
@@ -61,14 +62,14 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.4"
 
   val openTelemetryApi = "io.opentelemetry" % "opentelemetry-api" % openTelemetryV changing()
-  val openTelemetrySemConv = "io.opentelemetry" % "opentelemetry-semconv" % openTelemetryV changing()
+  val openTelemetrySemConv = "io.opentelemetry" % "opentelemetry-semconv" % openTelemetrySemConvV changing()
   val openTelemetryProp = "io.opentelemetry" % "opentelemetry-extension-trace-propagators" % openTelemetryV changing()
   val openTelemetrySdk = "io.opentelemetry" % "opentelemetry-sdk" % openTelemetryV changing()
   val openTelemetrySdkTesting = "io.opentelemetry" % "opentelemetry-sdk-testing" % openTelemetryV changing()
   val openTelemetryLoggingExporter = "io.opentelemetry" % "opentelemetry-exporter-logging" % openTelemetryInstV changing()
-  val openTelemetryOtlpExporter = "io.opentelemetry" % "opentelemetry-exporter-otlp" % openTelemetryInstV changing()
+  val openTelemetryOtlpExporter = "io.opentelemetry" % "opentelemetry-exporter-otlp" % openTelemetryInstV changing() exclude("io.opentelemetry", "dependencyManagement")
   val openTelemetryZipkinExporter = "io.opentelemetry" % "opentelemetry-exporter-zipkin" % openTelemetryInstV changing()
-  val openTelemetryJaegerExporter = "io.opentelemetry" % "opentelemetry-exporter-jaeger" % openTelemetryInstV changing()
+  val openTelemetryJaegerExporter = "io.opentelemetry" % "opentelemetry-exporter-jaeger" % openTelemetryInstV changing() exclude("io.opentelemetry", "dependencyManagement")
 
   // Spring
   val springWeb = ("org.springframework" % "spring-web" % "4.3.17.RELEASE")


### PR DESCRIPTION
Updates to OpenTelemetry 0.15.0.  Per the release notes this should be the last release of OpenTelemetry before 1.x and we should consider any final breaking changes or features we would want to consider before also revving Money to 1.x.