### PR TITLE
Support OTel Resource via config within SpanExporter adapter

### DIFF
--- a/money-otel-handler/src/main/scala/com/comcast/money/otel/handlers/MoneyReadableSpanData.scala
+++ b/money-otel-handler/src/main/scala/com/comcast/money/otel/handlers/MoneyReadableSpanData.scala
@@ -24,14 +24,16 @@ import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.ReadableSpan
 import io.opentelemetry.sdk.trace.data.{ EventData, LinkData, SpanData, StatusData }
 import io.opentelemetry.api.trace.{ SpanContext, SpanKind, TraceState, Span => OtelSpan }
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes
 
 import scala.collection.JavaConverters._
 
-private[otel] class MoneyReadableSpanData(info: SpanInfo) extends ReadableSpan with SpanData {
+private[otel] class MoneyReadableSpanData(info: SpanInfo, resourceAttributes: Attributes) extends ReadableSpan with SpanData {
   private val id = info.id
   private lazy val spanContext = id.toSpanContext
   private lazy val parentSpanContext = convertParentSpanContext(info.id)
   private lazy val libraryInfo = convertLibraryInfo(info.library)
+  private lazy val resource = convertResource(info, resourceAttributes)
   private lazy val attributes = convertAttributes(info.notes)
   private lazy val events = convertEvents(info.events)
   private lazy val links = convertLinks(info.links)
@@ -45,7 +47,7 @@ private[otel] class MoneyReadableSpanData(info: SpanInfo) extends ReadableSpan w
   override def getLatencyNanos: Long = info.durationNanos
   override def getTraceId: String = id.traceIdAsHex
   override def getSpanId: String = id.selfIdAsHex
-  override def getResource: Resource = Resource.getDefault
+  override def getResource: Resource = resource
   override def getKind: SpanKind = info.kind
   override def getStartEpochNanos: Long = info.startTimeNanos
   override def getLinks: util.List[LinkData] = links
@@ -71,6 +73,18 @@ private[otel] class MoneyReadableSpanData(info: SpanInfo) extends ReadableSpan w
     } else {
       InstrumentationLibraryInfo.empty
     }
+
+  private def convertResource(info: SpanInfo, resourceAttributes: Attributes): Resource = {
+    val library = info.library()
+    Resource.create(Attributes.builder()
+      .put(ResourceAttributes.SERVICE_NAME, info.appName())
+      .put(ResourceAttributes.TELEMETRY_SDK_NAME, library.name())
+      .put(ResourceAttributes.TELEMETRY_SDK_VERSION, library.version())
+      .put(ResourceAttributes.TELEMETRY_SDK_LANGUAGE, "scala")
+      .put(ResourceAttributes.HOST_NAME, info.host())
+      .putAll(resourceAttributes)
+      .build())
+  }
 
   private def appendNoteToBuilder[T](builder: AttributesBuilder, note: Note[T]): AttributesBuilder =
     builder.put(note.key, note.value)

--- a/money-otel-handler/src/test/scala/com/comcast/money/otel/handlers/MoneyReadableSpanDataSpec.scala
+++ b/money-otel-handler/src/test/scala/com/comcast/money/otel/handlers/MoneyReadableSpanDataSpec.scala
@@ -23,6 +23,7 @@ import io.opentelemetry.api.common.{ AttributeKey, Attributes }
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.api.trace.{ Span, SpanContext, SpanKind, StatusCode, TraceFlags, TraceState }
 import io.opentelemetry.sdk.trace.data.StatusData
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -31,10 +32,11 @@ import scala.collection.JavaConverters._
 class MoneyReadableSpanDataSpec extends AnyWordSpec with Matchers {
   val spanId = SpanId.createFrom(UUID.fromString("01234567-890A-BCDE-F012-34567890ABCD"), 81985529216486895L, 81985529216486895L)
   val childSpanId = SpanId.createFrom(UUID.fromString("01234567-890A-BCDE-F012-34567890ABCD"), 1147797409030816545L, 81985529216486895L)
+  val resourceAttributes = Attributes.of(AttributeKey.stringKey("foo"), "bar")
 
   "MoneyReadableSpanDataSpec" should {
     "wrap Money SpanInfo" in {
-      val underTest = new MoneyReadableSpanData(TestSpanInfo(spanId))
+      val underTest = new MoneyReadableSpanData(TestSpanInfo(spanId), resourceAttributes)
 
       underTest.getInstrumentationLibraryInfo.getName shouldBe "test"
       underTest.getTraceId shouldBe "01234567890abcdef01234567890abcd"
@@ -47,7 +49,13 @@ class MoneyReadableSpanDataSpec extends AnyWordSpec with Matchers {
       underTest.hasEnded shouldBe true
       underTest.getLinks.asScala should contain(MoneyLink(link))
       underTest.getTotalRecordedLinks shouldBe 0
-      underTest.getResource shouldBe Resource.getDefault
+      underTest.getResource.getAttributes shouldBe Attributes.of(
+        ResourceAttributes.TELEMETRY_SDK_NAME, "test",
+        ResourceAttributes.TELEMETRY_SDK_VERSION, "0.0.1",
+        ResourceAttributes.TELEMETRY_SDK_LANGUAGE, "scala",
+        ResourceAttributes.SERVICE_NAME, "app",
+        ResourceAttributes.HOST_NAME, "host",
+        AttributeKey.stringKey("foo"), "bar")
       underTest.getLatencyNanos shouldBe 2000000L
       underTest.getStatus shouldBe StatusData.create(StatusCode.OK, "description")
       underTest.getTotalAttributeCount shouldBe 1
@@ -59,7 +67,7 @@ class MoneyReadableSpanDataSpec extends AnyWordSpec with Matchers {
     }
 
     "wrap child Money SpanInfo" in {
-      val underTest = new MoneyReadableSpanData(TestSpanInfo(childSpanId))
+      val underTest = new MoneyReadableSpanData(TestSpanInfo(childSpanId), resourceAttributes)
 
       underTest.getInstrumentationLibraryInfo.getName shouldBe "test"
       underTest.getTraceId shouldBe "01234567890abcdef01234567890abcd"
@@ -72,7 +80,13 @@ class MoneyReadableSpanDataSpec extends AnyWordSpec with Matchers {
       underTest.hasEnded shouldBe true
       underTest.getLinks.asScala should contain(MoneyLink(link))
       underTest.getTotalRecordedLinks shouldBe 0
-      underTest.getResource shouldBe Resource.getDefault
+      underTest.getResource.getAttributes shouldBe Attributes.of(
+        ResourceAttributes.TELEMETRY_SDK_NAME, "test",
+        ResourceAttributes.TELEMETRY_SDK_VERSION, "0.0.1",
+        ResourceAttributes.TELEMETRY_SDK_LANGUAGE, "scala",
+        ResourceAttributes.SERVICE_NAME, "app",
+        ResourceAttributes.HOST_NAME, "host",
+        AttributeKey.stringKey("foo"), "bar")
       underTest.getLatencyNanos shouldBe 2000000L
       underTest.getStatus shouldBe StatusData.create(StatusCode.OK, "description")
       underTest.getTotalAttributeCount shouldBe 1


### PR DESCRIPTION
Adds support for `resource` configuration in adapter for OTel SpanExporters.  Lightbend Config supports environment variable substitution out of the box:

```hocon
handling = {
  async = true
  handlers = [
    {
      class = "com.comcast.money.otel.handlers.jaeger.JaegerOtelSpanHandler"
      resource = {
        deployment.environment = ${?XVP_ENV}
        cloud.region = ${?AWS_REGION}
      }
      batch = true
      exporter-timeout-ms = 30000
      max-batch-size = 512
      max-queue-size = 2048
      schedule-delay-ms = 5000
      exporter {
        endpoint = "localhost:14250"
        timeout-ms = 1000
      }
    }
  ]
}
```