### PR TITLE
Remove Scala dependency in money-api

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ lazy val copyApiDocsTask = taskKey[Unit]("Copies the scala docs from each projec
 
 lazy val props = new SystemProperties()
 
+autoScalaLibrary := false
+
 lazy val money =
   Project("money", file("."))
     .settings(projectSettings: _*)
@@ -41,7 +43,7 @@ lazy val money =
 lazy val moneyApi =
   Project("money-api", file("./money-api"))
     .enablePlugins(AutomateHeaderPlugin)
-    .settings(projectSettings: _*)
+    .settings(javaOnlyProjectSettings: _*)
     .settings(
       libraryDependencies ++=
         Seq(
@@ -105,7 +107,7 @@ lazy val moneyAspectj =
     .settings(
       libraryDependencies ++=
         Seq(
-          typesafeConfig,
+          typesafeConfig
         ) ++ commonTestDependencies
     )
     .dependsOn(moneyCore % "test->test;compile->compile")
@@ -164,7 +166,7 @@ lazy val moneyKafka =
           chill,
           chillAvro,
           chillBijection,
-          commonsIo,
+          commonsIo
         ) ++ commonTestDependencies
     )
     .dependsOn(moneyCore, moneyWire % "test->test;compile->compile")
@@ -320,6 +322,15 @@ lazy val moneyOtlpExporter =
     )
     .dependsOn(moneyCore, moneyOtelHandler % "test->test;compile->compile")
 
+
+def aspectjProjectSettings = projectSettings ++ Seq(
+  javaOptions in Test ++= (aspectjWeaverOptions in Aspectj).value // adds javaagent:aspectjweaver to java options, including test
+)
+
+def javaOnlyProjectSettings = projectSettings ++ Seq(
+  autoScalaLibrary := false
+)
+
 def projectSettings = basicSettings ++ Seq(
   ScoverageKeys.coverageHighlighting := true,
   ScoverageKeys.coverageMinimum := 80,
@@ -338,10 +349,6 @@ def projectSettings = basicSettings ++ Seq(
       url("https://github.com/pauljamescleary")
     )
   )
-)
-
-def aspectjProjectSettings = projectSettings ++ Seq(
-  javaOptions in Test ++= (aspectjWeaverOptions in Aspectj).value // adds javaagent:aspectjweaver to java options, including test
 )
 
 def basicSettings =  Defaults.itSettings ++ Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -352,8 +352,8 @@ def projectSettings = basicSettings ++ Seq(
 def basicSettings =  Defaults.itSettings ++ Seq(
   organization := "com.comcast.money",
   sonatypeProfileName := "com.comcast",
-  scalaVersion := "2.12.13",
-  crossScalaVersions := List("2.13.4", "2.12.13"),
+  scalaVersion := "2.12.12",
+  crossScalaVersions := List("2.13.3", "2.12.12"),
   resolvers ++= Seq(
     ("spray repo" at "http://repo.spray.io/").withAllowInsecureProtocol(true),
     "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases/",

--- a/build.sbt
+++ b/build.sbt
@@ -352,8 +352,8 @@ def projectSettings = basicSettings ++ Seq(
 def basicSettings =  Defaults.itSettings ++ Seq(
   organization := "com.comcast.money",
   sonatypeProfileName := "com.comcast",
-  scalaVersion := "2.12.12",
-  crossScalaVersions := List("2.13.3", "2.12.12"),
+  scalaVersion := "2.12.13",
+  crossScalaVersions := List("2.13.4", "2.12.13"),
   resolvers ++= Seq(
     ("spray repo" at "http://repo.spray.io/").withAllowInsecureProtocol(true),
     "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases/",
@@ -372,20 +372,5 @@ def basicSettings =  Defaults.itSettings ++ Seq(
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF", "-u", "target/scalatest-reports"),
   fork := true,
   publishArtifact in Test := false,
-  autoAPIMappings := true,
-  apiMappings ++= {
-    def findManagedDependency(organization: String, name: String): Option[File] = {
-      (for {
-        entry <- (fullClasspath in Compile).value
-        module <- entry.get(moduleID.key) if module.organization == organization && module.name.startsWith(name)
-      } yield entry.data).headOption
-    }
-    val links: Seq[Option[(File, URL)]] = Seq(
-      findManagedDependency("org.scala-lang", "scala-library").map(d => d -> url(s"https://www.scala-lang.org/api/2.12.12/")),
-      findManagedDependency("com.typesafe", "config").map(d => d -> url("https://typesafehub.github.io/config/latest/api/"))
-    )
-    val x = links.collect { case Some(d) => d }.toMap
-    println("links: " + x)
-    x
-  }
+  autoAPIMappings := true
 )

--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,6 @@ lazy val copyApiDocsTask = taskKey[Unit]("Copies the scala docs from each projec
 
 lazy val props = new SystemProperties()
 
-autoScalaLibrary := false
-
 lazy val money =
   Project("money", file("."))
     .settings(projectSettings: _*)

--- a/money-api/src/main/java/com/comcast/money/api/SpanBuilder.java
+++ b/money-api/src/main/java/com/comcast/money/api/SpanBuilder.java
@@ -17,6 +17,7 @@
 package com.comcast.money.api;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -24,7 +25,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
-import scala.Option;
 
 public interface SpanBuilder extends io.opentelemetry.api.trace.SpanBuilder {
 
@@ -42,7 +42,7 @@ public interface SpanBuilder extends io.opentelemetry.api.trace.SpanBuilder {
     /**
      * Sets the parent span to the specified span
      */
-    SpanBuilder setParent(Option<Span> span);
+    SpanBuilder setParent(Optional<Span> span);
 
     /**
      * {@inheritDoc}

--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpanBuilder.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpanBuilder.scala
@@ -24,6 +24,7 @@ import io.opentelemetry.api.common.{ AttributeKey, Attributes }
 import io.opentelemetry.context.Context
 import io.opentelemetry.api.trace.{ SpanContext, SpanKind, TraceFlags, Span => OtelSpan }
 
+import java.util.Optional
 import scala.collection.JavaConverters._
 
 private[core] class CoreSpanBuilder(
@@ -56,8 +57,8 @@ private[core] class CoreSpanBuilder(
     this
   }
 
-  override def setParent(span: Option[Span]): SpanBuilder = {
-    parentSpan = span
+  override def setParent(span: Optional[Span]): SpanBuilder = {
+    parentSpan = if (span.isPresent) Some(span.get) else None
     this
   }
 

--- a/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
@@ -25,6 +25,8 @@ import io.opentelemetry.context.{ Context, ContextStorage, Scope }
 import io.opentelemetry.api.trace.{ SpanContext, SpanKind, StatusCode, Span => OtelSpan }
 import com.comcast.money.core.formatters.Formatter
 
+import java.util.Optional
+
 // $COVERAGE-OFF$
 object DisabledSpanHandler extends SpanHandler {
 
@@ -99,7 +101,7 @@ object DisabledSpanBuilder extends SpanBuilder {
 
   override def setParent(span: Span): SpanBuilder = this
 
-  override def setParent(span: Option[Span]): SpanBuilder = this
+  override def setParent(span: Optional[Span]): SpanBuilder = this
 
   override def setSticky(sticky: Boolean): SpanBuilder = this
 

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanBuilderSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanBuilderSpec.scala
@@ -33,6 +33,8 @@ import org.scalatestplus.mockito.MockitoSugar
 import scala.collection.JavaConverters._
 import InstantImplicits._
 
+import java.util.Optional
+
 class CoreSpanBuilderSpec extends AnyWordSpec with Matchers with MockitoSugar {
   val clock = SystemClock
   val library = InstrumentationLibrary.UNKNOWN
@@ -149,7 +151,7 @@ class CoreSpanBuilderSpec extends AnyWordSpec with Matchers with MockitoSugar {
       }
 
       val result = underTest
-        .setParent(Some(parentSpan))
+        .setParent(Optional.of(parentSpan))
         .startSpan()
 
       result shouldBe span


### PR DESCRIPTION
The first (and definitely easiest) of what will likely be a long line of painful PRs.  Removes the Scala dependency from the money-api project.

Breaking change:  `SpanBuilder#setParent(Option<Span>)` changed to `SpanBuilder#setParent(Optional<Span>)`, although I might want to just remove this API in favor of the overload that accepts `Context`, as OpenTelemetry has.
