### PR TITLE
Add missing overload of Span#setAttribute

### DIFF
--- a/money-core/src/main/scala/com/comcast/money/core/CoreSpan.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/CoreSpan.scala
@@ -27,6 +27,7 @@ import io.opentelemetry.api.common.{ AttributeKey, Attributes }
 import io.opentelemetry.context.Scope
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
+import java.lang
 import scala.collection.mutable.ListBuffer
 
 /**
@@ -128,6 +129,7 @@ private[core] case class CoreSpan(
   override def setAttribute(attributeName: String, value: Double): Span = record(Note.of(attributeName, value))
   override def setAttribute(attributeName: String, value: Boolean): Span = record(Note.of(attributeName, value))
   override def setAttribute[T](key: AttributeKey[T], value: T): Span = record(Note.of(key, value))
+  override def setAttribute(key: AttributeKey[lang.Long], value: Int): Span = setAttribute[lang.Long](key, value.toLong)
 
   override def addEvent(eventName: String): Span = addEventInternal(eventName, Attributes.empty(), clock.now)
   override def addEvent(eventName: String, timestamp: Instant): Span = addEventInternal(eventName, Attributes.empty(), timestamp)

--- a/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/Disabled.scala
@@ -22,9 +22,10 @@ import com.comcast.money.api._
 import com.comcast.money.core.context.ContextStorageFilter
 import io.opentelemetry.api.common.{ AttributeKey, Attributes }
 import io.opentelemetry.context.{ Context, ContextStorage, Scope }
-import io.opentelemetry.api.trace.{ SpanContext, SpanKind, StatusCode, Span => OtelSpan }
+import io.opentelemetry.api.trace.{ SpanContext, SpanKind, StatusCode }
 import com.comcast.money.core.formatters.Formatter
 
+import java.lang
 import java.util.Optional
 
 // $COVERAGE-OFF$
@@ -159,6 +160,8 @@ object DisabledSpan extends Span {
   override def setAttribute(key: String, value: Boolean): Span = this
 
   override def setAttribute[T](key: AttributeKey[T], value: T): Span = this
+
+  override def setAttribute(key: AttributeKey[lang.Long], value: Int): Span = this
 
   override def addEvent(name: String): Span = this
 

--- a/money-core/src/main/scala/com/comcast/money/core/UnrecordedSpan.scala
+++ b/money-core/src/main/scala/com/comcast/money/core/UnrecordedSpan.scala
@@ -59,6 +59,7 @@ private[core] final case class UnrecordedSpan(
   override def setAttribute(key: String, value: Double): Span = this
   override def setAttribute(key: String, value: Boolean): Span = this
   override def setAttribute[T](key: AttributeKey[T], value: T): Span = this
+  override def setAttribute(key: AttributeKey[lang.Long], value: Int): Span = this
   override def addEvent(name: String): Span = this
   override def addEvent(name: String, timestamp: Long, unit: TimeUnit): Span = this
   override def addEvent(name: String, timestamp: Instant): Span = this

--- a/money-core/src/test/scala/com/comcast/money/core/CoreSpanSpec.scala
+++ b/money-core/src/test/scala/com/comcast/money/core/CoreSpanSpec.scala
@@ -115,6 +115,18 @@ class CoreSpanSpec extends AnyWordSpec with Matchers with TestData with MockitoS
       note.value shouldBe "bar"
     }
 
+    "set a attribute with a long attribute key and an int" in {
+      val underTest = CoreSpan(SpanId.createNew(), "test")
+      val i: Int = 123
+
+      underTest.setAttribute(AttributeKey.longKey("foo"), i)
+
+      underTest.info.notes should contain key "foo"
+      val note = underTest.info.notes.get("foo")
+      note.name shouldBe "foo"
+      note.value shouldBe 123L
+    }
+
     "add an event with name" in {
       val underTest = CoreSpan(SpanId.createNew(), "test")
 


### PR DESCRIPTION
Missed an overload of `Span#setAttribute` which his a helper for adding an `int` attribute value.