### PR TITLE
Update to OpenTelemetry 0.17

### DIFF
--- a/money-api/src/test/scala/com/comcast/money/api/SpanIdSpec.scala
+++ b/money-api/src/test/scala/com/comcast/money/api/SpanIdSpec.scala
@@ -82,7 +82,7 @@ class SpanIdSpec extends AnyWordSpec with Matchers {
       val traceId = IdGenerator.generateRandomTraceId()
       val selfId = IdGenerator.generateRandomId()
       val parentId = IdGenerator.generateRandomId()
-      val state = TraceState.builder().set("foo", "bar").build()
+      val state = TraceState.builder().put("foo", "bar").build()
       val remoteId = SpanId.createRemote(traceId, parentId, selfId, TraceFlags.getSampled, state)
 
       remoteId.traceId shouldBe traceId
@@ -108,7 +108,7 @@ class SpanIdSpec extends AnyWordSpec with Matchers {
       val traceId = IdGenerator.generateRandomTraceId()
       val selfId = IdGenerator.generateRandomId()
       val parentId = IdGenerator.generateRandomId()
-      val state = TraceState.builder().set("foo", "bar").build()
+      val state = TraceState.builder().put("foo", "bar").build()
       val remoteId = SpanId.createRemote(traceId, parentId, selfId, TraceFlags.getSampled, state)
 
       val childId = remoteId.createChild()
@@ -195,7 +195,7 @@ class SpanIdSpec extends AnyWordSpec with Matchers {
     }
 
     "returns SpanContext from span id" in {
-      val traceState = TraceState.builder().set("foo", "bar").build();
+      val traceState = TraceState.builder().put("foo", "bar").build();
       val spanId = new SpanId("01234567-890A-BCDE-F012-34567890ABCD", 81985529216486895L, false, TraceFlags.getSampled, traceState)
       val spanContext = spanId.toSpanContext
 
@@ -207,7 +207,7 @@ class SpanIdSpec extends AnyWordSpec with Matchers {
     }
 
     "returns SpanContext from remote span id" in {
-      val traceState = TraceState.builder().set("foo", "bar").build();
+      val traceState = TraceState.builder().put("foo", "bar").build();
       val spanId = new SpanId("01234567-890A-BCDE-F012-34567890ABCD", 81985529216486895L, true, TraceFlags.getSampled, traceState)
       val spanContext = spanId.toSpanContext
 

--- a/money-core/src/main/scala/com/comcast/money/core/formatters/OtelFormatter.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/formatters/OtelFormatter.scala
@@ -17,10 +17,9 @@
 package com.comcast.money.core.formatters
 
 import java.{ lang, util }
-
 import com.comcast.money.api.SpanId
 import io.opentelemetry.context.Context
-import io.opentelemetry.context.propagation.TextMapPropagator
+import io.opentelemetry.context.propagation.{ TextMapGetter, TextMapPropagator }
 import io.opentelemetry.api.trace._
 
 import scala.collection.JavaConverters._
@@ -32,7 +31,7 @@ class OtelFormatter(propagator: TextMapPropagator) extends Formatter {
   }
 
   def fromHttpHeaders(headers: Iterable[String], getHeader: String => String, log: String => Unit = _ => {}): Option[SpanId] = {
-    val getter = new TextMapPropagator.Getter[Unit] {
+    val getter = new TextMapGetter[Unit] {
       override def get(carrier: Unit, key: String): String = getHeader(key)
       override def keys(c: Unit): lang.Iterable[String] = headers.asJava
     }

--- a/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterPropagatorSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/formatters/FormatterPropagatorSpec.scala
@@ -16,9 +16,9 @@
 
 package com.comcast.money.core.formatters
 
-import com.comcast.money.api.{ IdGenerator, Span, SpanId }
+import com.comcast.money.api.{ IdGenerator, SpanId }
 import io.opentelemetry.context.Context
-import io.opentelemetry.context.propagation.TextMapPropagator
+import io.opentelemetry.context.propagation.{ TextMapGetter, TextMapSetter }
 import io.opentelemetry.api.trace.{ TraceFlags, TraceState, Span => OtelSpan }
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -43,7 +43,7 @@ class FormatterPropagatorSpec extends AnyWordSpec with MockitoSugar with Matcher
 
     "delegates Formatter.toHttpHeaders to TextMapPropagator.inject" in {
       val formatter = mock[Formatter]
-      val setter = mock[TextMapPropagator.Setter[Unit]]
+      val setter = mock[TextMapSetter[Unit]]
       val underTest = FormatterPropagator(formatter)
 
       val spanId = SpanId.createNew()
@@ -62,7 +62,7 @@ class FormatterPropagatorSpec extends AnyWordSpec with MockitoSugar with Matcher
 
     "delegates Formatter.fromHttpHeaders to TextMapPropagator.extract" in {
       val formatter = mock[Formatter]
-      val getter = mock[TextMapPropagator.Getter[Unit]]
+      val getter = mock[TextMapGetter[Unit]]
       val underTest = FormatterPropagator(formatter)
 
       val traceId = IdGenerator.generateRandomTraceId()
@@ -84,7 +84,7 @@ class FormatterPropagatorSpec extends AnyWordSpec with MockitoSugar with Matcher
 
     "delegates Formatter.fromHttpHeaders to TextMapPropagator.extract without span" in {
       val formatter = mock[Formatter]
-      val getter = mock[TextMapPropagator.Getter[Unit]]
+      val getter = mock[TextMapGetter[Unit]]
       val underTest = FormatterPropagator(formatter)
 
       val traceId = IdGenerator.generateRandomTraceId()

--- a/money-core/src/test/scala/com/comcast/money/core/formatters/TraceContextFormatterSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/formatters/TraceContextFormatterSpec.scala
@@ -61,7 +61,7 @@ class TraceContextFormatterSpec extends AnyWordSpec with MockitoSugar with Match
       forAll { (traceIdValue: UUID, spanIdValue: Long, sampled: Boolean) =>
         whenever(isValidIds(traceIdValue, spanIdValue)) {
           val traceFlags = if (sampled) TraceFlags.getSampled else TraceFlags.getDefault
-          val traceState = TraceState.builder().set("foo", "bar").build()
+          val traceState = TraceState.builder().put("foo", "bar").build()
           val expectedSpanId = SpanId.createRemote(traceIdValue.toString, spanIdValue, spanIdValue, traceFlags, traceState)
 
           underTest.toHttpHeaders(expectedSpanId, (k, v) => k match {

--- a/money-otel-formatters/src/main/scala/com/comcast/money/otel/formatters/B3MultiHeaderFormatter.scala
+++ b/money-otel-formatters/src/main/scala/com/comcast/money/otel/formatters/B3MultiHeaderFormatter.scala
@@ -20,7 +20,7 @@ import com.comcast.money.core.formatters.OtelFormatter
 import com.comcast.money.otel.formatters.B3MultiHeaderFormatter.{ B3ParentSpanIdHeader, B3SampledHeader, B3SpanIdHeader, B3TraceIdHeader }
 import io.opentelemetry.`extension`.trace.propagation.B3Propagator
 
-object B3MultiHeaderFormatter extends OtelFormatter(B3Propagator.builder().injectMultipleHeaders().build()) {
+object B3MultiHeaderFormatter extends OtelFormatter(B3Propagator.injectingMultiHeaders) {
   private[formatters] val B3TraceIdHeader = "X-B3-TraceId"
   private[formatters] val B3SpanIdHeader = "X-B3-SpanId"
   private[formatters] val B3ParentSpanIdHeader = "X-B3-ParentSpanId"

--- a/money-otel-formatters/src/main/scala/com/comcast/money/otel/formatters/B3SingleHeaderFormatter.scala
+++ b/money-otel-formatters/src/main/scala/com/comcast/money/otel/formatters/B3SingleHeaderFormatter.scala
@@ -20,7 +20,7 @@ import com.comcast.money.core.formatters.OtelFormatter
 import com.comcast.money.otel.formatters.B3SingleHeaderFormatter.B3Header
 import io.opentelemetry.`extension`.trace.propagation.B3Propagator
 
-object B3SingleHeaderFormatter extends OtelFormatter(B3Propagator.getInstance) {
+object B3SingleHeaderFormatter extends OtelFormatter(B3Propagator.injectingSingleHeader) {
   private[formatters] val B3Header = "b3"
 
   override def fields: Seq[String] = Seq(B3Header)

--- a/money-otel-handler/src/main/scala/com/comcast/money/otel/handlers/MoneyReadableSpanData.scala
+++ b/money-otel-handler/src/main/scala/com/comcast/money/otel/handlers/MoneyReadableSpanData.scala
@@ -68,7 +68,7 @@ private[otel] class MoneyReadableSpanData(info: SpanInfo) extends ReadableSpan w
     if (library != null) {
       InstrumentationLibraryInfo.create(library.name, library.version)
     } else {
-      InstrumentationLibraryInfo.getEmpty
+      InstrumentationLibraryInfo.empty
     }
 
   private def appendNoteToBuilder[T](builder: AttributesBuilder, note: Note[T]): AttributesBuilder =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val typesafeConfigV = "1.3.3"
   val openTelemetryV = "0.17.0"
   val openTelemetryInstV = "0.17.0"
-  val openTelemetrySemConvV = "0.16.0-alpha"
+  val openTelemetrySemConvV = "0.17.0-alpha"
 
   val akka =            "com.typesafe.akka"         %% "akka-actor"                  % akkaV
   val akkaStream =      "com.typesafe.akka"         %% "akka-stream"                 % akkaV

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,8 +9,8 @@ object Dependencies {
   val jodaV = "2.9.9"
   val json4sV = "3.6.10"
   val typesafeConfigV = "1.3.3"
-  val openTelemetryV = "0.16.0"
-  val openTelemetryInstV = "0.16.0"
+  val openTelemetryV = "0.17.0"
+  val openTelemetryInstV = "0.17.0"
   val openTelemetrySemConvV = "0.16.0-alpha"
 
   val akka =            "com.typesafe.akka"         %% "akka-actor"                  % akkaV


### PR DESCRIPTION
Update to OpenTelemetry 0.17

Changes:

1. `TraceStateBuilder.set` renamed to `TraceStateBuilder.put`
2. `TextMapPropagator.Getter` renamed to `TextMapGetter`
3. `TextMapPropagator.Setter` renamed to `TextMapSetter`
4. `B3Propagator.getInstance` renamed to `B3Propagator.injectingSingleHeader`, and `B3Propagator.injectingMultiHeaders` added
5. `InstrumentationLibraryInfo.getEmpty` renamed to `InstrumentationLibraryInfo.empty`